### PR TITLE
chore(hooks): scan the body the command is about to write, judge every command segment, and spend one Stop nudge per subject

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -637,6 +637,92 @@ gate_verb_args() {
   done < <(gate_segments "$cmd")
 }
 
+# gate_verb_args_dir <cmd> <fallback-dir> <verb-ere>
+#
+# `gate_verb_args` plus the working tree EACH matching segment runs in: one
+# "<dir><TAB><args-after-the-verb>" line per matching segment.
+#
+# WHY the tree has to come out of the SAME walk. `gate_target_dir` answers for
+# the WHOLE COMMAND -- its walk breaks at the first matching segment -- so a
+# gate that judges every segment judges them all against segment 1's tree.
+# Measured against this repo's real main checkout and its real linked worktree,
+# driving main-tree-branch-gate with a payload cwd of the MAIN tree:
+#
+#   git -C <worktree> switch -c a && git switch -c b     rc=0, want 2  BYPASS
+#   git -C <worktree> checkout -b a && git checkout -b b rc=0, want 2  BYPASS
+#   git switch main && git -C <worktree> switch -c a     rc=2, want 0  FALSE BLOCK
+#
+# The bypass is the `git fetch && git switch -c` one this branch already closed,
+# one operator further along: segment 1 resolves to a linked worktree, the gate
+# stands down for the whole command, and segment 2 -- running in the SHARED main
+# tree -- is never judged. The false block refuses a branch creation IN a linked
+# worktree, which is exactly what the worktree convention mandates. Both
+# directions were live at the head that shipped `main_tree_of`'s "called per
+# matched segment" comment; the comment described an intent the code did not
+# have.
+#
+# Callers split the line with `${line%%<TAB>*}` / `${line#*<TAB>}`, NOT with
+# `IFS=$'\t' read -r dir args`: tab is IFS whitespace, so that spelling folds a
+# TAB RUN inside the args and silently drops one.
+#
+# The `cd` / `-C` reading is a deliberate copy of gate_target_dir's rather than
+# a shared helper, because that function BREAKS at the verb -- the one thing
+# this walk must not do -- and it has other callers riding on that. The helper
+# harness pins the two against each other on the single-segment shape so the
+# copy cannot drift silently.
+gate_verb_args_dir() {
+  local cmd="$1" fallback="$2" re="$3"
+  local target="$fallback" segment cd_target c_target remaining verb_run tok seg_target
+  while IFS= read -r segment; do
+    if [[ "$segment" =~ ^cd[[:space:]]+$GATE_PATH_TOKEN ]]; then
+      cd_target=$(gate_unquote "${BASH_REMATCH[1]}")
+      # An UNEXPANDED path is not a path; skipping it falls back to the payload
+      # cwd, which fails CLOSED for this gate (go-to-k/cdkd#2130 review).
+      case "$cd_target" in *'$'*|*'`'*) continue ;; esac
+      [ -z "$cd_target" ] && continue
+      [[ "$cd_target" != /* ]] && cd_target="$target/$cd_target"
+      target="$cd_target"
+      continue
+    fi
+    [[ "$segment" =~ $re ]] || continue
+    # Saved BEFORE the token walk below: every `[[ =~ ]]` in it overwrites
+    # BASH_REMATCH.
+    verb_run="${BASH_REMATCH[0]}"
+    # A `cd` persists into the next segment; a `-C` binds only its own command.
+    # So the segment's dir starts from the running cd state and is overridden
+    # locally, never written back.
+    seg_target="$target"
+    c_target=""
+    remaining="$verb_run"
+    while [[ "$remaining" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; do
+      tok="${BASH_REMATCH[1]}"
+      remaining="${BASH_REMATCH[3]}"
+      [ -n "$tok" ] || break
+      case "$tok" in
+        -C=*) c_target="${tok#-C=}" ;;
+        -C)
+          if [[ "$remaining" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN(.*)$ ]]; then
+            c_target="${BASH_REMATCH[1]}"
+            remaining="${BASH_REMATCH[3]}"
+          fi
+          ;;
+        -C*) c_target="${tok#-C}" ;;
+        *) ;;
+      esac
+    done
+    if [ -n "$c_target" ]; then
+      c_target=$(gate_unquote "$c_target")
+      case "$c_target" in *'$'*|*'`'*) c_target="" ;; esac
+      if [ -n "$c_target" ]; then
+        [[ "$c_target" != /* ]] && c_target="$seg_target/$c_target"
+        seg_target="$c_target"
+      fi
+    fi
+    printf '%s\t%s\n' "$seg_target" "${segment#"$verb_run"}"
+  done < <(gate_segments "$cmd")
+  return 0
+}
+
 # gate_pr_selector <command> <verb-ere>
 #
 # Print the PR number the guarded command targets, or NOTHING when it carries no

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -839,5 +839,66 @@ want_match 1 "git stash is not git stage"    'git stash push -m x' "$A"
 want_args "-A"          "args after git stage"         'git stage -A' "$A"
 
 
+# --- gate_verb_args_dir: the tree AND the args, per segment, from one walk ----
+#
+# `want_dir` above measures `gate_target_dir`, which answers for the WHOLE
+# command. These measure the per-segment answer, and the FIRST of them is the
+# anti-drift fence: on a single-segment command the two functions must agree, so
+# the deliberate copy of the cd / `-C` reading inside `gate_verb_args_dir`
+# cannot drift from the original without a red case.
+want_lines() { # <expected, newline-joined> <label> <cmd> <fallback> <re>
+  local want="$1" label="$2" cmd="$3" fallback="$4" re="$5" got
+  got=$(gate_verb_args_dir "$cmd" "$fallback" "$re")
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %s\n' "$label"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s\n  want: %s\n  got:  %s\n' "$label" "$want" "$got"
+  fi
+}
+
+TAB=$(printf '\t')
+for _probe in 'git push origin main' 'cd /a/b && git push origin main' \
+              'git -C /w/t push origin main' 'cd /a/b && git -C /w/t push origin main' \
+              'cd /a/b && cd c && git push origin main'; do
+  _one=$(gate_target_dir "$_probe" /fallback "$P")
+  _each=$(gate_verb_args_dir "$_probe" /fallback "$P")
+  _each="${_each%%$TAB*}"
+  if [ "$_one" = "$_each" ]; then
+    pass=$((pass + 1)); printf 'OK   per-segment dir agrees with gate_target_dir :: %s\n' "$_probe"
+  else
+    fail=$((fail + 1)); printf 'FAIL per-segment dir disagrees :: %s\n  whole: %s\n  seg:   %s\n' "$_probe" "$_one" "$_each"
+  fi
+done
+unset _probe _one _each
+
+# ...and the part `gate_target_dir` CANNOT express: two segments, two trees.
+want_lines "/w/one${TAB}origin a
+/w/two${TAB}origin b" "two -C segments resolve independently" \
+  'git -C /w/one push origin a && git -C /w/two push origin b' /fallback "$P"
+# A `cd` PERSISTS into the next segment; a `-C` binds only its own command.
+want_lines "/a/b${TAB}origin a
+/a/b${TAB}origin b" "a cd carries into later segments" \
+  'cd /a/b && git push origin a && git push origin b' /fallback "$P"
+want_lines "/a/b${TAB}origin a
+/w/t${TAB}origin b
+/a/b${TAB}origin c" "a -C does not leak into the next segment" \
+  'cd /a/b && git push origin a && git -C /w/t push origin b && git push origin c' /fallback "$P"
+# An UNEXPANDED path is skipped, exactly as `gate_target_dir` skips it, so the
+# segment falls back to the running cd state rather than to a literal `$W`.
+want_lines "/fallback${TAB}origin a" "an unexpanded -C falls back, not to a literal" \
+  'git -C "$W" push origin a' /fallback "$P"
+
+
+
+# A FLOOR on the case total. Every `for` loop above expands a LIST, and emptying
+# one -- or deleting a case -- removes assertions SILENTLY while the tally still
+# reads `fail: 0`. No suite in this repo had one, so the only thing standing
+# between a gutted loop and a green run was somebody noticing the number move.
+# Raise it when cases are added; never lower it to make a red run green.
+CASE_FLOOR=367
+if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
+  fail=$((fail + 1))
+  printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
+fi
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -65,6 +65,12 @@ cat > "$SHIM/gh" <<'GH'
 [ -n "${GH_LOG:-}" ] && printf '%s\n' "$*" >> "$GH_LOG"
 case "$*" in
   "auth status"*) exit 0 ;;
+  # post-merge-orphan-push-gate asks `gh pr list --head <branch> --state merged`.
+  # Exactly ONE branch answers with a merged PR, so a case that blocks proves the
+  # gate resolved THAT branch rather than merely reaching gh.
+  *"pr list"*"--head feat/merged"*)
+    echo '[{"number":7,"mergedAt":"2026-01-01T00:00:00Z","headRefName":"feat/merged","title":"merged lane"}]' ;;
+  *"pr list"*) echo '[]' ;;
   *"pr view --json number"*) echo 999 ;;   # the CURRENT BRANCH's PR, never the target
   *"pr view"*"body"*) echo 'Closes (#12)' ;;
   *"pr view"*) echo '{"additions":50,"deletions":10,"changedFiles":2,"files":[],"headRefOid":"abc","headRefName":"f"}' ;;
@@ -174,6 +180,49 @@ run_case_cwd "main-tree-branch: chained -c in a worktree" 0 main-tree-branch-gat
 # ...and a `-C` back at the main tree is blocked from anywhere, so the case
 # above is passing on the resolved TREE rather than on the command shape.
 run_case_cwd "main-tree-branch: -C main tree from a worktree" 2 main-tree-branch-gate.sh "$MT_WT" "git fetch && git -C $repo switch -c feat/x"
+
+# post-merge-orphan-push-gate blocks a push to a branch whose PR already merged.
+# Same defect as main-tree-branch-gate above and fixed the same way: it read the
+# remote/branch off the WHOLE COMMAND with a leftmost-longest `=~ [[:space:]]push
+# (.*)$`, then cut at the first `&&` / `;` / `|`. Run standalone, that parse gave:
+#
+#   git push origin feat/x                            -> args [origin feat/x]
+#   echo "remember to push origin main" && git push origin feat/x
+#                                                     -> args [origin main"...]
+#   git push origin main && git push origin feat/x    -> args [origin main...]
+#
+# so a quoted MENTION steers the branch to `main"` and a chain is judged on the
+# FIRST push. Either way `gh pr list --head <wrong branch>` finds nothing, the
+# gate exits 0, and the orphan push proceeds unjudged. The gh stub answers a
+# merged PR for `feat/merged` and an empty list for everything else, so a case
+# that blocks proves WHICH branch the gate resolved.
+run_case "orphan-push: bare push to a merged branch"  2 post-merge-orphan-push-gate.sh 'git push origin feat/merged'
+run_case "orphan-push: quoted push MENTION first"     2 post-merge-orphan-push-gate.sh 'echo \"remember to push origin main\" && git push origin feat/merged'
+run_case "orphan-push: chained, merged one is LAST"   2 post-merge-orphan-push-gate.sh 'git push origin main && git push origin feat/merged'
+# EVERY matching segment is judged, not the last: with the merged push FIRST, a
+# gate that only looked at the final segment would let it through.
+run_case "orphan-push: chained, merged one is FIRST"  2 post-merge-orphan-push-gate.sh 'git push origin feat/merged && git push origin main'
+run_case "orphan-push: cd prefix with a semicolon"    2 post-merge-orphan-push-gate.sh 'cd /tmp; git push origin feat/merged'
+run_case "orphan-push: flags around the positionals"  2 post-merge-orphan-push-gate.sh 'git push --force-with-lease origin feat/merged'
+# The allowances, unchanged. Each is the false-BLOCK direction of a case above.
+run_case "orphan-push: unmerged branch passes"        0 post-merge-orphan-push-gate.sh 'git push origin feat/live'
+run_case "orphan-push: deletion refspec passes"       0 post-merge-orphan-push-gate.sh 'git push origin :feat/merged'
+run_case "orphan-push: sha:branch refspec passes"     0 post-merge-orphan-push-gate.sh 'git push origin abc123:feat/merged'
+run_case "orphan-push: non-origin remote passes"      0 post-merge-orphan-push-gate.sh 'git push upstream feat/merged'
+# The mandated quoted-body false-positive pair. Both carry a WORD after the
+# branch so that dropping the verb ERE's start anchor yields a parsable
+# `origin feat/merged ...` -- without it the mention parses to a branch with a
+# stray quote, gh answers nothing, and the case would pass against the broken
+# gate for the wrong reason.
+run_case "orphan-push: double-quoted mention"         0 post-merge-orphan-push-gate.sh 'echo \"next: git push origin feat/merged then open a PR\"'
+run_case "orphan-push: single-quoted mention"         0 post-merge-orphan-push-gate.sh "git commit -m 'then git push origin feat/merged later'"
+# `-u` with no branch derives it from the resolved tree via `symbolic-ref`, so
+# both polarities are pinned: the sandbox repo is on `feature` (not merged), and
+# a worktree checked out on `feat/merged` must block.
+run_case "orphan-push: -u with no branch, on feature" 0 post-merge-orphan-push-gate.sh 'git push -u origin'
+MERGED_WT="$TMPDIR/wt-merged"
+git -C "$repo" worktree add -q -b feat/merged "$MERGED_WT" 2>/dev/null
+run_case_cwd "orphan-push: -u with no branch, on the merged branch" 2 post-merge-orphan-push-gate.sh "$MERGED_WT" 'git push -u origin'
 
 # markgate-pipe-gate guards the two markgate VERDICT verbs, and only when their
 # exit status feeds a pipe (go-to-k/cdk-local#571). Driven through the real hook

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -91,6 +91,21 @@ run_case() {
   fi
 }
 
+# The same call from a DIFFERENT cwd -- the linked-worktree half of the
+# main-tree cases below, which are precisely about which TREE the resolved
+# segment lands in.
+run_case_cwd() {
+  local name="$1" want="$2" hook="$3" cwd="$4" cmd="$5" got out payload
+  payload=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$cwd" "$cmd")
+  out=$(printf '%s' "$payload" | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 \
+    "$HOOKS/$hook" 2>&1); got=$?
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(exit $got)"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (want %s, got %s)\n  out: %s\n' "$name" "$want" "$got" "$out"
+  fi
+}
+
 # check-gate guards `git commit` — and ONLY that verb.
 run_case "check-gate: bare commit"            2 check-gate.sh 'git commit -m x'
 run_case "check-gate: add -A && commit"       2 check-gate.sh 'git add -A && git commit -m x'
@@ -125,6 +140,40 @@ run_case "branch-gate: chained commit"        2 branch-gate.sh 'vp run check && 
 run_case "branch-gate: status on main"        0 branch-gate.sh 'git status'
 git -C "$repo" checkout -q feature
 run_case "branch-gate: commit on a feature branch" 0 branch-gate.sh 'git commit -m x'
+
+# main-tree-branch-gate blocks feature-branch creation in the MAIN worktree, and
+# the CHAINED spelling is the one that matters: the gate used to parse its
+# verdict with an awk walker over the whole command, which skipped to the FIRST
+# `git` token, read `sub=fetch`, and fell to a fail-open `*)` arm. Measured
+# against the real hook in the real main checkout on `main`, before the fix:
+# `git switch -c wt-probe origin/main` exited 2 while
+# `git fetch origin && git switch -c wt-probe origin/main` exited 0, and
+# `git status && git checkout -b wt-probe` exited 0 too. `/work-issues` prints
+# the chained spelling, so the bypass was on the mandated path.
+MT_WT="$TMPDIR/wt-lane"
+git -C "$repo" worktree add -q -b wt-lane "$MT_WT" 2>/dev/null
+run_case "main-tree-branch: bare switch -c"        2 main-tree-branch-gate.sh 'git switch -c feat/x origin/main'
+run_case "main-tree-branch: CHAINED switch -c"     2 main-tree-branch-gate.sh 'git fetch origin && git switch -c feat/x origin/main'
+run_case "main-tree-branch: CHAINED checkout -b"   2 main-tree-branch-gate.sh 'git status && git checkout -b feat/x'
+# EVERY matching segment is judged, not just the first: an allowed target in the
+# first half must not license the second.
+run_case "main-tree-branch: allowed then blocked"  2 main-tree-branch-gate.sh 'git switch main && git switch -c feat/x'
+# The allowances, PER SEGMENT. Each is the false-BLOCK direction of the case
+# above it, so a gate that simply blocked every chained `git` would fail here.
+run_case "main-tree-branch: CHAINED switch main"   0 main-tree-branch-gate.sh 'git fetch origin && git switch main'
+run_case "main-tree-branch: CHAINED checkout --"   0 main-tree-branch-gate.sh 'git status && git checkout -- README.md'
+run_case "main-tree-branch: chained sha checkout"  0 main-tree-branch-gate.sh 'git fetch && git checkout 0123456789abcdef'
+run_case "main-tree-branch: worktree add passes"   0 main-tree-branch-gate.sh 'git worktree add .claude/worktrees/x -b x origin/main'
+# The mandated quoted-body false-positive pair. A matcher change is exactly
+# where these regress, and this gate now reads its ARGUMENTS through the matcher
+# too, so both halves are pinned here rather than only in the helper harness.
+run_case "main-tree-branch: double-quoted mention" 0 main-tree-branch-gate.sh 'echo \"next: git switch -c feat/x\"'
+run_case "main-tree-branch: single-quoted mention" 0 main-tree-branch-gate.sh "git commit -m 'then git switch -c feat/x'"
+# The same chained creation inside a LINKED worktree is the sanctioned shape.
+run_case_cwd "main-tree-branch: chained -c in a worktree" 0 main-tree-branch-gate.sh "$MT_WT" 'git fetch origin && git switch -c feat/x origin/main'
+# ...and a `-C` back at the main tree is blocked from anywhere, so the case
+# above is passing on the resolved TREE rather than on the command shape.
+run_case_cwd "main-tree-branch: -C main tree from a worktree" 2 main-tree-branch-gate.sh "$MT_WT" "git fetch && git -C $repo switch -c feat/x"
 
 # markgate-pipe-gate guards the two markgate VERDICT verbs, and only when their
 # exit status feeds a pipe (go-to-k/cdk-local#571). Driven through the real hook

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -92,9 +92,21 @@ GIT
 # A `gh` shim that LOGS its argv. Without it the gh-calling gates fail open and
 # every pair below is satisfied vacuously at 0 -- which is exactly how three live
 # bypasses were certified green (see run_sel).
+# The stub DRAINS ITS STDIN, and that is the point rather than hygiene. A gate
+# calls `gh` from inside a `while IFS= read -r` loop whose stdin IS the
+# `gate_segments` process substitution, so a `gh` that reads stdin eats the
+# segments the walk has not judged yet -- and the real `gh` is free to. The
+# `</dev/null` redirections in post-merge-orphan-push-gate exist for exactly
+# that, and its own comment used to say no case could pin them. One can: this
+# line plus the two-push case below.
+#
+# `GH_FAIL` makes the stub answer NOTHING, which is how the gate's "gh pr list
+# failed or returned empty" arm is reached with a gh that exists.
 cat > "$SHIM/gh" <<'GH'
 #!/usr/bin/env bash
+cat >/dev/null
 [ -n "${GH_LOG:-}" ] && printf '%s\n' "$*" >> "$GH_LOG"
+[ -n "${GH_FAIL:-}" ] && exit 0
 case "$*" in
   "auth status"*) exit 0 ;;
   # post-merge-orphan-push-gate asks `gh pr list --head <branch> --state merged`.
@@ -188,6 +200,25 @@ run_note_count() {
       "$name" "$got" "$want" "$out"
   fi
 }
+# The same count, over the SHIM farm (gh PRESENT) and with the stub answering
+# nothing, so the gate's OTHER note -- "gh pr list failed or returned empty" --
+# is the one measured. That note describes a per-COMMAND condition and was
+# printed once per gateable SEGMENT.
+#
+# run_note_count_shim <name> <hook> <cmd> <substring> <expected count>
+run_note_count_shim() {
+  local name="$1" hook="$2" cmd="$3" needle="$4" want="$5" got out
+  out=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd" \
+    | env PATH="$SHIM:/usr/bin:/bin" GH_FAIL=1 "$HOOKS/$hook" 2>&1)
+  got=$(printf '%s\n' "$out" | grep -cF -- "$needle" | tr -d ' ')
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(said it $got time(s))"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (said it %s time(s), expected %s)\n  out: %s\n' \
+      "$name" "$got" "$want" "$out"
+  fi
+}
+
 # The farm itself: everything the gate and the shared matcher shell out to, and
 # NOTHING else -- no `gh` exists anywhere on this PATH, on any host.
 NOGH="$TMPDIR/nogh"; mkdir -p "$NOGH"
@@ -271,6 +302,46 @@ run_case_cwd "main-tree-branch: chained -c in a worktree" 0 main-tree-branch-gat
 # above is passing on the resolved TREE rather than on the command shape.
 run_case_cwd "main-tree-branch: -C main tree from a worktree" 2 main-tree-branch-gate.sh "$MT_WT" "git fetch && git -C $repo switch -c feat/x"
 
+# The BLOCKING arms of `verdict_for` had no case at all, which is a one-sided
+# fence in the dangerous direction: every pass arm was pinned and every block
+# arm was free. Measured before adding these -- deleting the plain-switch arm,
+# and deleting the `show-ref` local-branch arm, each left this suite green.
+run_case "main-tree-branch: plain switch to a feature branch" 2 main-tree-branch-gate.sh 'git switch feature'
+run_case "main-tree-branch: checkout of an existing local branch" 2 main-tree-branch-gate.sh 'git checkout feature'
+# ...and its discriminator: a name that is NOT a local branch is a pathspec/sha
+# and must pass, so the case above cannot be satisfied by blocking every name.
+run_case "main-tree-branch: checkout of a non-branch name passes" 0 main-tree-branch-gate.sh 'git checkout README.md'
+
+# PER-SEGMENT TREE RESOLUTION. `main_tree_of` said "called per matched segment"
+# while the tree was in fact resolved ONCE per verb candidate, outside the walk,
+# so segment 1 decided every segment. Both directions were live; measured
+# against the real main checkout and its real linked worktree, payload cwd = the
+# main tree:
+#
+#   git -C <wt> switch -c a && git switch -c b       rc=0, want 2  BYPASS
+#   git -C <wt> checkout -b a && git checkout -b b   rc=0, want 2  BYPASS
+#   git switch main && git -C <wt> switch -c a       rc=2, want 0  FALSE BLOCK
+run_case "main-tree-branch: worktree segment does not excuse a later main-tree switch" 2 \
+  main-tree-branch-gate.sh "git -C $MT_WT switch -c feat/a && git switch -c feat/b"
+run_case "main-tree-branch: worktree segment does not excuse a later main-tree checkout" 2 \
+  main-tree-branch-gate.sh "git -C $MT_WT checkout -b feat/a && git checkout -b feat/b"
+run_case "main-tree-branch: a main-tree segment does not condemn a later worktree one" 0 \
+  main-tree-branch-gate.sh "git switch main && git -C $MT_WT switch -c feat/a"
+# A `cd` PERSISTS into later segments while a `-C` binds only its own command --
+# the two halves of the per-segment resolution, each with its false direction.
+run_case "main-tree-branch: cd into a worktree carries into the next segment" 0 \
+  main-tree-branch-gate.sh "cd $MT_WT && git switch -c feat/a && git switch -c feat/b"
+run_case "main-tree-branch: a -C back at the main tree after that cd still blocks" 2 \
+  main-tree-branch-gate.sh "cd $MT_WT && git switch -c feat/a && git -C $repo switch -c feat/b"
+
+# The block MESSAGE names the branch, not the flag: the verdict for
+# `git switch --create feat/x` was already right, and the text called the
+# branch `--create` -- the name the message then tells you to replay elsewhere.
+run_case_msg "main-tree-branch: --create names the branch" 2 main-tree-branch-gate.sh \
+  'git switch --create feat/x' "feat/x" "'--create'"
+run_case_msg "main-tree-branch: --detach is not a branch name" 2 main-tree-branch-gate.sh \
+  'git switch --detach origin/main' "detaches HEAD" "feature branch '--detach'"
+
 # post-merge-orphan-push-gate blocks a push to a branch whose PR already merged.
 # Same defect as main-tree-branch-gate above and fixed the same way: it read the
 # remote/branch off the WHOLE COMMAND with a leftmost-longest `=~ [[:space:]]push
@@ -351,6 +422,25 @@ run_case_msg "orphan-push: refusal names the blocking segment" 2 post-merge-orph
 run_note_count "orphan-push: the no-gh note is stated once" post-merge-orphan-push-gate.sh \
   'git push origin a && git push origin b && git push origin c' \
   'gh not installed' 1
+
+# The gh call's `</dev/null`, which the gate's own comment called unpinnable.
+# The stub above drains stdin, and the walk's stdin IS the segment stream: a
+# `gh` invoked without `</dev/null` eats every segment after the one that called
+# it, so the SECOND push -- the one to the merged branch -- is never judged and
+# the gate exits 0. The order matters: the live branch must come FIRST, so the
+# gate really does call gh and carry on.
+run_case "orphan-push: a gh call does not eat the segments after it" 2 \
+  post-merge-orphan-push-gate.sh 'git push origin feat/live && git push origin feat/merged'
+# The false-BLOCK control: two LIVE branches must still pass, so the case above
+# is not satisfied by a gate that blocks any two-push command.
+run_case "orphan-push: two live pushes still pass" 0 \
+  post-merge-orphan-push-gate.sh 'git push origin feat/live && git push origin feat/other'
+
+# The gh-FAILURE note is a per-COMMAND decision, like the missing-gh note above.
+run_note_count_shim "orphan-push: the gh-failure note is stated once" post-merge-orphan-push-gate.sh \
+  'git push origin a && git push origin b && git push origin c' \
+  'gh pr list failed or returned empty' 1
+
 
 # markgate-pipe-gate guards the two markgate VERDICT verbs, and only when their
 # exit status feeds a pipe (go-to-k/cdk-local#571). Driven through the real hook
@@ -663,5 +753,16 @@ for g in closes-paren-form-gate.sh non-english-text-gate.sh \
   selector_guard "$g"
 done
 
+
+# A FLOOR on the case total. Every `for` loop above expands a LIST, and emptying
+# one -- or deleting a case -- removes assertions SILENTLY while the tally still
+# reads `fail: 0`. No suite in this repo had one, so the only thing standing
+# between a gutted loop and a green run was somebody noticing the number move.
+# Raise it when cases are added; never lower it to make a red run green.
+CASE_FLOOR=167
+if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
+  fail=$((fail + 1))
+  printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
+fi
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -24,7 +24,39 @@ git init -q -b feature "$repo"
 git -C "$repo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
 : > "$repo/.markgate.yml"   # opt in to the markgate convention
 
+# --- BASH INTERPRETER FENCE ---
+# Every case launches its hook through `env PATH="$SHIM:/usr/bin:/bin"`, and the
+# hooks' `#!/usr/bin/env bash` resolves `bash` off THAT path -- so until now the
+# interpreter was whatever `/bin/bash` happens to be, which on macOS is 3.2 and
+# on most Linux distros is 5.x. That is the right DEFAULT (the shipped hook has
+# to survive the bash a user actually has) but it made the other tally
+# untakeable: there was no way to re-run the same 149 cases under the OTHER
+# major version without editing this file.
+#
+# So the interpreter is now an explicit symlink at the FRONT of that PATH.
+# Default `/bin/bash` -- byte-identical behaviour to before -- and
+# `HOOK_BASH=/opt/homebrew/bin/bash bash .claude/hooks/gate-command-recognition.test.sh`
+# takes the 5.x tally. An explicitly set HOOK_BASH that is not executable is
+# FATAL rather than a silent fall-back: a typo'd override that quietly ran the
+# default would report the version it did not run.
+if [ -n "${HOOK_BASH:-}" ]; then
+  if [ ! -x "$HOOK_BASH" ]; then
+    printf 'FATAL - HOOK_BASH is not an executable: %s\n' "$HOOK_BASH" >&2
+    exit 1
+  fi
+else
+  HOOK_BASH=/bin/bash
+  [ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+  [ -n "$HOOK_BASH" ] && [ -x "$HOOK_BASH" ] || {
+    printf 'FATAL - no usable bash found for the hooks\n' >&2
+    exit 1
+  }
+fi
+
 SHIM="$TMPDIR/bin"; mkdir -p "$SHIM"
+ln -sf "$HOOK_BASH" "$SHIM/bash"
+printf 'hook interpreter: %s (bash %s)\n' "$HOOK_BASH" \
+  "$("$HOOK_BASH" -c 'echo "$BASH_VERSION"')"
 # Both stubs LOG THEIR $PWD when asked to. A gate `cd`s into the directory it
 # resolved before asking markgate, so that log is a direct read of
 # gate_target_dir's answer through the real hook -- which is the only way to
@@ -111,6 +143,64 @@ run_case_cwd() {
     fail=$((fail + 1)); printf 'FAIL %s (want %s, got %s)\n  out: %s\n' "$name" "$want" "$got" "$out"
   fi
 }
+
+# The exit code alone cannot say WHICH segment a block is about, and the message
+# is the whole product of a block -- it names the branch the user must replay
+# somewhere else. `run_case` compares exit codes only, so a gate that blocks for
+# the right reason and then NAMES THE WRONG BRANCH is green there. Assert the
+# text: `have` must appear, `nothave` (when given) must not.
+#
+# run_case_msg <name> <expect_exit> <hook> <cmd> <have> [<nothave>]
+run_case_msg() {
+  local name="$1" want="$2" hook="$3" cmd="$4" have="$5" nothave="${6:-}" got out payload why=""
+  payload=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd")
+  out=$(printf '%s' "$payload" | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 \
+    "$HOOKS/$hook" 2>&1); got=$?
+  [ "$got" = "$want" ] || why="exit $got, want $want"
+  printf '%s' "$out" | grep -qF -- "$have" || why="${why:+$why; }message lacks [$have]"
+  if [ -n "$nothave" ] && printf '%s' "$out" | grep -qF -- "$nothave"; then
+    why="${why:+$why; }message wrongly contains [$nothave]"
+  fi
+  if [ -z "$why" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(exit $got, names [$have])"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (%s)\n  out: %s\n' "$name" "$why" "$out"
+  fi
+}
+
+# How many times a hook emits one line of stderr for ONE command. A note that
+# describes a per-COMMAND decision ("this machine has no gh, so nothing was
+# checked") must be stated once however many segments the walk judges.
+# PATH is a hermetic symlink farm rather than a subtraction from the real PATH:
+# `gh` lives in /usr/bin on some distros and in /opt/homebrew/bin here, so
+# "PATH minus the shim dir" is gh-free only by luck of the host.
+#
+# run_note_count <name> <hook> <cmd> <substring> <expected count>
+run_note_count() {
+  local name="$1" hook="$2" cmd="$3" needle="$4" want="$5" got out
+  out=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"%s"}}' "$repo" "$cmd" \
+    | env PATH="$NOGH" "$HOOKS/$hook" 2>&1)
+  got=$(printf '%s\n' "$out" | grep -cF -- "$needle" | tr -d ' ')
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "$name" "(said it $got time(s))"
+  else
+    fail=$((fail + 1)); printf 'FAIL %s (said it %s time(s), expected %s)\n  out: %s\n' \
+      "$name" "$got" "$want" "$out"
+  fi
+}
+# The farm itself: everything the gate and the shared matcher shell out to, and
+# NOTHING else -- no `gh` exists anywhere on this PATH, on any host.
+NOGH="$TMPDIR/nogh"; mkdir -p "$NOGH"
+ln -sf "$HOOK_BASH" "$NOGH/bash"
+for _t in git jq cat dirname sed grep awk tr head; do
+  _p="$(command -v "$_t" 2>/dev/null || true)"
+  [ -n "$_p" ] && ln -sf "$_p" "$NOGH/$_t"
+done
+unset _t _p
+if [ -x "$NOGH/gh" ] || env PATH="$NOGH" command -v gh >/dev/null 2>&1; then
+  printf 'FATAL - the gh-free farm resolved a gh; run_note_count would be vacuous\n' >&2
+  exit 1
+fi
 
 # check-gate guards `git commit` — and ONLY that verb.
 run_case "check-gate: bare commit"            2 check-gate.sh 'git commit -m x'
@@ -223,6 +313,44 @@ run_case "orphan-push: -u with no branch, on feature" 0 post-merge-orphan-push-g
 MERGED_WT="$TMPDIR/wt-merged"
 git -C "$repo" worktree add -q -b feat/merged "$MERGED_WT" 2>/dev/null
 run_case_cwd "orphan-push: -u with no branch, on the merged branch" 2 post-merge-orphan-push-gate.sh "$MERGED_WT" 'git push -u origin'
+# ...and the same shape with a trailing REDIRECTION, which is what pins the
+# `args="${args%%>*}"` strip in parse_push_args. Deleting that strip leaves all
+# the cases above green, because every one of them fills `branch` from a real
+# positional before the `>` token is ever reached. Only a push that OMITS the
+# branch lets `>/tmp/log` BE the first free positional -- gh then answers an
+# empty list for a branch named `>/tmp/log` and the gate exits 0 on a push to a
+# merged branch. Measured: with the strip removed this case returns 0.
+run_case_cwd "orphan-push: -u, redirected, on the merged branch" 2 post-merge-orphan-push-gate.sh "$MERGED_WT" 'git push -u origin >/tmp/log'
+
+# A NON-GATEABLE push BEFORE the merged one. The two chain cases above both put
+# a push that IS judged (and passes) first, so they only pin the
+# judged-and-allowed arm of the walk; `parse_push_args … || continue` -- the arm
+# for a segment that is not gateable AT ALL -- had no case. Mutating that
+# `continue` to `break` leaves all 149 of them green while these two return 0:
+# the walk gives up at the first un-judgeable segment and never reaches the
+# merged push behind it. Both non-gateable shapes get a case, because they
+# return 1 from different places in the parse (the remote check and the refspec
+# check).
+run_case "orphan-push: non-origin push FIRST, merged one after" 2 post-merge-orphan-push-gate.sh 'git push upstream feat/x && git push origin feat/merged'
+run_case "orphan-push: deletion refspec FIRST, merged one after" 2 post-merge-orphan-push-gate.sh 'git push origin :feat/x && git push origin feat/merged'
+
+# The block MESSAGE names the segment that blocked, not the last one walked.
+# `blocked=1; break` is what makes that true, and deleting the `break` also
+# leaves 149 green -- the walk runs on, `branch` is overwritten by the trailing
+# `main`, and the refusal tells the user to replay a branch that is not the
+# problem. Exit codes cannot see that, so assert the text both ways.
+run_case_msg "orphan-push: refusal names the blocking segment" 2 post-merge-orphan-push-gate.sh \
+  'git push origin feat/merged && git push origin main' \
+  "branch 'feat/merged'" "branch 'main'"
+
+# The "gh not installed" note describes a per-COMMAND fact, so a chain of three
+# gateable pushes must state it ONCE. Memoising only the SUCCESS arm of
+# resolve_gh (`[ -n "$gh_bin" ] && return 0`, with nothing recording a failed
+# probe) prints it three times; no exit code moves, since the gate fails open
+# either way.
+run_note_count "orphan-push: the no-gh note is stated once" post-merge-orphan-push-gate.sh \
+  'git push origin a && git push origin b && git push origin c' \
+  'gh not installed' 1
 
 # markgate-pipe-gate guards the two markgate VERDICT verbs, and only when their
 # exit status feeds a pipe (go-to-k/cdk-local#571). Driven through the real hook

--- a/.claude/hooks/issue-dup-check-gate.sh
+++ b/.claude/hooks/issue-dup-check-gate.sh
@@ -344,11 +344,15 @@ seg_has_marker() {
   # `extract_files`, deliberately not shared, and it has already DIVERGED in
   # three ways: it runs on ONE SEGMENT rather than the whole command, it adds
   # the bare `-F <file>` arm (gh's short `--body-file`), and its caller treats
-  # an unreadable path as a BLOCK where that hook falls back to scanning the
-  # whole command (go-to-k/cdk-local#637). The third stays a deliberate
-  # opposite -- that gate objects to content it FINDS, so the command text is a
-  # usable substitute for the body, while this one must FIND a marker, and a
-  # missed read there costs one warning where a missed read here costs the gate.
+  # an unreadable path as a BLOCK where that hook extracts the HEREDOC BODY the
+  # command is about to write there (go-to-k/cdk-local#637). The third stays a
+  # deliberate opposite, and note the two fallbacks are NOT the same shape: this
+  # gate must FIND an anchored marker, so extra text can only make it pass and
+  # the whole COMMAND is a safe substitute for the body; that gate objects to
+  # content it FINDS, so extra text makes it BLOCK -- a whole-command scan there
+  # was measured refusing an ordinary `gh issue create --title '... #2397 ...'`,
+  # which is why it reads the heredoc alone. A missed read there costs one
+  # warning; a missed read here costs the gate.
   # Stated rather than left to be discovered: if you fix a path-extraction bug
   # in either, check the other.
   done < <(printf '%s' "$seg" | perl -0777 -ne '

--- a/.claude/hooks/issue-dup-check-gate.sh
+++ b/.claude/hooks/issue-dup-check-gate.sh
@@ -344,9 +344,11 @@ seg_has_marker() {
   # `extract_files`, deliberately not shared, and it has already DIVERGED in
   # three ways: it runs on ONE SEGMENT rather than the whole command, it adds
   # the bare `-F <file>` arm (gh's short `--body-file`), and its caller treats
-  # an unreadable path as a BLOCK where that hook simply skips the file. The
-  # third is a deliberate opposite -- that gate objects to content it FINDS, so
-  # a missed read costs one warning, while a missed read here costs the gate.
+  # an unreadable path as a BLOCK where that hook falls back to scanning the
+  # whole command (go-to-k/cdk-local#637). The third stays a deliberate
+  # opposite -- that gate objects to content it FINDS, so the command text is a
+  # usable substitute for the body, while this one must FIND a marker, and a
+  # missed read there costs one warning where a missed read here costs the gate.
   # Stated rather than left to be discovered: if you fix a path-extraction bug
   # in either, check the other.
   done < <(printf '%s' "$seg" | perl -0777 -ne '

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -54,8 +54,14 @@ if [ ! -r "$_gate_lib" ]; then
 fi
 # shellcheck source=/dev/null
 . "$_gate_lib"
-if ! declare -F gate_matches >/dev/null 2>&1; then
-  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
+if ! declare -F gate_matches >/dev/null 2>&1 \
+  || ! declare -F gate_verb_args_dir >/dev/null 2>&1; then
+  # `gate_verb_args_dir` is named too, not only `gate_matches`: it feeds the
+  # segment loop through a process substitution, so a library that predates it
+  # yields NO lines, the loop body never runs, and the gate exits 0 -- a silent
+  # bypass with no error anywhere. That is precisely what this fail-closed
+  # check exists to stop.
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches / gate_verb_args_dir is undefined (truncated or stale file?)." >&2
   exit 2
 fi
 
@@ -110,12 +116,29 @@ canonicalize() {
 # in to the worktree convention; prints nothing and returns 1 otherwise. Called
 # per matched segment, since `-C` / a preceding `cd` can put two segments of one
 # command in two different trees.
+#
+# LIMIT, stated rather than hidden. `gate_segments` FLATTENS a subshell, so a
+# `cd` inside one leaks past the closing paren and steers every later segment:
+#
+#   (cd <worktree> && git switch -c a) && git switch -c b
+#
+# resolves segment 3 to the worktree and PASSES. Measured from the real main
+# checkout, rc=0 where 2 is wanted -- and measured the same against the hook
+# BEFORE the per-segment change, so this is a pre-existing bound rather than one
+# that change introduced. Closing it means teaching the shared segmenter to
+# report subshell depth, which is a change to every gate that calls it, not to
+# this one. The exposure is narrow in the other direction too: the false-BLOCK
+# twin cannot happen, since a leaked `cd` can only ever make the gate quieter.
 main_tree_of() {
   local dir="$1" main_tree
   # `git rev-parse --show-toplevel` returns the CURRENT worktree's top, which
   # differs between the main tree and any `.claude/worktrees/<x>/`. Cheaper
   # heuristic: the main worktree is whatever `git worktree list` lists first.
-  main_tree=$(git -C "$dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+  # `substr($0, 10)` rather than `$2`: awk splits on whitespace, so a worktree
+  # path containing a SPACE was truncated at it and the compare below then
+  # never matched -- the gate stood down over a main tree it had mis-read. The
+  # sibling repo's copy already read the whole field.
+  main_tree=$(git -C "$dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10); exit}')
   # Not in a git repo / cannot resolve — pass through (we do not gate what we
   # cannot see).
   [ -n "$main_tree" ] || return 1
@@ -155,10 +178,22 @@ verdict_for() {
   case "$verb" in
     switch)
       # `git switch <name>` / `git switch -c <name>` / `git switch -C <name>`
-      # (force-create).
-      if [[ "$first_token" == "-c" || "$first_token" == "-C" ]]; then
+      # (force-create), and the LONG forms of both. Reading only `-c` / `-C` got
+      # the verdict right and the TEXT wrong: `git switch --create feat/x`
+      # blocked while naming the branch `--create`, which is the name the
+      # message then tells you to replay in a worktree.
+      if [[ "$first_token" == "-c" || "$first_token" == "-C" \
+         || "$first_token" == "--create" || "$first_token" == "--force-create" ]]; then
         target_branch="$second_token"
         block_reason="creates new feature branch '$target_branch'"
+        return 0
+      fi
+      # `--detach` moves the SHARED tree off `main` exactly as a branch switch
+      # does, so the verdict is unchanged; only the wording is, since there is
+      # no branch to name.
+      if [[ "$first_token" == "--detach" || "$first_token" == "-d" ]]; then
+        target_branch=""
+        block_reason="detaches HEAD in the main tree (\`git switch $first_token\`)"
         return 0
       fi
       target_branch="$first_token"
@@ -215,19 +250,36 @@ for gate_candidate in "$GATE_RE_GIT_SWITCH" "$GATE_RE_GIT_CHECKOUT"; do
   else
     verb="checkout"
   fi
-  # Where the gated command will actually run: a `-C <path>` inside the MATCHED
-  # segment wins, else the last `cd <path>` segment before it, else the hook
-  # payload's cwd (see gate_target_dir in _command-match.sh).
-  seg_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_candidate")
-  seg_main=$(main_tree_of "$seg_dir") || continue
-  while IFS= read -r seg_args; do
+  # Where each matching SEGMENT runs, resolved by the SAME walk that yields its
+  # arguments: a `-C <path>` inside THAT segment wins, else the `cd <path>`
+  # segments before it, else the hook payload's cwd.
+  #
+  # Resolving it once per COMMAND -- `gate_target_dir`, whose walk stops at the
+  # first matching segment -- made segment 1's tree decide every segment, and
+  # got BOTH directions wrong. Measured against the real main checkout and the
+  # real linked worktree, payload cwd = the main tree:
+  #
+  #   git -C <wt> switch -c a && git switch -c b       rc=0, want 2  BYPASS
+  #   git -C <wt> checkout -b a && git checkout -b b   rc=0, want 2  BYPASS
+  #   git switch main && git -C <wt> switch -c a       rc=2, want 0  FALSE BLOCK
+  #
+  # The first two are the `git fetch && git switch -c` bypass this branch closed
+  # one commit earlier, one operator further along; the third refuses a branch
+  # creation IN a linked worktree, which is what the convention mandates.
+  # `main_tree_of` already said "called per matched segment" here -- it was not.
+  while IFS= read -r seg_line; do
+    # Split on the FIRST tab only. `IFS=$'\t' read -r dir args` would fold a TAB
+    # RUN inside the args -- tab is IFS whitespace -- and drop one.
+    seg_dir="${seg_line%%$'\t'*}"
+    seg_args="${seg_line#*$'\t'}"
+    seg_main=$(main_tree_of "$seg_dir") || continue
     if verdict_for "$verb" "$seg_args" "$seg_dir"; then
       target_dir="$seg_dir"
       main_tree="$seg_main"
       blocked=1
       break
     fi
-  done < <(gate_verb_args "$cmd" "$gate_candidate")
+  done < <(gate_verb_args_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_candidate")
   [ "$blocked" -eq 1 ] && break
 done
 

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -66,56 +66,36 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || ec
 hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
 
 # Only gate `git switch` / `git checkout`; anything else passes through.
-# `gate_matches` splits the command into segments, so the verb is caught in ANY position — after a
-# `git add -A &&`, after a `cd <wt>;`, inside a subshell, behind a leading
-# `VAR=x` assignment — while a mention inside a quoted string or a heredoc body
-# is still ignored. `gate_re` keeps whichever verb matched so the target-dir
-# resolution below reads the right segment.
-gate_re=""
-for gate_candidate in "$GATE_RE_GIT_SWITCH" "$GATE_RE_GIT_CHECKOUT"; do
-  if gate_matches "$cmd" "$gate_candidate"; then
-    gate_re="$gate_candidate"
-    break
-  fi
-done
-[ -n "$gate_re" ] || exit 0
-
-# Where the gated command will actually run: a `-C <path>` inside the MATCHED
-# segment wins, else the last `cd <path>` segment before it, else the hook
-# payload's cwd (see gate_target_dir in _command-match.sh).
-target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_re")
-
-# Is the target dir the main worktree (= the top-level of the
-# shared .git directory)? `git rev-parse --show-toplevel` returns
-# the current worktree's top — which differs between the main
-# tree and any `.claude/worktrees/<x>/`. The MAIN tree's toplevel
-# equals the directory whose parent contains `.git` as a regular
-# directory (not a gitfile pointing into a worktrees subdir).
+# `gate_matches` splits the command into segments, so the verb is caught in ANY
+# position — after a `git fetch origin &&`, after a `cd <wt>;`, inside a
+# subshell, behind a leading `VAR=x` assignment — while a mention inside a
+# quoted string or a heredoc body is still ignored.
 #
-# Cheaper heuristic: the main worktree is whatever `git worktree
-# list` lists first. We use that and compare to target_dir.
-main_tree=$(git -C "$target_dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+# The SEGMENT model has to carry the VERDICT too, not only the trigger. This
+# gate used to parse the operation with an awk walker over the WHOLE command,
+# which skipped to the FIRST `git` token and read the subcommand there. In a
+# chained form that first `git` is a DIFFERENT command, so the walker read
+# `sub=fetch`, fell to the `*)` "fail open to avoid false positives" arm, and
+# exited 0 — a LIVE BYPASS of the very contention this gate exists to prevent,
+# in the exact spelling this repo's `/work-issues` skill prints. Measured in the
+# main checkout, on `main`:
+#
+#   git switch -c wt-probe origin/main                     -> rc=2  BLOCKED
+#   git fetch origin && git switch -c wt-probe origin/main -> rc=0  PASS
+#   git status && git checkout -b wt-probe                 -> rc=0  PASS
+#
+# The arguments now come from `gate_verb_args`, which strips exactly the text
+# the verb ERE matched off the SEGMENT that matched it. That is the same
+# constant which armed the gate, so it can no longer trigger one way and parse
+# another — the property `gate_pr_selector` exists to give the `gh` gates.
+# EVERY matching segment is judged rather than one: `git switch main && git
+# switch -c feat` must block on its second half.
 
-if [[ -z "$main_tree" ]]; then
-  # Not in a git repo / can't resolve — pass through (we don't gate
-  # what we can't see).
-  exit 0
-fi
-
-# Repo opt-in scope (cdkd#1259): only repos following the worktree +
-# markgate convention get main-tree branch protection. Unrelated repos
-# (a personal blog, a scratch clone) have no parallel-agent contention
-# on their main tree. Opt-in signal: a `.markgate.yml` at the main
-# worktree root.
-if [[ ! -f "$main_tree/.markgate.yml" ]]; then
-  exit 0
-fi
-
-# Canonicalize both sides before compare. macOS resolves
-# `/tmp` → `/private/tmp` and `/var` → `/private/var` via symlinks;
-# `git worktree list --porcelain` always emits the real path, while
-# the user's cwd may still carry the symlink. `cd <dir> && pwd -P`
-# is the portable canonicalizer (BSD readlink lacks `-f` until 12+).
+# Canonicalize a path before comparing. macOS resolves `/tmp` → `/private/tmp`
+# and `/var` → `/private/var` via symlinks; `git worktree list --porcelain`
+# always emits the real path, while the user's cwd may still carry the symlink.
+# `cd <dir> && pwd -P` is the portable canonicalizer (BSD readlink lacks `-f`
+# until 12+).
 canonicalize() {
   local p="$1"
   if [[ -d "$p" ]]; then
@@ -124,133 +104,134 @@ canonicalize() {
     printf '%s' "${p%/}"
   fi
 }
-target_norm=$(canonicalize "$target_dir")
-main_norm=$(canonicalize "$main_tree")
 
-if [[ "$target_norm" != "$main_norm" ]]; then
-  # Target is a worktree (`.claude/worktrees/<x>/` or similar) —
-  # branch-switching there is fine.
-  exit 0
-fi
+# main_tree_of <dir>
+# Prints the MAIN worktree's path when <dir> IS that worktree and the repo opts
+# in to the worktree convention; prints nothing and returns 1 otherwise. Called
+# per matched segment, since `-C` / a preceding `cd` can put two segments of one
+# command in two different trees.
+main_tree_of() {
+  local dir="$1" main_tree
+  # `git rev-parse --show-toplevel` returns the CURRENT worktree's top, which
+  # differs between the main tree and any `.claude/worktrees/<x>/`. Cheaper
+  # heuristic: the main worktree is whatever `git worktree list` lists first.
+  main_tree=$(git -C "$dir" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+  # Not in a git repo / cannot resolve — pass through (we do not gate what we
+  # cannot see).
+  [ -n "$main_tree" ] || return 1
+  # Repo opt-in scope (cdkd#1259): only repos following the worktree + markgate
+  # convention get main-tree branch protection. Unrelated repos (a personal
+  # blog, a scratch clone) have no parallel-agent contention on their main tree.
+  # Opt-in signal: a `.markgate.yml` at the main worktree root.
+  [ -f "$main_tree/.markgate.yml" ] || return 1
+  # Target is a linked worktree (`.claude/worktrees/<x>/` or similar) —
+  # branch-switching there is exactly what the convention asks for.
+  [ "$(canonicalize "$dir")" = "$(canonicalize "$main_tree")" ] || return 1
+  printf '%s' "$main_tree"
+}
 
-# Target IS the main worktree. Parse the operation to decide:
+# verdict_for <verb> <args> <dir>
+# 0 = the segment must be BLOCKED (with `target_branch` / `block_reason` set),
+# 1 = allowed. <args> is everything after the matched verb, flags included,
+# because the verb ERE already consumed the leading `git -C … ` flag run.
+#
 #   `git switch <main|master>`         → allow
 #   `git checkout <main|master>`       → allow
 #   `git switch -c <branch>`           → block
 #   `git switch <other-branch>`        → block
 #   `git checkout -b <branch>`         → block
-#   `git checkout <other-branch>`      → block (only when <other-branch>
-#                                        is a local branch — file-path
-#                                        / sha checkouts pass through)
+#   `git checkout <other-branch>`      → block (only when <other-branch> is a
+#                                        local branch — file-path / sha
+#                                        checkouts pass through)
 #   `git checkout -- <pathspec>`       → allow (file restore)
-#   `git checkout <sha>`               → allow (detached HEAD, rare in
-#                                        agent workflows but legitimate)
-#
-# Extract the operative subcommand + first non-flag arg via awk
-# tokenization (portable across BSD / GNU sed — `\b` in sed -E is
-# not supported on macOS).
-#
-# Walk the command's tokens: skip an optional `cd <path> && `
-# prefix, then skip the `git` token + any global flag tokens
-# (`-X` / `--foo` / `-C <path>` / `-c <key>=<val>`), then the
-# next token is the subcommand and everything after is its args.
-subcmd_args=$(printf '%s' "$cmd" | awk '
-  {
-    i = 1
-    # Skip an optional leading "cd <path> && " prefix.
-    if (i <= NF && $i == "cd") {
-      # Consume "cd <path> &&"; if not followed by &&, fall through.
-      saved_i = i
-      i++
-      if (i <= NF) { i++ }  # path token
-      if (i <= NF && $i == "&&") { i++ } else { i = saved_i }
-    }
-    # Expect "git" next (the gate regex guarantees it appears).
-    while (i <= NF && $i != "git") { i++ }
-    if (i > NF) { print ""; exit }
-    i++  # consume "git"
-    # Skip global flag tokens: any token starting with "-" plus an
-    # optional non-flag value token for the -C / -c family.
-    while (i <= NF && substr($i, 1, 1) == "-") {
-      flag = $i
-      i++
-      # `-C <path>` / `-c <key>=<val>` consume the next token IF
-      # the flag is exactly one of those and the next token does
-      # not start with "-".
-      if ((flag == "-C" || flag == "-c") && i <= NF && substr($i, 1, 1) != "-") {
-        i++
-      }
-    }
-    # Now $i is the subcommand. Print it + everything after.
-    out = ""
-    for (j = i; j <= NF; j++) {
-      out = out (out == "" ? "" : " ") $j
-    }
-    print out
-  }')
-sub=$(printf '%s' "$subcmd_args" | awk '{print $1}')
-
-case "$sub" in
-  switch)
-    # `git switch <name>` or `git switch -c <name>` or `git switch
-    # -C <name>` (force-create).
-    rest=$(printf '%s' "$subcmd_args" | awk '{$1=""; sub(/^ +/, ""); print}')
-    # If first token is `-c` / `-C`, the branch is being created → block.
-    first_token=$(printf '%s' "$rest" | awk '{print $1}')
-    if [[ "$first_token" == "-c" || "$first_token" == "-C" ]]; then
-      target_branch=$(printf '%s' "$rest" | awk '{print $2}')
-      block_reason="creates new feature branch '$target_branch'"
-    else
+#   `git checkout <sha>`               → allow (detached HEAD, rare in agent
+#                                        workflows but legitimate)
+verdict_for() {
+  local verb="$1" rest="$2" dir="$3" first_token second_token
+  first_token=$(printf '%s' "$rest" | awk '{print $1}')
+  second_token=$(printf '%s' "$rest" | awk '{print $2}')
+  target_branch=""
+  block_reason=""
+  case "$verb" in
+    switch)
+      # `git switch <name>` / `git switch -c <name>` / `git switch -C <name>`
+      # (force-create).
+      if [[ "$first_token" == "-c" || "$first_token" == "-C" ]]; then
+        target_branch="$second_token"
+        block_reason="creates new feature branch '$target_branch'"
+        return 0
+      fi
       target_branch="$first_token"
       if [[ "$target_branch" == "main" || "$target_branch" == "master" ]]; then
-        exit 0
+        return 1
       fi
-      # `git switch -` (switch back to previous branch) — can't know
-      # what that resolves to without running git. Conservatively
-      # block; agents shouldn't be using `git switch -` in the main
-      # tree anyway.
+      # `git switch -` (switch back to previous branch) — cannot be known
+      # without running git. Conservatively block; agents should not be using
+      # `git switch -` in the main tree anyway.
       if [[ "$target_branch" == "-" ]]; then
         block_reason="switches to previous branch (\`git switch -\`); resolved branch unknown — block conservatively"
       else
         block_reason="switches to feature branch '$target_branch'"
       fi
-    fi
-    ;;
-  checkout)
-    # `git checkout <name>` / `git checkout -b <name>` / `git
-    # checkout -- <pathspec>` / `git checkout <sha>`.
-    rest=$(printf '%s' "$subcmd_args" | awk '{$1=""; sub(/^ +/, ""); print}')
-    first_token=$(printf '%s' "$rest" | awk '{print $1}')
-    if [[ "$first_token" == "-b" || "$first_token" == "-B" ]]; then
-      target_branch=$(printf '%s' "$rest" | awk '{print $2}')
-      block_reason="creates new feature branch '$target_branch'"
-    elif [[ "$first_token" == "--" ]]; then
+      return 0
+      ;;
+    checkout)
+      # `git checkout <name>` / `git checkout -b <name>` / `git checkout --
+      # <pathspec>` / `git checkout <sha>`.
+      if [[ "$first_token" == "-b" || "$first_token" == "-B" ]]; then
+        target_branch="$second_token"
+        block_reason="creates new feature branch '$target_branch'"
+        return 0
+      fi
       # File restore — pass through.
-      exit 0
-    elif [[ "$first_token" == "main" || "$first_token" == "master" ]]; then
-      exit 0
-    elif [[ -z "$first_token" ]]; then
-      # `git checkout` with no args — defaults to file restore in some
-      # versions, NOP in others. Pass through.
-      exit 0
-    else
-      # Could be a branch name or a sha. If it resolves to a local
-      # branch via `git show-ref refs/heads/<name>`, treat as branch
-      # switch (block). Otherwise treat as sha / pathspec (pass).
-      if git -C "$target_dir" show-ref --verify --quiet "refs/heads/$first_token" 2>/dev/null; then
+      [[ "$first_token" == "--" ]] && return 1
+      [[ "$first_token" == "main" || "$first_token" == "master" ]] && return 1
+      # `git checkout` with no args — defaults to file restore in some versions,
+      # a NOP in others. Pass through.
+      [[ -z "$first_token" ]] && return 1
+      # Could be a branch name or a sha. If it resolves to a local branch via
+      # `git show-ref refs/heads/<name>`, treat as a branch switch (block).
+      # Otherwise treat as sha / pathspec (pass).
+      if git -C "$dir" show-ref --verify --quiet "refs/heads/$first_token" 2>/dev/null; then
         target_branch="$first_token"
         block_reason="switches to feature branch '$first_token'"
-      else
-        exit 0
+        return 0
       fi
+      return 1
+      ;;
+  esac
+  return 1
+}
+
+target_dir=""
+main_tree=""
+target_branch=""
+block_reason=""
+blocked=0
+for gate_candidate in "$GATE_RE_GIT_SWITCH" "$GATE_RE_GIT_CHECKOUT"; do
+  gate_matches "$cmd" "$gate_candidate" || continue
+  if [ "$gate_candidate" = "$GATE_RE_GIT_SWITCH" ]; then
+    verb="switch"
+  else
+    verb="checkout"
+  fi
+  # Where the gated command will actually run: a `-C <path>` inside the MATCHED
+  # segment wins, else the last `cd <path>` segment before it, else the hook
+  # payload's cwd (see gate_target_dir in _command-match.sh).
+  seg_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$gate_candidate")
+  seg_main=$(main_tree_of "$seg_dir") || continue
+  while IFS= read -r seg_args; do
+    if verdict_for "$verb" "$seg_args" "$seg_dir"; then
+      target_dir="$seg_dir"
+      main_tree="$seg_main"
+      blocked=1
+      break
     fi
-    ;;
-  *)
-    # Unrecognized subcommand inside switch|checkout regex match —
-    # shouldn't happen, but fail open to avoid false positives.
-    exit 0
-    ;;
-esac
+  done < <(gate_verb_args "$cmd" "$gate_candidate")
+  [ "$blocked" -eq 1 ] && break
+done
+
+[ "$blocked" -eq 1 ] || exit 0
 
 # Compose the block message.
 branch_slug=$(printf '%s' "${target_branch:-feature-branch}" | tr -c 'a-zA-Z0-9._/-' '-')

--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -73,182 +73,238 @@ gate_matches "$cmd" "$GATE_RE_GIT_PUSH" || exit 0
 # payload's cwd (see gate_target_dir in _command-match.sh).
 target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_PUSH")
 
-# Parse `git push [...] <remote> <branch>` out of the command. We strip
-# the `git ... push` prefix (incl. any `-C <path>` between `git` and
-# `push`) and then walk the remaining tokens, skipping known flags that
-# do not take a positional value (-u, --set-upstream, --force, etc.) and
-# flag-with-value pairs (--repo <r>, -o <opt>, --push-option <opt>).
+# Parse `git push [...] <remote> <branch>` out of ONE MATCHED SEGMENT. The
+# arguments come from `gate_verb_args`, which strips exactly the text the verb
+# ERE matched -- `git <every leading flag> push` -- off the segment that matched
+# it, so the gate can no longer trigger one way and parse another.
 #
-# We only need to recognise enough flags to land on the (remote, branch)
-# pair for the common shapes; ambiguous / exotic forms fall through to
-# the safe "pass through" branch.
-push_args=""
-# Find `push` and everything after it. The pattern intentionally tolerates
-# the `git -C <path> push` form by ignoring the leading `git -C <path>`.
-if [[ "$cmd" =~ [[:space:]]push([[:space:]]+(.*))?$ || "$cmd" =~ ^push([[:space:]]+(.*))?$ ]]; then
-  # BASH_REMATCH[2] contains the post-`push` portion or empty.
-  push_args="${BASH_REMATCH[2]:-}"
-fi
+# It used to read them off the WHOLE COMMAND, with
+# `[[ "$cmd" =~ [[:space:]]push([[:space:]]+(.*))?$ ]]`. `=~` is POSIX
+# leftmost-longest, so that finds the FIRST ` push` anywhere in the text and
+# takes everything after it -- and the separator strips below then cut at the
+# first `&&` / `;` / `|`. Two ordinary shapes fall out of that, both measured by
+# running the parse standalone, and both are LIVE BYPASSES rather than cosmetic:
+#
+#   git push origin feat/merged                              -> origin feat/merged
+#   echo "remember to push origin main" && git push origin feat/merged
+#                                                            -> origin  main"
+#   git push origin main && git push origin feat/merged      -> origin  main
+#
+# In the second a quoted MENTION of push steers the branch to `main"`; in the
+# third the chain is judged on the FIRST push. Either way
+# `gh pr list --head <wrong branch>` finds no merged PR, the gate exits 0, and
+# the orphan push -- commits that silently never reach main, the entire failure
+# this hook exists to prevent -- proceeds unjudged. The same defect was
+# reproduced in the sibling repo's copy of this gate, which is why it is fixed
+# rather than filed.
+#
+# EVERY matching segment is judged, not the last one: `git push origin main &&
+# git push origin feat/merged` contains two real pushes, and judging either one
+# alone leaves the other in exactly the hole just closed. The walk stops at the
+# first segment that blocks, so the common single-push command still makes at
+# most one `gh` call.
+#
+# LIMIT, stated rather than hidden: `target_dir` is resolved ONCE, for the whole
+# command, because `gate_target_dir` reports the LAST matching segment's tree
+# and the shared helper exposes no per-segment answer. Reconstructing a
+# per-segment prefix to ask again was considered and rejected -- re-splitting
+# text that has already been segmented would let a NEWLINE inside a quoted
+# argument (`gh pr create --body "...\ncd /evil"`) surface as a `cd` segment,
+# which is a worse hole than the one it closes. The exposure is narrow: the
+# positional branch is read from the segment itself, so `target_dir` only
+# decides the `symbolic-ref` fallback for a push that OMITS the branch, and only
+# when one command pushes from two different trees.
 
-# Strip trailing shell-redirection / chain noise (`>x`, `2>&1`,
-# `&& foo`, `; foo`, `| foo`) so they do not pollute positional
-# extraction. Whatever's after the first chain separator can't be a
-# push arg anyway.
-push_args="${push_args%%|*}"
-push_args="${push_args%%;*}"
-push_args="${push_args%%&&*}"
-push_args="${push_args%%>*}"
+# Resolved lazily and memoised: a command whose remote is not `origin` must not
+# print the "gh not installed" note, which is what hoisting this above the walk
+# would do.
+gh_bin=""
+resolve_gh() {
+  [ -n "$gh_bin" ] && return 0
+  # $GH_BIN, when set and executable, wins — this is the mock injection point
+  # for smoke tests. Otherwise look up on PATH. When gh is missing, pass through
+  # with a stderr debug note rather than failing closed.
+  if [ -n "${GH_BIN:-}" ] && [ -x "${GH_BIN}" ]; then
+    gh_bin="${GH_BIN}"
+  elif command -v gh >/dev/null 2>&1; then
+    gh_bin="$(command -v gh)"
+  else
+    echo "post-merge-orphan-push-gate: gh not installed; skipping check." >&2
+    return 1
+  fi
+  return 0
+}
 
-# Tokenise. We use read -a so single-quoted args stay together by best
-# effort; an exotic case like `git push origin "feature/x y"` (literal
-# space in branch name) is rare enough that we accept missing it — the
-# gate degrades to pass-through rather than mis-fire.
-# shellcheck disable=SC2206
-tokens=($push_args)
+# parse_push_args <segment-args>
+# Sets `remote` / `branch`. Returns 1 when this segment is not a gateable push.
+#
+# Only known flags are modelled — enough to land on the (remote, branch) pair
+# for the common shapes; ambiguous / exotic forms fall through to the safe
+# "pass through" branch.
+parse_push_args() {
+  local args="$1" tok next i
+  # Trailing shell REDIRECTION (`>x`, `2>&1`) is the only chain noise that can
+  # still be here. The `|`, `;` and `&&` strips this used to carry are gone:
+  # `gate_segments` ends a segment AT those separators, so anything they could
+  # have cut is no longer in `args` to begin with — and a `push` after one of
+  # them is now its own segment with its own turn in the walk, which is the
+  # whole point.
+  args="${args%%>*}"
+
+  # Tokenise. Single-quoted args stay together by best effort; an exotic case
+  # like `git push origin "feature/x y"` (literal space in a branch name) is
+  # rare enough that we accept missing it — the gate degrades to pass-through
+  # rather than mis-fire.
+  # shellcheck disable=SC2206
+  local tokens=($args)
+
+  remote=""
+  branch=""
+  i=0
+  while [ "$i" -lt "${#tokens[@]}" ]; do
+    tok="${tokens[$i]}"
+    case "$tok" in
+      # Flags that take NO value — skip just this token.
+      -u|--set-upstream|-f|--force|--force-with-lease|--force-if-includes|\
+      -n|--dry-run|-v|--verbose|-q|--quiet|--all|--tags|--follow-tags|\
+      --mirror|--prune|--delete|--atomic|--no-verify|--verify|--progress|\
+      --no-progress|--ipv4|--ipv6|-4|-6|--thin|--no-thin|--signed|\
+      --no-signed|--porcelain|--no-recurse-submodules)
+        ;;
+      # Flags that DO take a value — skip this token AND the next.
+      # `--foo=bar` (single token, captured by *=*) — no extra skip.
+      # `--foo bar` (two tokens) — skip the next token too.
+      # `--recurse-submodules` has BOTH a flag-only form and a
+      # `--recurse-submodules <mode>` form; we peek at the next token
+      # before deciding to consume it.
+      --repo|-o|--push-option|--receive-pack|--exec|--repo=*|\
+      --push-option=*|-o=*|--receive-pack=*|--exec=*|--recurse-submodules|\
+      --recurse-submodules=*)
+        case "$tok" in
+          *=*) ;;
+          --recurse-submodules)
+            next="${tokens[$((i + 1))]:-}"
+            case "$next" in
+              check|on-demand|only|no)
+                i=$((i + 1))
+                ;;
+            esac
+            ;;
+          *)
+            i=$((i + 1))
+            ;;
+        esac
+        ;;
+      # Any other --flag we don't know about — skip just this token, on
+      # the assumption it's flag-only. False negatives (missing the gate
+      # because of a flag we didn't model) are cheaper than blocking
+      # legitimate pushes.
+      -*) ;;
+      # First positional → remote. Second positional → branch (refspec).
+      *)
+        if [ -z "$remote" ]; then
+          remote="$tok"
+        elif [ -z "$branch" ]; then
+          branch="$tok"
+        fi
+        ;;
+    esac
+    i=$((i + 1))
+  done
+
+  # Default remote when omitted (e.g. `git push`).
+  [ -n "$remote" ] || remote="origin"
+
+  # The rule applies only to the GitHub origin remote — other remotes pass
+  # through.
+  [ "$remote" = "origin" ] || return 1
+
+  # `git push origin :branch` (or `git push origin --delete branch`) is an
+  # explicit deletion request, not a content push — let it through. Likewise
+  # `git push origin <sha>:<branch>` (force-push from a specific sha) — we
+  # cannot safely reason about whether the destination ref is the merged PR's
+  # old head without parsing refspecs, so we pass through.
+  case "$branch" in
+    :*|*:*) return 1 ;;
+  esac
+
+  # When the branch was not specified positionally (e.g. `git push origin`
+  # alone, or `git push -u origin` with no branch), derive the current branch
+  # from the resolved target dir.
+  if [ -z "$branch" ]; then
+    branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+  fi
+
+  # Still no branch (detached HEAD, non-git dir) — nothing to gate.
+  [ -n "$branch" ] || return 1
+
+  # Detached-HEAD-style refspecs like `HEAD` are not a static branch name the
+  # user mistakenly re-pushed, so pass through.
+  case "$branch" in
+    HEAD|refs/*) return 1 ;;
+  esac
+
+  return 0
+}
+
+# judge_push
+# 0 when the push must be BLOCKED (with `pr_number` / `pr_merged_at` /
+# `pr_title` set for the message), 1 when it is allowed.
+judge_push() {
+  local pr_json
+  resolve_gh || return 1
+
+  # Query GitHub for any MERGED PR with this head ref. `--limit 1` because
+  # branch names are unique per repo (a branch can only have ever been the head
+  # ref of one PR at a time; if multiple PRs ever shared the name, the
+  # most-recently-merged one is the relevant one — that is the default ordering
+  # anyway).
+  #
+  # `gh pr list` exits non-zero on auth failure / network error. We treat that
+  # as "couldn't check" and pass through with a debug note — same fail-open
+  # posture as the missing-gh branch.
+  pr_json=$("${gh_bin}" pr list --head "$branch" --state merged --limit 1 \
+              --json number,mergedAt,headRefName,title 2>/dev/null || true)
+
+  if [ -z "$pr_json" ] || [ "$pr_json" = "null" ]; then
+    echo "post-merge-orphan-push-gate: gh pr list failed or returned empty; skipping check." >&2
+    return 1
+  fi
+
+  # jq across an empty array returns "null" for `.[0]` — safe to query scalar
+  # fields directly with `// empty` as a defensive default.
+  pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null || echo "")
+  pr_head=$(printf '%s' "$pr_json" | jq -r '.[0].headRefName // empty' 2>/dev/null || echo "")
+  pr_merged_at=$(printf '%s' "$pr_json" | jq -r '.[0].mergedAt // empty' 2>/dev/null || echo "")
+  pr_title=$(printf '%s' "$pr_json" | jq -r '.[0].title // empty' 2>/dev/null || echo "")
+
+  # No PR matching this branch → nothing to gate.
+  [ -n "$pr_number" ] || return 1
+
+  # Defensive: the API returned a PR but its head ref does not match the branch
+  # we asked about. Could happen if `--head` matches loosely on a future
+  # GitHub-side change. Pass through rather than mis-fire.
+  [ "$pr_head" = "$branch" ] || return 1
+
+  return 0
+}
 
 remote=""
 branch=""
-i=0
-while [ "$i" -lt "${#tokens[@]}" ]; do
-  tok="${tokens[$i]}"
-  case "$tok" in
-    # Skip the trailing `git push` itself if it sneaks in.
-    push) ;;
-    # Flags that take NO value — skip just this token.
-    -u|--set-upstream|-f|--force|--force-with-lease|--force-if-includes|\
-    -n|--dry-run|-v|--verbose|-q|--quiet|--all|--tags|--follow-tags|\
-    --mirror|--prune|--delete|--atomic|--no-verify|--verify|--progress|\
-    --no-progress|--ipv4|--ipv6|-4|-6|--thin|--no-thin|--signed|\
-    --no-signed|--porcelain|--no-recurse-submodules)
-      ;;
-    # Flags that DO take a value — skip this token AND the next.
-    # `--foo=bar` (single token, captured by *=*) — no extra skip.
-    # `--foo bar` (two tokens) — skip the next token too.
-    # `--recurse-submodules` has BOTH a flag-only form and a
-    # `--recurse-submodules <mode>` form; we peek at the next token
-    # before deciding to consume it.
-    --repo|-o|--push-option|--receive-pack|--exec|--repo=*|\
-    --push-option=*|-o=*|--receive-pack=*|--exec=*|--recurse-submodules|\
-    --recurse-submodules=*)
-      case "$tok" in
-        *=*) ;;
-        --recurse-submodules)
-          next="${tokens[$((i + 1))]:-}"
-          case "$next" in
-            check|on-demand|only|no)
-              i=$((i + 1))
-              ;;
-          esac
-          ;;
-        *)
-          i=$((i + 1))
-          ;;
-      esac
-      ;;
-    # Any other --flag we don't know about — skip just this token, on
-    # the assumption it's flag-only. False negatives (missing the gate
-    # because of a flag we didn't model) are cheaper than blocking
-    # legitimate pushes.
-    -*) ;;
-    # First positional → remote. Second positional → branch (refspec).
-    *)
-      if [ -z "$remote" ]; then
-        remote="$tok"
-      elif [ -z "$branch" ]; then
-        branch="$tok"
-      fi
-      ;;
-  esac
-  i=$((i + 1))
-done
+pr_number=""
+pr_head=""
+pr_merged_at=""
+pr_title=""
+blocked=0
+while IFS= read -r seg_args; do
+  parse_push_args "$seg_args" || continue
+  if judge_push; then
+    blocked=1
+    break
+  fi
+done < <(gate_verb_args "$cmd" "$GATE_RE_GIT_PUSH")
 
-# Default remote when omitted (e.g. `git push`).
-if [ -z "$remote" ]; then
-  remote="origin"
-fi
-
-# Bail out early when the remote isn't `origin`. The rule applies only
-# to the GitHub origin remote — other remotes pass through.
-if [ "$remote" != "origin" ]; then
-  exit 0
-fi
-
-# `git push origin :branch` (or `git push origin --delete branch`) is an
-# explicit deletion request, not a content push — let it through.
-# Likewise `git push origin <sha>:<branch>` (force-push from a specific
-# sha) — we can't safely reason about whether the destination ref is
-# the merged-PR's old head without parsing refspecs, so we pass through.
-if [[ "$branch" == :* ]] || [[ "$branch" == *:* ]]; then
-  exit 0
-fi
-
-# When the branch wasn't specified positionally (e.g. `git push origin`
-# alone, or `git push -u origin` with no branch), derive the current
-# branch from the resolved target dir.
-if [ -z "$branch" ]; then
-  branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
-fi
-
-# If we still don't have a branch (detached HEAD, non-git dir), there's
-# nothing to gate.
-if [ -z "$branch" ]; then
-  exit 0
-fi
-
-# Detached-HEAD-style refspecs like `HEAD` aren't a static branch name
-# the user mistakenly re-pushed, so pass through.
-case "$branch" in
-  HEAD|refs/*) exit 0 ;;
-esac
-
-# Locate the gh binary. $GH_BIN, when set and executable, wins — this is
-# the mock injection point for smoke tests. Otherwise look up on
-# PATH. When gh is missing, pass through with a stderr debug note rather
-# than failing closed.
-if [ -n "${GH_BIN:-}" ] && [ -x "${GH_BIN}" ]; then
-  gh_bin="${GH_BIN}"
-elif command -v gh >/dev/null 2>&1; then
-  gh_bin="$(command -v gh)"
-else
-  echo "post-merge-orphan-push-gate: gh not installed; skipping check." >&2
-  exit 0
-fi
-
-# Query GitHub for any MERGED PR with this head ref. We use --limit 1
-# because branch names are unique per repo (a branch can only have ever
-# been the head ref of one PR at a time; if multiple PRs ever shared the
-# name, the most-recently-merged one is the relevant one — that's the
-# default ordering anyway).
-#
-# `gh pr list` exits non-zero on auth failure / network error. We treat
-# that as "couldn't check" and pass through with a debug note — same
-# fail-open posture as the missing-gh branch.
-pr_json=$("${gh_bin}" pr list --head "$branch" --state merged --limit 1 \
-            --json number,mergedAt,headRefName,title 2>/dev/null || true)
-
-if [ -z "$pr_json" ] || [ "$pr_json" = "null" ]; then
-  echo "post-merge-orphan-push-gate: gh pr list failed or returned empty; skipping check." >&2
-  exit 0
-fi
-
-# jq across an empty array returns "null" for `.[0]` — safe to query
-# scalar fields directly with `// empty` as a defensive default.
-pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null || echo "")
-pr_head=$(printf '%s' "$pr_json" | jq -r '.[0].headRefName // empty' 2>/dev/null || echo "")
-pr_merged_at=$(printf '%s' "$pr_json" | jq -r '.[0].mergedAt // empty' 2>/dev/null || echo "")
-pr_title=$(printf '%s' "$pr_json" | jq -r '.[0].title // empty' 2>/dev/null || echo "")
-
-# No PR matching this branch → nothing to gate.
-if [ -z "$pr_number" ]; then
-  exit 0
-fi
-
-# Defensive: the API returned a PR but its head ref doesn't match the
-# branch we asked about. Could happen if `--head` matches loosely on a
-# future GitHub-side change. Pass through rather than mis-fire.
-if [ "$pr_head" != "$branch" ]; then
-  exit 0
-fi
+[ "$blocked" -eq 1 ] || exit 0
 
 # Block the push.
 cat >&2 <<EOF

--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -150,6 +150,8 @@ target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_PUSH")
 # could not check anything on this machine" -- so it is stated once per command.
 gh_bin=""
 gh_probed=0
+# Same one-note-per-command rule for the gh FAILURE note below.
+gh_failed_noted=0
 resolve_gh() {
   if [ "$gh_probed" -eq 1 ]; then
     [ -n "$gh_bin" ] && return 0
@@ -270,12 +272,20 @@ parse_push_args() {
   # through, contrary to what this comment used to claim: `--delete` sits in the
   # valueless-flag list above, so it is skipped and `branch` lands in `$branch`
   # as an ordinary positional, which then blocks like any content push. Left as
-  # is deliberately. Deleting the merged branch again is a no-op on GitHub (the
-  # merge already deleted it), so the false block costs nothing real, whereas
-  # teaching the flag list to swallow its argument would hand every `--delete`
-  # spelling a pass-through the `:branch` arm grants only after reading a
-  # refspec. If it ever needs to pass, the fix is a `--delete`-specific arm
-  # here, not a change to the flag list.
+  # is deliberately -- but the reason has to be narrower than the one that used
+  # to stand here. "Deleting the merged branch again is a no-op" holds only
+  # while the branch is GONE, and the one case where `git push origin --delete
+  # <merged>` is a REAL operation is exactly the case this gate warns about: an
+  # ORPHAN ref re-created after the merge deleted it. Deleting that is the right
+  # cleanup, and the block then prints a cherry-pick remedy that does not apply
+  # to it.
+  #
+  # It is still left as is, because the cost is a confusing message on a
+  # deliberate cleanup, against teaching the flag list to swallow its argument
+  # -- which would hand EVERY `--delete` spelling a pass-through the `:branch`
+  # arm grants only after reading a refspec. If it ever needs to pass, the fix
+  # is a `--delete`-specific arm here (which can then print the right remedy),
+  # not a change to the flag list.
   case "$branch" in
     :*|*:*) return 1 ;;
   esac
@@ -288,8 +298,15 @@ parse_push_args() {
     # the `gate_segments` process substitution, so a callee that reads stdin
     # would consume segments the walk has not judged yet. `symbolic-ref` does
     # not read stdin today; the fence is here so that stays a property of the
-    # CALL SITE rather than of the callee. No case can pin it -- the failure it
-    # forecloses does not exist yet -- which is why it is stated here.
+    # CALL SITE rather than of the callee.
+    #
+    # THIS half is genuinely unpinnable and the `gh` one below is NOT, which is
+    # a distinction an earlier version of this comment did not draw -- it
+    # claimed "no case can pin it" for both. `git` is the real binary in the
+    # smoke suite, so making it drain stdin would mean shipping a git stub; the
+    # `gh` call is already a suite-owned stub, so teaching that stub to read
+    # stdin plus one two-push case discriminates its `</dev/null` exactly. That
+    # case now exists in gate-command-recognition.test.sh.
     branch=$(git -C "$target_dir" symbolic-ref --short HEAD </dev/null 2>/dev/null || echo "")
   fi
 
@@ -327,7 +344,18 @@ judge_push() {
               --json number,mergedAt,headRefName,title </dev/null 2>/dev/null || true)
 
   if [ -z "$pr_json" ] || [ "$pr_json" = "null" ]; then
-    echo "post-merge-orphan-push-gate: gh pr list failed or returned empty; skipping check." >&2
+    # ONCE PER COMMAND, like `resolve_gh`'s missing-gh note and for the same
+    # reason: it describes a per-command condition ("this machine's gh could
+    # not answer"), not a per-segment verdict. Unguarded it printed once per
+    # gateable segment, so `git push origin a && git push origin b && git push
+    # origin c` emitted it three times -- while `.claude/rules/hooks.md` states
+    # the note is stated once. The memo is a separate flag rather than a check
+    # on `pr_json`, because an empty answer is also a legitimate per-segment
+    # result.
+    if [ "$gh_failed_noted" -eq 0 ]; then
+      gh_failed_noted=1
+      echo "post-merge-orphan-push-gate: gh pr list failed or returned empty; skipping check." >&2
+    fi
     return 1
   fi
 

--- a/.claude/hooks/post-merge-orphan-push-gate.sh
+++ b/.claude/hooks/post-merge-orphan-push-gate.sh
@@ -105,22 +105,57 @@ target_dir=$(gate_target_dir "$cmd" "${hook_cwd:-$PWD}" "$GATE_RE_GIT_PUSH")
 # most one `gh` call.
 #
 # LIMIT, stated rather than hidden: `target_dir` is resolved ONCE, for the whole
-# command, because `gate_target_dir` reports the LAST matching segment's tree
-# and the shared helper exposes no per-segment answer. Reconstructing a
-# per-segment prefix to ask again was considered and rejected -- re-splitting
-# text that has already been segmented would let a NEWLINE inside a quoted
-# argument (`gh pr create --body "...\ncd /evil"`) surface as a `cd` segment,
-# which is a worse hole than the one it closes. The exposure is narrow: the
-# positional branch is read from the segment itself, so `target_dir` only
-# decides the `symbolic-ref` fallback for a push that OMITS the branch, and only
-# when one command pushes from two different trees.
+# command, because `gate_target_dir` reports the FIRST matching segment's tree
+# and the shared helper exposes no per-segment answer. FIRST, not last: the
+# helper `break`s out of its segment walk as soon as a segment matches the verb
+# ERE. Measured, not assumed --
+#
+#   gate_target_dir 'git -C /aaa push origin && git -C /bbb push origin' \
+#                   /fallback "$GATE_RE_GIT_PUSH"          -> /aaa
+#
+# -- and the direction matters to a reader even though the BOUND does not: it is
+# the EARLIEST push's tree that is in force for every segment, so the last
+# `-C` in the command is precisely the one that is NOT consulted.
+#
+# Reconstructing a per-segment prefix to ask again was considered and rejected,
+# but NOT for the reason once given here. That reason -- that re-splitting text
+# which `gate_segments` has already segmented would let a NEWLINE inside a
+# quoted argument (`gh pr create --body "...<newline>cd /evil"`) surface as a
+# `cd` segment -- does not reproduce: `gate_segments` flattens a quoted newline
+# to a SPACE, so `gh pr create --body "line1<newline>cd /evil" && git push
+# origin feat/x` splits into exactly two segments, and re-splitting either of
+# them returns that same segment unchanged. Re-splitting is idempotent and no
+# `cd` segment appears.
+#
+# The obstacle that DOES exist is the `break` above. Handed a prefix that ends
+# at segment N, `gate_target_dir` still answers for the first matching segment
+# inside that prefix rather than for N, so the per-segment question cannot be
+# asked at all without changing the shared helper -- which is a change to every
+# gate that calls it, not to this one.
+#
+# The exposure is narrow either way: the positional branch is read from the
+# segment itself, so `target_dir` only decides the `symbolic-ref` fallback for a
+# push that OMITS the branch, and only when one command pushes from two
+# different trees.
 
 # Resolved lazily and memoised: a command whose remote is not `origin` must not
 # print the "gh not installed" note, which is what hoisting this above the walk
 # would do.
+#
+# BOTH ARMS are memoised, via `gh_probed` rather than via `gh_bin`. Keying the
+# memo on `gh_bin` alone memoised only SUCCESS: on a machine without `gh`,
+# `gh_bin` stays empty, so every gateable segment re-ran the lookup and re-printed
+# the note, and `git push origin a && git push origin b && git push origin c`
+# emitted it three times. The note is a debug aid for ONE decision -- "this gate
+# could not check anything on this machine" -- so it is stated once per command.
 gh_bin=""
+gh_probed=0
 resolve_gh() {
-  [ -n "$gh_bin" ] && return 0
+  if [ "$gh_probed" -eq 1 ]; then
+    [ -n "$gh_bin" ] && return 0
+    return 1
+  fi
+  gh_probed=1
   # $GH_BIN, when set and executable, wins — this is the mock injection point
   # for smoke tests. Otherwise look up on PATH. When gh is missing, pass through
   # with a stderr debug note rather than failing closed.
@@ -149,6 +184,12 @@ parse_push_args() {
   # have cut is no longer in `args` to begin with — and a `push` after one of
   # them is now its own segment with its own turn in the walk, which is the
   # whole point.
+  # Pinned by "orphan-push: -u, redirected, on the merged branch": without this
+  # strip `git push -u origin >/tmp/log` parses `>/tmp/log` as the positional
+  # BRANCH, gh answers an empty list for it, and the gate exits 0 on a push to a
+  # merged branch. (`git push origin feat/merged >/tmp/log` does NOT
+  # discriminate -- the branch is already filled by then and the stray token is
+  # dropped -- which is why the case omits the branch.)
   args="${args%%>*}"
 
   # Tokenise. Single-quoted args stay together by best effort; an exotic case
@@ -219,11 +260,22 @@ parse_push_args() {
   # through.
   [ "$remote" = "origin" ] || return 1
 
-  # `git push origin :branch` (or `git push origin --delete branch`) is an
-  # explicit deletion request, not a content push — let it through. Likewise
-  # `git push origin <sha>:<branch>` (force-push from a specific sha) — we
-  # cannot safely reason about whether the destination ref is the merged PR's
-  # old head without parsing refspecs, so we pass through.
+  # `git push origin :branch` is an explicit deletion request, not a content
+  # push — let it through. Likewise `git push origin <sha>:<branch>`
+  # (force-push from a specific sha) — we cannot safely reason about whether the
+  # destination ref is the merged PR's old head without parsing refspecs, so we
+  # pass through.
+  #
+  # `git push origin --delete branch` is NOT covered here and does NOT pass
+  # through, contrary to what this comment used to claim: `--delete` sits in the
+  # valueless-flag list above, so it is skipped and `branch` lands in `$branch`
+  # as an ordinary positional, which then blocks like any content push. Left as
+  # is deliberately. Deleting the merged branch again is a no-op on GitHub (the
+  # merge already deleted it), so the false block costs nothing real, whereas
+  # teaching the flag list to swallow its argument would hand every `--delete`
+  # spelling a pass-through the `:branch` arm grants only after reading a
+  # refspec. If it ever needs to pass, the fix is a `--delete`-specific arm
+  # here, not a change to the flag list.
   case "$branch" in
     :*|*:*) return 1 ;;
   esac
@@ -232,7 +284,13 @@ parse_push_args() {
   # alone, or `git push -u origin` with no branch), derive the current branch
   # from the resolved target dir.
   if [ -z "$branch" ]; then
-    branch=$(git -C "$target_dir" symbolic-ref --short HEAD 2>/dev/null || echo "")
+    # `</dev/null`: this runs inside a `while IFS= read -r` loop whose stdin IS
+    # the `gate_segments` process substitution, so a callee that reads stdin
+    # would consume segments the walk has not judged yet. `symbolic-ref` does
+    # not read stdin today; the fence is here so that stays a property of the
+    # CALL SITE rather than of the callee. No case can pin it -- the failure it
+    # forecloses does not exist yet -- which is why it is stated here.
+    branch=$(git -C "$target_dir" symbolic-ref --short HEAD </dev/null 2>/dev/null || echo "")
   fi
 
   # Still no branch (detached HEAD, non-git dir) — nothing to gate.
@@ -263,8 +321,10 @@ judge_push() {
   # `gh pr list` exits non-zero on auth failure / network error. We treat that
   # as "couldn't check" and pass through with a debug note — same fail-open
   # posture as the missing-gh branch.
+  # `</dev/null` for the same reason as the `symbolic-ref` call above: the walk
+  # that reaches here is reading `gate_segments` on stdin.
   pr_json=$("${gh_bin}" pr list --head "$branch" --state merged --limit 1 \
-              --json number,mergedAt,headRefName,title 2>/dev/null || true)
+              --json number,mergedAt,headRefName,title </dev/null 2>/dev/null || true)
 
   if [ -z "$pr_json" ] || [ "$pr_json" = "null" ]; then
     echo "post-merge-orphan-push-gate: gh pr list failed or returned empty; skipping check." >&2

--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -181,49 +181,92 @@ MAX_REPORT=10
 # A file that EXISTS is treated the same way when the command REWRITES it,
 # because then what is on disk is the PREVIOUS body -- the other half of the same
 # window, and the one that reads as a working gate while judging text nobody
-# submitted.
-cmd_writes_path() {
+# submitted. An APPEND is the third case and is NOT the same: the disk copy
+# survives as the first half of the submitted body, so both halves are scanned.
+
+# `>` / `tee` (no `-a`) naming the path: the command REPLACES what is on disk, so
+# the previous body is not part of what gets submitted.
+#
+# The terminator class is not decoration. `(?:\s|$)` alone missed the TIGHT
+# spelling of the very shape this exists for -- `>f<<EOF` -- as well as `>f;` and
+# `>f&&`. Measured here before the widening: an EXISTING clean body file
+# rewritten by `cat >f<<EOF` carrying `Must-fix #1` exited 0. All three arms are
+# pinned by cases.
+#
+# `>` must NOT match the `>` inside `>>`, and `tee` must not match `tee -a`:
+# an APPEND leaves the previous body in place as the FIRST HALF of what is
+# submitted. Treating one as the other is what `cmd_writes_path` did, and it made
+# this gate WEAKER than the code it replaced -- `origin/main` and this lane's own
+# first commit both exited 2 on an append over an offending file where the tip
+# exited 0. Hence two predicates rather than one flag.
+cmd_rewrites_path() {
   local path="$1"
   CMD="$cmd" TARGET="$path" perl -0777 -e '
     my $cmd = $ENV{CMD};
     my $t   = quotemeta($ENV{TARGET});
-    # `>` / `>>` / `tee [-a]` naming the path, quoted or bare. A heredoc body is
-    # written through exactly this redirect (`cat > f <<EOF`), so matching the
-    # redirect covers the heredoc shape without parsing heredocs.
-    # The terminator class is not decoration. `(?:\s|$)` alone missed the TIGHT
-    # spelling of the very shape this exists for -- `>f<<EOF` -- as well as `>f;`
-    # and `>f&&`. Measured here before the widening: an EXISTING clean body file
-    # rewritten by `cat >f<<EOF` carrying `Must-fix #1` exited 0.
-    exit 0 if $cmd =~ /(?:>>?|\btee\b(?:\s+-a)?)\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    # (?<!>) keeps `>>f` out of the `>f` arm while leaving `1>f` / `2>f` in it;
+    # the tee arm spells the flag-less form explicitly.
+    exit 0 if $cmd =~ /(?<!>)>\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    exit 0 if $cmd =~ /\btee\b(?!\s+-a\b)(?:\s+-[^a\s-][^\s]*)*\s+(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
     exit 1;
   ' 2>/dev/null
 }
 
-# The body of the heredoc that writes a given path. Handles both orders
-# (`cat > f <<EOF` / `cat <<EOF > f`), quoted and unquoted delimiters, and
-# `<<-`'s tab-stripped terminator. Prints nothing when the command does not write
-# the path through a heredoc.
-heredoc_body_for() {
+# `>>` / `tee -a` naming the path: the command APPENDS, so the submitted body is
+# whatever is already on disk FOLLOWED BY the new text. Both halves have to be
+# scanned; scanning only the new half is the B1 regression above.
+cmd_appends_path() {
+  local path="$1"
+  CMD="$cmd" TARGET="$path" perl -0777 -e '
+    my $cmd = $ENV{CMD};
+    my $t   = quotemeta($ENV{TARGET});
+    exit 0 if $cmd =~ />>\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    exit 0 if $cmd =~ /\btee\b(?:\s+-[^\s]*)*\s+-a\b(?:\s+-[^\s]*)*\s+(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    exit 1;
+  ' 2>/dev/null
+}
+
+# EVERY heredoc body that writes a given path, in command order, joined by
+# newlines. Handles both orders (`cat > f <<EOF` / `cat <<EOF > f`), quoted and
+# unquoted delimiters, `<<-`'s tab-stripped terminator, and the append forms.
+#
+# Two things this must report separately, because collapsing them is a
+# false-BLOCK:
+#   - "no heredoc writes this path" -> the caller may fall back to the file
+#   - "a heredoc writes this path and its body is EMPTY" -> there is nothing to
+#     scan and the file must NOT be consulted, since an empty rewrite means the
+#     submitted body is empty. Inferring this from empty stdout (which
+#     `heredoc_body_for` did) made an empty heredoc over an offending file exit 2
+#     -- the unclearable block this whole fallback exists to end, since the
+#     author cannot edit a line they are not submitting.
+# So found-ness rides the EXIT STATUS and the body rides stdout.
+#
+# Only the FIRST chunk used to be collected (`last;` at the end of the loop), so
+# `cat >f <<A ... A; cat >>f <<B ... B` with the offender in B exited 0. Measured
+# on the tip before this change.
+heredoc_bodies_for() {
   CMD="$cmd" TARGET="$1" perl -0777 -e '
     my $c = $ENV{CMD};
     my $t = quotemeta($ENV{TARGET});
     my @lines = split /\n/, $c, -1;
+    my $found = 0;
+    my @out;
     for my $i (0 .. $#lines) {
       my $l = $lines[$i];
-      next unless $l =~ /(?:>>?|\btee\b(?:\s+-a)?)\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+      next unless $l =~ /(?:>>?|\btee\b(?:\s+-[^\s]*)*)\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
       next unless $l =~ /(<<-?)\s*(["\x27]?)([A-Za-z_][A-Za-z0-9_]*)\2/;
       my $dash  = ($1 eq "<<-");
       my $delim = $3;
-      my @body;
+      $found = 1;
       for my $j ($i + 1 .. $#lines) {
         my $probe = $lines[$j];
         $probe =~ s/^\t+// if $dash;
         last if $probe eq $delim;
-        push @body, $lines[$j];
+        push @out, $lines[$j];
       }
-      print join("\n", @body), "\n" if @body;
-      last;
     }
+    print join("\n", @out), "\n" if @out;
+    exit($found ? 0 : 1);
   ' 2>/dev/null
 }
 
@@ -262,35 +305,58 @@ scan_text() {
 # scanning for exactly this reason; this repo has no such gate, so the evidence
 # here is the two controls above, pinned as cases.)
 #
+# What gets scanned, per body file:
+#   heredoc chunks -- whenever any heredoc writes the path, and ALL of them.
+#   the file       -- unless a heredoc REWRITE discards it. An append keeps it
+#                     (it is the first half of the submission), and so does a
+#                     command that does not write the path at all.
+# A rewrite the extractor cannot read (`printf > f`) leaves `found` false, so the
+# file is still consulted -- the known limit below, unchanged.
+#
 # Known miss, stated rather than hidden: a one-call body written by something
 # other than a heredoc redirect (`printf > f`, `python3 -c ... > f`) cannot be
 # extracted, so it falls back to whatever is on disk -- and to nothing at all
 # when the path does not exist yet. Both halves are pinned by cases.
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
-  body_text=""
-  if [[ ! -f "$f" ]] || cmd_writes_path "$f"; then
-    body_text=$(heredoc_body_for "$f")
+
+  heredoc_text=""
+  heredoc_found=0
+  if heredoc_text=$(heredoc_bodies_for "$f"); then
+    heredoc_found=1
   fi
-  if [[ -n "$body_text" ]]; then
-    scan_text "$f (heredoc, not yet written)" "$body_text"
+
+  scan_file=1
+  [[ -f "$f" ]] || scan_file=0
+  if [[ "$heredoc_found" -eq 1 ]] && cmd_rewrites_path "$f"; then
+    # The disk copy is discarded by the rewrite, so it is not part of the
+    # submission -- even when the same command also appends after it.
+    scan_file=0
+  fi
+
+  if [[ "$heredoc_found" -eq 1 && -n "$heredoc_text" ]]; then
+    if cmd_appends_path "$f" && [[ "$scan_file" -eq 1 ]]; then
+      scan_text "$f (heredoc, appended to the file below)" "$heredoc_text"
+    else
+      scan_text "$f (heredoc, not yet written)" "$heredoc_text"
+    fi
     if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
       break
     fi
-    continue
   fi
-  [[ -f "$f" ]] || continue
 
-  while IFS=$'\t' read -r ln content; do
-    [[ -z "$content" ]] && continue
-    hit=$(find_offender "$content")
-    if [[ -n "$hit" ]]; then
-      OFFENDERS+=("$f:$ln: $content")
-      if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
-        break
+  if [[ "$scan_file" -eq 1 ]]; then
+    while IFS=$'\t' read -r ln content; do
+      [[ -z "$content" ]] && continue
+      hit=$(find_offender "$content")
+      if [[ -n "$hit" ]]; then
+        OFFENDERS+=("$f:$ln: $content")
+        if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
+          break
+        fi
       fi
-    fi
-  done < <(strip_code_blocks < "$f")
+    done < <(strip_code_blocks < "$f")
+  fi
 
   if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
     break

--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -170,9 +170,70 @@ find_offender() {
 declare -a OFFENDERS=()
 MAX_REPORT=10
 
+# When the named body file cannot be READ, scan the WHOLE COMMAND instead of
+# skipping (go-to-k/cdk-local#637, ported from go-to-k/cdkd#2397). The hook runs
+# BEFORE the command does, so whenever the heredoc that writes the body and the
+# `gh` call that consumes it sit in ONE Bash call -- the publishing shape this
+# repo mandates, since a gated command needs its own Bash call and the body has
+# to exist by then -- the path does not exist yet. `[[ ! -f "$f" ]] && continue`
+# made that a SILENT PASS.
+#
+# Both sibling gates already do this: `issue-dup-check-gate.sh` and
+# `issue-classification-label-gate.sh` hit the same window and fall back to the
+# command, each with a comment saying that failing closed there would refuse the
+# flow the rules prescribe. So this is a port, not a design decision.
+#
+# A file that EXISTS is scanned too when the command REWRITES it, because then
+# what is on disk is the PREVIOUS body -- the other half of the same window, and
+# the one that reads as a working gate while judging text nobody submitted.
+#
+# Note the direction differs from `issue-dup-check-gate.sh`'s fallback and that
+# is deliberate: this gate objects to content it FINDS, so scanning extra text
+# can only add a refusal that names a real `#N`, while that gate needs to FIND a
+# marker and so treats an unreadable path as a block.
+cmd_writes_path() {
+  local path="$1"
+  CMD="$cmd" TARGET="$path" perl -0777 -e '
+    my $cmd = $ENV{CMD};
+    my $t   = quotemeta($ENV{TARGET});
+    # `>` / `>>` / `tee [-a]` naming the path, quoted or bare. A heredoc body is
+    # written through exactly this redirect (`cat > f <<EOF`), so matching the
+    # redirect covers the heredoc shape without parsing heredocs.
+    exit 0 if $cmd =~ /(?:>>?|\btee\b(?:\s+-a)?)\s*(["\x27]?)$t\1(?:\s|$)/;
+    exit 1;
+  ' 2>/dev/null
+}
+
+scan_text() {
+  # $1 = label used in the offender report, $2 = the text to scan.
+  local label="$1"
+  while IFS=$'\t' read -r ln content; do
+    [[ -z "$content" ]] && continue
+    hit=$(find_offender "$content")
+    if [[ -n "$hit" ]]; then
+      OFFENDERS+=("$label:$ln: $content")
+      if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
+        return
+      fi
+    fi
+  done < <(printf '%s' "$2" | strip_code_blocks)
+}
+
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
-  [[ ! -f "$f" ]] && continue
+  if [[ ! -f "$f" ]]; then
+    scan_text "<command>" "$cmd"
+    if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
+      break
+    fi
+    continue
+  fi
+  if cmd_writes_path "$f"; then
+    scan_text "<command>" "$cmd"
+    if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
+      break
+    fi
+  fi
 
   while IFS=$'\t' read -r ln content; do
     [[ -z "$content" ]] && continue

--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -170,27 +170,18 @@ find_offender() {
 declare -a OFFENDERS=()
 MAX_REPORT=10
 
-# When the named body file cannot be READ, scan the WHOLE COMMAND instead of
-# skipping (go-to-k/cdk-local#637, ported from go-to-k/cdkd#2397). The hook runs
-# BEFORE the command does, so whenever the heredoc that writes the body and the
-# `gh` call that consumes it sit in ONE Bash call -- the publishing shape this
-# repo mandates, since a gated command needs its own Bash call and the body has
-# to exist by then -- the path does not exist yet. `[[ ! -f "$f" ]] && continue`
-# made that a SILENT PASS.
+# When the named body file cannot be READ, scan the text the command is about to
+# WRITE there instead of skipping (go-to-k/cdk-local#637, ported from
+# go-to-k/cdkd#2397). The hook runs BEFORE the command does, so whenever the
+# heredoc that writes the body and the `gh` call that consumes it sit in ONE Bash
+# call -- the publishing shape this repo mandates, since a gated command needs
+# its own Bash call and the body has to exist by then -- the path does not exist
+# yet. `[[ ! -f "$f" ]] && continue` made that a SILENT PASS.
 #
-# Both sibling gates already do this: `issue-dup-check-gate.sh` and
-# `issue-classification-label-gate.sh` hit the same window and fall back to the
-# command, each with a comment saying that failing closed there would refuse the
-# flow the rules prescribe. So this is a port, not a design decision.
-#
-# A file that EXISTS is scanned too when the command REWRITES it, because then
-# what is on disk is the PREVIOUS body -- the other half of the same window, and
-# the one that reads as a working gate while judging text nobody submitted.
-#
-# Note the direction differs from `issue-dup-check-gate.sh`'s fallback and that
-# is deliberate: this gate objects to content it FINDS, so scanning extra text
-# can only add a refusal that names a real `#N`, while that gate needs to FIND a
-# marker and so treats an unreadable path as a block.
+# A file that EXISTS is treated the same way when the command REWRITES it,
+# because then what is on disk is the PREVIOUS body -- the other half of the same
+# window, and the one that reads as a working gate while judging text nobody
+# submitted.
 cmd_writes_path() {
   local path="$1"
   CMD="$cmd" TARGET="$path" perl -0777 -e '
@@ -199,8 +190,40 @@ cmd_writes_path() {
     # `>` / `>>` / `tee [-a]` naming the path, quoted or bare. A heredoc body is
     # written through exactly this redirect (`cat > f <<EOF`), so matching the
     # redirect covers the heredoc shape without parsing heredocs.
-    exit 0 if $cmd =~ /(?:>>?|\btee\b(?:\s+-a)?)\s*(["\x27]?)$t\1(?:\s|$)/;
+    # The terminator class is not decoration. `(?:\s|$)` alone missed the TIGHT
+    # spelling of the very shape this exists for -- `>f<<EOF` -- as well as `>f;`
+    # and `>f&&`. Measured here before the widening: an EXISTING clean body file
+    # rewritten by `cat >f<<EOF` carrying `Must-fix #1` exited 0.
+    exit 0 if $cmd =~ /(?:>>?|\btee\b(?:\s+-a)?)\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
     exit 1;
+  ' 2>/dev/null
+}
+
+# The body of the heredoc that writes a given path. Handles both orders
+# (`cat > f <<EOF` / `cat <<EOF > f`), quoted and unquoted delimiters, and
+# `<<-`'s tab-stripped terminator. Prints nothing when the command does not write
+# the path through a heredoc.
+heredoc_body_for() {
+  CMD="$cmd" TARGET="$1" perl -0777 -e '
+    my $c = $ENV{CMD};
+    my $t = quotemeta($ENV{TARGET});
+    my @lines = split /\n/, $c, -1;
+    for my $i (0 .. $#lines) {
+      my $l = $lines[$i];
+      next unless $l =~ /(?:>>?|\btee\b(?:\s+-a)?)\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+      next unless $l =~ /(<<-?)\s*(["\x27]?)([A-Za-z_][A-Za-z0-9_]*)\2/;
+      my $dash  = ($1 eq "<<-");
+      my $delim = $3;
+      my @body;
+      for my $j ($i + 1 .. $#lines) {
+        my $probe = $lines[$j];
+        $probe =~ s/^\t+// if $dash;
+        last if $probe eq $delim;
+        push @body, $lines[$j];
+      }
+      print join("\n", @body), "\n" if @body;
+      last;
+    }
   ' 2>/dev/null
 }
 
@@ -219,21 +242,44 @@ scan_text() {
   done < <(printf '%s' "$2" | strip_code_blocks)
 }
 
+# A file the command REWRITES holds the PREVIOUS body, so reading it judges text
+# nobody is submitting -- in both directions. It can miss (the stale copy is
+# clean, the new one is not) and it can BLOCK a clean submission while quoting a
+# line that will not exist, which the author cannot clear because the offending
+# text is not in what they are submitting. So the text being SUBMITTED is
+# extracted from the heredoc instead.
+#
+# The first attempt scanned the WHOLE COMMAND here, copying
+# `issue-dup-check-gate.sh`. That is safe for THAT gate and not for this one, and
+# the difference is what each looks for: it needs one anchored marker to be
+# PRESENT, so extra text can only make it pass; this gate objects to content it
+# FINDS, so extra text makes it BLOCK. Measured on that first attempt, both
+# against this repo's own copy: `gh issue create --title 'follow-up to #2397
+# discussion' --body-file <absent>` went from 0 to 2, and so did
+# `git commit -m 'address review #3' && gh pr create --body-file <absent>`. Both
+# are ordinary commands. (go-to-k/cdkd#2397's sibling reached the same verdict
+# from its own `gh-body-english-gate.sh`, which had refused whole-command
+# scanning for exactly this reason; this repo has no such gate, so the evidence
+# here is the two controls above, pinned as cases.)
+#
+# Known miss, stated rather than hidden: a one-call body written by something
+# other than a heredoc redirect (`printf > f`, `python3 -c ... > f`) cannot be
+# extracted, so it falls back to whatever is on disk -- and to nothing at all
+# when the path does not exist yet. Both halves are pinned by cases.
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
-  if [[ ! -f "$f" ]]; then
-    scan_text "<command>" "$cmd"
+  body_text=""
+  if [[ ! -f "$f" ]] || cmd_writes_path "$f"; then
+    body_text=$(heredoc_body_for "$f")
+  fi
+  if [[ -n "$body_text" ]]; then
+    scan_text "$f (heredoc, not yet written)" "$body_text"
     if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
       break
     fi
     continue
   fi
-  if cmd_writes_path "$f"; then
-    scan_text "<command>" "$cmd"
-    if [[ "${#OFFENDERS[@]}" -ge "$MAX_REPORT" ]]; then
-      break
-    fi
-  fi
+  [[ -f "$f" ]] || continue
 
   while IFS=$'\t' read -r ln content; do
     [[ -z "$content" ]] && continue

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -18,11 +18,15 @@
 #           and the skill in direct contradiction
 #   - BLOCK for chained spellings, PASS for a command that merely QUOTES the verb
 #   - both halves of the go-to-k/cdk-local#637 window, below
-#   - the two FALSE-BLOCK controls that rule out a whole-command scan, and the
+#   - the three FALSE-BLOCK controls that rule out a whole-command scan, and the
 #     `printf > f` limit the heredoc extraction cannot reach
+#   - the third write shape, an APPEND, where the disk copy is the FIRST HALF of
+#     the submitted body and both halves must be scanned
+#   - every heredoc chunk writing the path, not merely the first, and an EMPTY
+#     heredoc body as distinct from no heredoc at all
 #
 # Measured rather than asserted (2026-08-31, bash 5.3): an always-`exit 0` stub
-# fails 10 of these and an always-`exit 2` stub fails 13, so neither direction
+# fails 16 of these and an always-`exit 2` stub fails 16, so neither direction
 # can pass vacuously. Keep these numbers current when cases are added -- a stale
 # count in a comment that exists to prove non-vacuity is itself the thing it
 # warns about.
@@ -221,6 +225,99 @@ PRINTF_OVER_STALE="printf 'Must-fix 4: clean now\\n' > $ITEMNUM
 gh pr create --body-file $ITEMNUM"
 run "KNOWN LIMIT: a printf-written body falls back to the stale file" "$PRINTF_OVER_STALE" 2
 
+
+# --- An APPEND is not a rewrite ---------------------------------------------
+# `>>` / `tee -a` leave the file in place: what gets submitted is the DISK COPY
+# FOLLOWED BY the new chunk. The first version of the fallback matched `>>` and
+# `tee -a` with the same predicate as `>` and then scanned the heredoc INSTEAD of
+# the file, which made this gate WEAKER than the code it replaced -- measured on
+# an append over an offending file: `origin/main` 2, this lane's first commit
+# (5ddab33) 2, the tip 0. Both halves are asserted, since a hook that scanned
+# only the file would satisfy the first case and a hook that scanned only the
+# heredoc would satisfy the second.
+APPENDED=$(write_file appended.md "# Title
+
+Must-fix #1: already on disk
+")
+APPEND_OVER_OFFENDER="cat >> $APPENDED <<'EOF'
+Must-fix 2: clean appended chunk
+EOF
+gh pr create --body-file $APPENDED"
+run "an APPEND still scans the file it appends to" "$APPEND_OVER_OFFENDER" 2
+APPEND_TEE="tee -a $APPENDED <<'EOF'
+Must-fix 2: clean appended chunk
+EOF
+gh pr create --body-file $APPENDED"
+run "...and 'tee -a' is an append too" "$APPEND_TEE" 2
+APPEND_BAD_CHUNK="cat >> $CLEAN <<'EOF'
+Must-fix #8: the appended chunk offends
+EOF
+gh pr create --body-file $CLEAN"
+run "an APPEND also scans the chunk being appended" "$APPEND_BAD_CHUNK" 2
+# The false-BLOCK control for the append path, carrying a `#N` OUTSIDE the body
+# for the same reason the two controls above do: a clean append to a clean file
+# must pass even when the command text around it mentions an issue number.
+APPEND_CLEAN="git commit -m 'address review #3' && cat >> $CLEAN <<'EOF'
+Must-fix 2: clean appended chunk
+EOF
+gh pr create --body-file $CLEAN"
+run "a clean APPEND to a clean file passes" "$APPEND_CLEAN" 0
+
+# --- EVERY heredoc writing the path, not just the first ---------------------
+# The extractor ended its loop with `last;`, so a body assembled from two chunks
+# was judged on the first alone. Measured on the tip: the command below exited 0.
+TWO_CHUNKS="cat > $TMPROOT/two-chunks.md <<'A'
+Must-fix 1: first chunk is clean
+A
+cat >> $TMPROOT/two-chunks.md <<'B'
+Must-fix #9: the offender is in the SECOND chunk
+B
+gh pr create --body-file $TMPROOT/two-chunks.md"
+run "the SECOND heredoc chunk writing the path is scanned too" "$TWO_CHUNKS" 2
+# The control: two clean chunks REWRITING an offending file still pass, so the
+# case above is not passing merely because two heredocs block. It also pins that
+# a multi-chunk rewrite still discards the disk copy.
+TWO_CHUNKS_CLEAN="cat > $ITEMNUM <<'A'
+Must-fix 1: first chunk is clean
+A
+cat >> $ITEMNUM <<'B'
+Must-fix 2: second chunk is clean
+B
+gh pr create --body-file $ITEMNUM"
+run "...while two CLEAN chunks rewriting an offending file pass" "$TWO_CHUNKS_CLEAN" 0
+
+# --- An EMPTY heredoc body is not "no heredoc" ------------------------------
+# The extractor printed only `if @body`, so an empty body was indistinguishable
+# from no heredoc at all and the caller fell back to the STALE file: an empty
+# rewrite of an offending file exited 2. That is the unclearable false block this
+# whole fallback exists to end -- the author cannot edit a line they are not
+# submitting. Found-ness now rides the exit status.
+EMPTY_REWRITE="cat > $ITEMNUM <<'EOF'
+EOF
+gh pr create --body-file $ITEMNUM"
+run "an EMPTY heredoc rewrite does not fall back to the stale file" "$EMPTY_REWRITE" 0
+# Its control is `KNOWN LIMIT: a printf-written body falls back to the stale
+# file` above: with NO heredoc the fallback must still happen, so the case above
+# cannot be satisfied by simply never reading the file.
+
+# --- The other two widened terminator arms ----------------------------------
+# `>f<<EOF` has a case above; `>f;` and `>f&&` did not, so narrowing the class
+# back to `[\s<]` left the suite green. Both put the redirect at the END of its
+# line, which is exactly where the old `(?:\s|$)` looked correct and was not.
+SEMI_TERM="cat <<'EOF' >$CLEAN;
+# Title
+
+Must-fix #5: semicolon terminator
+EOF
+gh pr create --body-file $CLEAN"
+run "the '>f;' terminator is still scanned" "$SEMI_TERM" 2
+AMP_TERM="cat <<'EOF' >$CLEAN&&
+# Title
+
+Must-fix #6: and-and terminator
+EOF
+gh pr create --body-file $CLEAN"
+run "the '>f&&' terminator is still scanned" "$AMP_TERM" 2
 
 # --- Registration -----------------------------------------------------------
 # A gate nothing invokes is a gate that does not fire, which no behavioural case

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -25,11 +25,11 @@
 #   - every heredoc chunk writing the path, not merely the first, and an EMPTY
 #     heredoc body as distinct from no heredoc at all
 #
-# Measured rather than asserted (2026-08-31, bash 5.3): an always-`exit 0` stub
-# fails 16 of these and an always-`exit 2` stub fails 16, so neither direction
-# can pass vacuously. Keep these numbers current when cases are added -- a stale
-# count in a comment that exists to prove non-vacuity is itself the thing it
-# warns about.
+# Measured rather than asserted, and RE-MEASURED 2026-09-01 at 33 cases under
+# BOTH interpreters: an always-`exit 0` stub fails 16 of these and an
+# always-`exit 2` stub fails 16, so neither direction can pass vacuously. Keep
+# these numbers current when cases are added -- a stale count in a comment that
+# exists to prove non-vacuity is itself the thing it warns about.
 
 set -u
 
@@ -38,6 +38,39 @@ PASS=0
 FAIL=0
 
 TMPROOT=$(mktemp -d)
+# bash 3.2 is NOT exercised on the HOOK by running THIS FILE under /bin/bash.
+# The hook's shebang is `#!/usr/bin/env bash`, which resolves through PATH and
+# finds whatever bash is first there -- Homebrew 5.x on a dev Mac -- so
+# `/bin/bash <suite>` measured the SUITE under 3.2 and the SUBJECT under 5.x.
+# `HOOK_BASH` puts a `bash` shim first on PATH so the shebang, the explicit
+# `bash "$HOOK"` calls, and any `bash` the hook itself spawns all follow the
+# harness. Proved load-bearing rather than assumed: injecting a `;;&` (a bash
+# 4+ case terminator) into the hook reddens cases only WITH the shim in place.
+# DEFAULTED to `/bin/bash` (3.2 on macOS) rather than left opt-in, matching
+# `gate-command-recognition.test.sh` in this repo: nothing sets `HOOK_BASH` in
+# `vp run test:hooks`, so an opt-in fence measures 5.x in CI forever and the 3.2
+# tally is only ever taken by hand. Override with
+# `HOOK_BASH=/opt/homebrew/bin/bash bash <this file>` to take the 5.x one.
+HOOK_BASH="${HOOK_BASH:-/bin/bash}"
+[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+if [ -n "${HOOK_BASH:-}" ]; then
+  # Resolved to an ABSOLUTE path first: `HOOK_BASH=bash` would otherwise make
+  # `ln -sf bash <shim>/bash` a symlink pointing at ITSELF, and every hook
+  # invocation would die on ELOOP -- a suite-wide red with a cause nowhere near
+  # the hook.
+  HOOK_BASH_BIN="$(command -v "$HOOK_BASH" 2>/dev/null || printf '%s' "$HOOK_BASH")"
+  case "$HOOK_BASH_BIN" in /*) ;; *) HOOK_BASH_BIN="$PWD/$HOOK_BASH_BIN" ;; esac
+  HOOK_BASH_SHIM="$TMPROOT/bash32-shim"
+  mkdir -p "$HOOK_BASH_SHIM"
+  ln -sf "$HOOK_BASH_BIN" "$HOOK_BASH_SHIM/bash"
+  PATH="$HOOK_BASH_SHIM:$PATH"
+  export PATH
+fi
+# PRINTED, not merely honoured: a suite that does not say which interpreter it
+# measured cannot be read as evidence about either one.
+printf 'hook interpreter: %s (bash %s)\n' \
+  "$(command -v bash)" "$(bash -c 'echo "$BASH_VERSION"')"
+
 trap 'rm -rf "$TMPROOT"' EXIT
 
 # write_file <name> <content>  -> echoes the absolute path

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Smoke tests for pr-body-item-number-gate.sh
+#
+# Run from anywhere:  bash .claude/hooks/pr-body-item-number-gate.test.sh
+# `vp run test:hooks` globs `.claude/hooks/*.test.sh`, so this file is picked up
+# with no registration step.
+#
+# The gate blocks a `gh` writer whose `--body-file` / `-F body=@` body carries a
+# `#N` token GitHub would auto-link to an unrelated issue or PR. Asserts, in
+# both directions:
+#   - PASS  for the allow-listed contexts: `closes #N`, `(#N)`, a soft `refs: #N`,
+#           a full GitHub URL, and anything inside a fenced code block
+#   - BLOCK for item-number prefixes (`Must-fix #1`) and for a bare `#N` in prose
+#   - BLOCK for the SAME-repo qualified `go-to-k/cdk-local#N` spelling, which
+#           this repo deliberately refuses in a BODY -- `/work-issues` section
+#           10-c names a full URL as the only body spelling and the qualified
+#           form as the `.claude/**` one, so allowing it here would put the hook
+#           and the skill in direct contradiction
+#   - BLOCK for chained spellings, PASS for a command that merely QUOTES the verb
+#   - both halves of the go-to-k/cdk-local#637 window, below
+#
+# Measured rather than asserted (2026-08-31, bash 5.3): an always-`exit 0` stub
+# fails 8 of these and an always-`exit 2` stub fails 9, so neither direction
+# can pass vacuously. Keep these numbers current when cases are added -- a stale
+# count in a comment that exists to prove non-vacuity is itself the thing it
+# warns about.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/pr-body-item-number-gate.sh"
+PASS=0
+FAIL=0
+
+TMPROOT=$(mktemp -d)
+trap 'rm -rf "$TMPROOT"' EXIT
+
+# write_file <name> <content>  -> echoes the absolute path
+write_file() {
+  printf '%s' "$2" > "$TMPROOT/$1"
+  echo "$TMPROOT/$1"
+}
+
+# run <name> <command> <expected-exit>
+run() {
+  local name="$1" command="$2" expect="$3"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" '{tool_name:"Bash", tool_input:{command:$c}}')
+  out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ]; then
+    echo "PASS: $name (exit $rc)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $name (exit $rc, expected $expect)"
+    printf '%s\n' "$out" | sed 's/^/      /' | head -5
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# --- Fixture body files -----------------------------------------------------
+
+CLEAN=$(write_file clean.md "# Title
+
+Must-fix 1: thing one
+Must-fix 2: thing two
+")
+
+ITEMNUM=$(write_file itemnum.md "# Title
+
+Must-fix #1: thing one
+")
+
+BARE=$(write_file bare.md "# Title
+
+The regression landed in #1234 and nobody noticed.
+")
+
+ALLOWED=$(write_file allowed.md "# Title
+
+closes #1234
+Backport of (#231).
+refs: #99
+See https://github.com/go-to-k/cdk-local/issues/512 for the trace.
+")
+
+FENCED=$(write_file fenced.md "# Title
+
+\`\`\`
+Must-fix #1: inside a fenced block, not auto-linked
+\`\`\`
+")
+
+# The qualified same-repo spelling. Refused in a BODY on purpose -- see the
+# header. Pinned so a future port of the sibling repo's allow arm cannot land
+# here silently.
+QUALIFIED=$(write_file qualified.md "# Title
+
+Ported from go-to-k/cdk-local#587.
+")
+
+# --- Baseline behaviour -----------------------------------------------------
+
+run "clean bare-number body passes"            "gh pr create --body-file $CLEAN"    0
+run "item-number #N body blocked"              "gh pr create --body-file $ITEMNUM"  2
+run "bare #N in prose blocked"                 "gh pr create --body-file $BARE"     2
+run "allow-listed contexts pass"               "gh pr create --body-file $ALLOWED"  0
+run "fenced code block passes"                 "gh pr create --body-file $FENCED"   0
+run "same-repo qualified ref blocked in a body" "gh pr create --body-file $QUALIFIED" 2
+run "gh issue create with #N body blocked"     "gh issue create --title t --body-file $ITEMNUM" 2
+run "gh api -F body=@ with #N blocked"         "gh api -X PATCH repos/o/r/pulls/1 -F body=@$ITEMNUM" 2
+run "chained: git push && gh pr create blocked" "git push && gh pr create --body-file $ITEMNUM" 2
+run "quoted mention of the verb passes"        "echo \"then gh pr create --body-file $ITEMNUM\"" 0
+run "no body file passes"                      "gh pr create --title t --body 'Must-fix #1'" 0
+run "unrelated command passes"                 "ls -la" 0
+run "empty command passes"                     "" 0
+
+# --- go-to-k/cdk-local#637: the body file does not exist YET ----------------
+# The hook runs BEFORE the command, so in the one-call `heredoc -> file ->
+# --body-file` shape the path is absent and the pre-fix `[[ ! -f "$f" ]] &&
+# continue` was a silent pass. Both sibling gates that hit this window already
+# fall back to scanning the whole command; these pin the port.
+ABSENT="$TMPROOT/never-written.md"
+HEREDOC_BAD="cat > $ABSENT <<'EOF'
+# Title
+
+Must-fix #1: thing one
+EOF
+gh issue create --title t --body-file $ABSENT"
+HEREDOC_OK="cat > $ABSENT <<'EOF'
+# Title
+
+Must-fix 1: thing one
+EOF
+gh issue create --title t --body-file $ABSENT"
+
+run "one-call heredoc with #N in the body blocks" "$HEREDOC_BAD" 2
+# The false-BLOCK direction is what the sibling gates' comments warn about: this
+# is the shape the rules PRESCRIBE, so a clean body written the same way must
+# pass. Without this case the arm above would also be satisfied by a hook that
+# blocked every unreadable body file.
+run "one-call heredoc with a clean body passes"   "$HEREDOC_OK" 0
+
+# --- The other half of the same window --------------------------------------
+# The path EXISTS, holding the PREVIOUS body, while the command rewrites it.
+# Reading the file alone judges text nobody is submitting -- and does so while
+# looking like a working gate, which is worse than the absent case.
+STALE_REWRITE="cat > $CLEAN <<'EOF'
+# Title
+
+Must-fix #7: rewritten
+EOF
+gh pr create --body-file $CLEAN"
+run "a stale body file is not trusted when the command rewrites it" "$STALE_REWRITE" 2
+
+# The control that keeps the case above honest: the same clean file, NOT
+# rewritten by the command, must still pass. (It is also `clean bare-number body
+# passes` above, restated here so deleting either case leaves the pair visible.)
+run "a clean body file the command does not rewrite passes" "gh pr create --body-file $CLEAN" 0
+
+# --- Registration -----------------------------------------------------------
+# A gate nothing invokes is a gate that does not fire, which no behavioural case
+# above can detect.
+registration_check() {
+  local settings
+  settings="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.claude/settings.json"
+  if [ -f "$settings" ] && grep -q 'pr-body-item-number-gate.sh' "$settings"; then
+    echo "PASS: registered in .claude/settings.json"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: not registered in .claude/settings.json"; FAIL=$((FAIL + 1))
+  fi
+}
+registration_check
+
+echo ""
+echo "Pass: $PASS  Fail: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -18,9 +18,11 @@
 #           and the skill in direct contradiction
 #   - BLOCK for chained spellings, PASS for a command that merely QUOTES the verb
 #   - both halves of the go-to-k/cdk-local#637 window, below
+#   - the two FALSE-BLOCK controls that rule out a whole-command scan, and the
+#     `printf > f` limit the heredoc extraction cannot reach
 #
 # Measured rather than asserted (2026-08-31, bash 5.3): an always-`exit 0` stub
-# fails 8 of these and an always-`exit 2` stub fails 9, so neither direction
+# fails 10 of these and an always-`exit 2` stub fails 13, so neither direction
 # can pass vacuously. Keep these numbers current when cases are added -- a stale
 # count in a comment that exists to prove non-vacuity is itself the thing it
 # warns about.
@@ -116,8 +118,9 @@ run "empty command passes"                     "" 0
 # --- go-to-k/cdk-local#637: the body file does not exist YET ----------------
 # The hook runs BEFORE the command, so in the one-call `heredoc -> file ->
 # --body-file` shape the path is absent and the pre-fix `[[ ! -f "$f" ]] &&
-# continue` was a silent pass. Both sibling gates that hit this window already
-# fall back to scanning the whole command; these pin the port.
+# continue` was a silent pass. The two sibling gates that hit this window fall
+# back to the whole COMMAND; this one falls back to the HEREDOC BODY alone, for
+# the reason the false-block controls further down measure.
 ABSENT="$TMPROOT/never-written.md"
 HEREDOC_BAD="cat > $ABSENT <<'EOF'
 # Title
@@ -155,6 +158,69 @@ run "a stale body file is not trusted when the command rewrites it" "$STALE_REWR
 # rewritten by the command, must still pass. (It is also `clean bare-number body
 # passes` above, restated here so deleting either case leaves the pair visible.)
 run "a clean body file the command does not rewrite passes" "gh pr create --body-file $CLEAN" 0
+
+# --- The FALSE-BLOCK controls -----------------------------------------------
+# The first port of this fallback scanned the WHOLE COMMAND when the path was
+# absent or rewritten, copying `issue-dup-check-gate.sh`. That is safe for THAT
+# gate and not for this one: it needs one anchored marker to be PRESENT, so
+# extra text can only make it pass, while this gate objects to content it FINDS,
+# so extra text makes it BLOCK. Both of these are ORDINARY commands, and both
+# were measured going 0 -> 2 against the whole-command version. They are the
+# cases that force the heredoc extraction rather than a command scan, so they
+# are the two that must never be deleted as "obviously fine".
+run "an issue TITLE carrying #N does not block an absent body" \
+  "gh issue create --title 'follow-up to #2397 discussion' --body-file $TMPROOT/never-written-2.md" 0
+COMMIT_PREAMBLE="git commit -m 'address review #3' && cat > $ABSENT <<'EOF'
+# Title
+
+Must-fix 1: thing one
+EOF
+gh pr create --body-file $ABSENT"
+run "a COMMIT MESSAGE carrying #N does not block a clean body" "$COMMIT_PREAMBLE" 0
+
+# --- The stale file is not consulted at all once a heredoc is extracted ------
+# The inverse of `a stale body file is not trusted when the command rewrites
+# it`: here the file on disk OFFENDS and the body being submitted is clean, so a
+# gate that read the file would block a submission whose offending line does not
+# exist -- unclearable, because the author cannot edit text they are not sending.
+STALE_OFFENDING_CLEAN_REWRITE="cat > $ITEMNUM <<'EOF'
+# Title
+
+Must-fix 1: rewritten clean
+EOF
+gh pr create --body-file $ITEMNUM"
+run "an offending stale file rewritten by a CLEAN heredoc passes" "$STALE_OFFENDING_CLEAN_REWRITE" 0
+
+# --- The TIGHT heredoc spelling ---------------------------------------------
+# `cat >f<<EOF`, no spaces. `cmd_writes_path`'s terminator class used to be
+# `(?:\s|$)`, which matched neither this nor `>f;` nor `>f&&` -- so the tightest
+# spelling of the very shape the fallback exists for went unscanned. Measured
+# before the widening: this command exited 0.
+TIGHT="cat >$CLEAN<<'EOF'
+# Title
+
+Must-fix #3: tight redirect
+EOF
+gh pr create --body-file $CLEAN"
+run "the tight 'cat >f<<EOF' spelling is still scanned" "$TIGHT" 2
+
+# --- KNOWN LIMIT: a body not written by a heredoc cannot be extracted --------
+# `printf > f` / `python3 -c ... > f` write the body through a redirect this
+# gate recognises, but there is no heredoc to read, so the scan falls back to
+# whatever is ON DISK. Asserted in both directions so the limit is a recorded
+# behaviour rather than a surprise:
+#   - path ABSENT  -> nothing to scan at all, so an offending body PASSES
+#   - path EXISTS  -> the STALE file is scanned, so its content decides
+# Neither is a silent pass in the shape the repo actually mandates (a heredoc);
+# widening to cover them would mean interpreting arbitrary shell, which is the
+# whole-command scan the two controls above rule out.
+PRINTF_ABSENT="printf 'Must-fix #4: not extractable\\n' > $TMPROOT/never-written-3.md
+gh pr create --body-file $TMPROOT/never-written-3.md"
+run "KNOWN LIMIT: a printf-written body with an absent path is not scanned" "$PRINTF_ABSENT" 0
+PRINTF_OVER_STALE="printf 'Must-fix 4: clean now\\n' > $ITEMNUM
+gh pr create --body-file $ITEMNUM"
+run "KNOWN LIMIT: a printf-written body falls back to the stale file" "$PRINTF_OVER_STALE" 2
+
 
 # --- Registration -----------------------------------------------------------
 # A gate nothing invokes is a gate that does not fire, which no behavioural case

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -124,7 +124,7 @@ command -v python3 >/dev/null 2>&1 || exit 0
 #     session's to touch. And because this repo SQUASH-merges, a merged branch
 #     reads as ahead forever, so one un-removed worktree would have made that
 #     permanent.
-parsed=$(HOOK_INPUT="$input" python3 -c '
+parsed=$(HOOK_INPUT="$input" ENV_SID="${CLAUDE_CODE_SESSION_ID:-}" python3 -c '
 import json, os
 
 try:
@@ -142,16 +142,36 @@ if isinstance(flag, str):
     flag = flag.strip().lower() not in ("", "false", "0", "no")
 print("1" if flag else "0")
 print(data.get("cwd") or "")
-print((data.get("session_id") or "").replace("\t", " ").replace("\n", " "))
+
+# BOTH sources of the session id are resolved HERE, and normalised once, on the
+# way out. The fallback used to sit in shell AFTER this block, so it skipped the
+# fold entirely: a tab or a newline in `CLAUDE_CODE_SESSION_ID` reached the
+# record, where a tab adds a FIELD and a newline ends the line early. Either way
+# the read-back shifts, `prev_sid` never matches its own write, and the cadence
+# stops bounding anything -- unbounded `additionalContext`, one per turn,
+# against `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`. Measured with a payload carrying no
+# `session_id`: a plain value gave `ctx, sys, sys` while a leading tab, an
+# embedded tab and an embedded newline each gave `ctx, ctx, ctx`.
+sid = data.get("session_id") or os.environ.get("ENV_SID") or "shared"
+sid = sid.replace("\t", " ").replace("\n", " ").replace("\r", " ")
+print(sid or "shared")
 ')
 active=$(printf '%s\n' "$parsed" | sed -n 1p)
 hook_cwd=$(printf '%s\n' "$parsed" | sed -n 2p)
 sid=$(printf '%s\n' "$parsed" | sed -n 3p)
-[ -n "$sid" ] || sid="${CLAUDE_CODE_SESSION_ID:-shared}"
+# Defence in depth only: `parsed` is line-structured, so an empty line 3 would
+# mean the python block failed outright.
+[ -n "$sid" ] || sid="shared"
 
-# Already nudged once this turn and the model came back to Stop. Saying it again
-# would spin the turn instead of ending it, so stand down.
-[ "$active" = "1" ] && exit 0
+# Already continued once this turn on a hook's account. ARMING again would spin
+# the turn instead of ending it -- but going fully SILENT here was wrong, and
+# `exit 0` was exactly that. A lane can be COMMITTED during the continuation, in
+# which case this pass is the FIRST time the condition holds at all and the user
+# would never be told. A bare `systemMessage` does not continue a turn, so
+# saying it costs nothing. `resumed` is consumed where the channel is decided,
+# below; it suppresses the ARM and nothing else.
+resumed=0
+[ "$active" = "1" ] && resumed=1
 
 # Where is the SESSION? `cwd` from the event payload, resolved to its worktree
 # root. Falling back to this hook copy's own checkout is correct rather than
@@ -198,12 +218,15 @@ if [ -n "$self_branch" ]; then
   if [ -z "$unpushed" ]; then
     push_state="unpushed"
     push_line="It has no upstream yet, so nothing has been submitted: push it, open the PR, then merge."
+    push_line_user="It has no upstream yet, so nothing has been submitted."
   elif [ "$unpushed" -gt 0 ]; then
     push_state="unpushed"
     push_line="It has ${unpushed} commit(s) not yet pushed, so nothing carrying them has been submitted: push, open or update the PR, then merge."
+    push_line_user="It has ${unpushed} commit(s) not yet pushed."
   else
     push_state="pushed"
     push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none."
+    push_line_user="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches."
   fi
   msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
 This session's worktree is on '$self_branch', which is committed but not on origin/main, so you are not
@@ -216,6 +239,22 @@ is one you must NOT remove (an outer tool owns it, or you were launched inside i
 'git switch --detach origin/main' clears the lane here, because a worktree with no current branch is not
 a lane at all.
 Every unmerged lane in this checkout:"
+  # The DOWNGRADE text, and it is a different message rather than the same one
+  # on a quieter channel. Three paths reach it -- a repeat subject, a resumed
+  # pass, and a record that could not be persisted -- and on all three the
+  # reader is a HUMAN. Sending them the model's text ("you are not done: rebase,
+  # run the gates, open the PR") addresses the person as the agent, which is
+  # go-to-k/cdkd#2389's defect in miniature: that issue was exactly a message
+  # written AT the agent reaching only the party who cannot act on it, and
+  # emitting one string on both channels reproduces it on three paths instead of
+  # one. So this says what is true for a person: which lane, what state it is
+  # in, and that the agent has already been told.
+  msg_user="NOTE: this session's worktree is on '$self_branch', which is committed but not on origin/main.
+$push_line_user
+The agent has already been told about this lane in this session, so this is a status line for you rather
+than another nudge. If '$self_branch' is in fact already merged (this repo SQUASH-merges, so a merged
+branch keeps reading as ahead), clearing it means removing the worktree and deleting the branch.
+Every unmerged lane in this checkout:"
   channel="ctx"
 else
   msg="NOTE: unmerged lane(s) exist in this checkout, none of them this session's.
@@ -224,6 +263,9 @@ other sessions, or are already merged (this repo SQUASH-merges, so a merged bran
 ancestor of origin/main and keeps reading as ahead -- clearing one means removing its worktree and
 deleting the branch, not opening another PR).
 Lanes:"
+  # Already user-facing -- this branch never reaches the model channel at all,
+  # so there is nothing to split.
+  msg_user="$msg"
   channel="sys"
 fi
 
@@ -250,11 +292,17 @@ fi
 #   the same lane, unpushed -> pushed   -> nudge (a PR should exist now, and a
 #                                          pushed branch with none is the
 #                                          failure this hook is for)
+#   the same lane, pushed -> unpushed   -> quiet (that is an ordinary COMMIT)
 #   the same lane, same push state      -> quiet
 #   a DIFFERENT lane                    -> nudge (it is a different subject)
 #
-# The commit COUNT is deliberately not in the key: it changes every time the
-# model commits, which would re-arm the nudge on ordinary work and leave the
+# The comparison is DIRECTED, and reading it as a plain `prev != current`
+# equality is the shape that made this cadence per-commit rather than
+# per-subject. Only `unpushed -> pushed` re-arms; the reverse is what happens
+# every time the model commits.
+#
+# The commit COUNT is deliberately not in the key either: it changes every time
+# the model commits, which would re-arm the nudge on ordinary work and leave the
 # cadence as unbounded as it started.
 #
 # The record lives in the PER-WORKTREE git dir, so lanes never share one and
@@ -265,28 +313,93 @@ fi
 # nudge rather than a missed one, the safe direction.
 if [ "$channel" = "ctx" ]; then
   git_dir=$(git -C "$session_root" rev-parse --absolute-git-dir 2>/dev/null || true)
+  arm=1
+  persisted=0
   if [ -n "$git_dir" ]; then
     state_file="${git_dir}/stop-nudge-lane"
     subject="${self_branch}:${push_state}"
     prev_sid=""
     prev_subject=""
+    prev_ts=""
+    prev_rest=""
     if [ -r "$state_file" ]; then
-      IFS="$TAB" read -r prev_sid prev_subject _ <"$state_file" 2>/dev/null || true
+      IFS="$TAB" read -r prev_sid prev_subject prev_ts prev_rest <"$state_file" 2>/dev/null || true
     fi
-    if [ "$prev_sid" = "$sid" ] && [ "$prev_subject" = "$subject" ]; then
-      channel="sys"
-    else
+    # A record is consulted only when it is WELL-FORMED: exactly three
+    # tab-separated fields with a numeric epoch. Anything else -- an empty file,
+    # a truncated write, a fourth field from a future format, a clobber that
+    # interleaved two writers -- is treated as NO record, which falls to ARM.
+    # That is the safe direction: an extra nudge, never a missed one, matching
+    # the concurrent-clobber trade the record already accepts.
+    case "$prev_ts" in
+      "" | *[!0-9]*) prev_sid=""; prev_subject="" ;;
+    esac
+    [ -z "$prev_rest" ] || { prev_sid=""; prev_subject=""; }
+    prev_branch=${prev_subject%:*}
+    prev_push=${prev_subject##*:}
+
+    # The predicate is DIRECTED, and an undirected equality test was a real bug
+    # rather than a simplification. `pushed -> unpushed` is what an ordinary
+    # COMMIT looks like, so `prev_subject != subject` re-armed on every commit
+    # and again on every push. Measured on one lane before this fix:
+    # `commit ctx, repeat sys, push ctx, repeat sys, commit ctx, push ctx, ...`
+    # -- two forced continuations per commit/push cycle, forever, which is the
+    # per-commit cadence the comment above explicitly disclaims.
+    #
+    # So: a new session, a lane never seen, a DIFFERENT branch, or the one
+    # transition that opens an action the model did not have (`unpushed ->
+    # pushed`, after which a PR should exist and its absence is the failure this
+    # hook is for). Never `pushed -> unpushed`.
+    if [ "$prev_sid" = "$sid" ] && [ -n "$prev_subject" ] && [ "$prev_branch" = "$self_branch" ]; then
+      if [ "$prev_push" = "unpushed" ] && [ "$push_state" = "pushed" ]; then
+        arm=1
+      else
+        arm=0
+      fi
+    fi
+
+    # Written on BOTH arms: the record holds the last OBSERVED subject, not the
+    # last NUDGED one. Recording only on the arm would freeze `prev_push` at
+    # `pushed` and silence the next genuine `unpushed -> pushed`.
+    #
+    # ...except on a RESUMED pass, which never arms (below). Writing there would
+    # record a subject as seen while the model was never told about it, so the
+    # next ordinary turn would find its own first nudge already spent.
+    # `2>/dev/null` precedes the write redirect so a failed redirect is not
+    # reported on the hook's real stderr.
+    if [ "$resumed" != "1" ]; then
       tmp="${state_file}.$$"
-      if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" >"$tmp" 2>/dev/null; then
-        mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+      if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" 2>/dev/null >"$tmp"; then
+        if mv -f "$tmp" "$state_file" 2>/dev/null; then
+          persisted=1
+        else
+          rm -f "$tmp" 2>/dev/null || true
+        fi
       else
         rm -f "$tmp" 2>/dev/null || true
       fi
     fi
   fi
+
+  # A resumed pass suppresses the ARM and nothing else -- the warning still
+  # leaves, on the user channel.
+  [ "$resumed" = "1" ] && arm=0
+  # A nudge that cannot be RECORDED cannot be bounded, and an unbounded one is
+  # what this mechanism exists to remove -- so an unresolvable or unwritable git
+  # dir costs the MODEL channel, not the warning.
+  [ "$persisted" = "1" ] || arm=0
+  [ "$arm" = "1" ] || channel="sys"
 fi
 
-MSG="$msg
+# The channel decides WHICH TEXT, not just where it goes. A downgrade means the
+# reader changed from the agent to a person, so the message changes with it.
+if [ "$channel" = "ctx" ]; then
+  out_msg="$msg"
+else
+  out_msg="$msg_user"
+fi
+
+MSG="$out_msg
 $lanes" CHANNEL="$channel" python3 -c '
 import json, os
 

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -27,9 +27,10 @@ set -u
 
 # The Stop event's JSON arrives on stdin, and is consumed here rather than
 # lazily: the payload has to be drained whether or not this hook goes on to use
-# it. Two fields are PARSED out of it further down, once a lane has actually
+# it. Three fields are PARSED out of it further down, once a lane has actually
 # been found -- `stop_hook_active` (has the harness already continued this
-# turn?) and `cwd` (which worktree is the session in?). Same `cat` form every
+# turn?), `cwd` (which worktree is the session in?) and `session_id` (whose
+# nudge record is this?). Same `cat` form every
 # other hook here uses -- Claude Code writes the payload and closes the pipe,
 # so this does not block.
 input=$(cat 2>/dev/null || true)
@@ -141,9 +142,12 @@ if isinstance(flag, str):
     flag = flag.strip().lower() not in ("", "false", "0", "no")
 print("1" if flag else "0")
 print(data.get("cwd") or "")
+print((data.get("session_id") or "").replace("\t", " ").replace("\n", " "))
 ')
 active=$(printf '%s\n' "$parsed" | sed -n 1p)
 hook_cwd=$(printf '%s\n' "$parsed" | sed -n 2p)
+sid=$(printf '%s\n' "$parsed" | sed -n 3p)
+[ -n "$sid" ] || sid="${CLAUDE_CODE_SESSION_ID:-shared}"
 
 # Already nudged once this turn and the model came back to Stop. Saying it again
 # would spin the turn instead of ending it, so stand down.
@@ -184,13 +188,33 @@ $lane_paths
 LANE_ROWS
 
 if [ -n "$self_branch" ]; then
+  # Whether the branch has been PUSHED is NOT used to decide the channel -- the
+  # discriminator go-to-k/cdkd#2391 proposed. It would have gone quiet on a
+  # branch that is pushed with NO PR, which is a real failure and one of the two
+  # this hook exists to catch. It earns its keep in the TEXT instead, where it
+  # names which half of the remaining work is left. No upstream at all reads as
+  # unpushed, which is what it is.
+  unpushed=$(git -C "$session_root" rev-list --count '@{u}..' 2>/dev/null || echo "")
+  if [ -z "$unpushed" ]; then
+    push_state="unpushed"
+    push_line="It has no upstream yet, so nothing has been submitted: push it, open the PR, then merge."
+  elif [ "$unpushed" -gt 0 ]; then
+    push_state="unpushed"
+    push_line="It has ${unpushed} commit(s) not yet pushed, so nothing carrying them has been submitted: push, open or update the PR, then merge."
+  else
+    push_state="pushed"
+    push_line="It is fully pushed, so a PR may already be in flight -- but a pushed branch with NO PR is exactly the failure this catches. Check, and open one if there is none."
+  fi
   msg="WARNING: YOUR OWN lane is unmerged -- a NOT-CLOSEABLE verdict is a TO-DO LIST, not a stopping point.
 This session's worktree is on '$self_branch', which is committed but not on origin/main, so you are not
-done: rebase, run the gates, open the PR, merge. If you are ending the turn with nothing that will
-re-invoke you, the honest label is STOPPED, not WAITING.
+done: rebase, run the gates, open the PR, merge. $push_line
+If you are ending the turn with nothing that will re-invoke you, the honest label is STOPPED, not WAITING.
 One false positive is expected and is cheap to clear: this repo SQUASH-merges, so a merged branch never
 becomes an ancestor of origin/main and keeps reading as ahead. If '$self_branch' is already merged, the
-remaining work is to remove its worktree and delete the branch -- not to open another PR.
+remaining work is to remove its worktree and delete the branch -- not to open another PR. When this tree
+is one you must NOT remove (an outer tool owns it, or you were launched inside it), detach instead:
+'git switch --detach origin/main' clears the lane here, because a worktree with no current branch is not
+a lane at all.
 Every unmerged lane in this checkout:"
   channel="ctx"
 else
@@ -201,6 +225,65 @@ ancestor of origin/main and keeps reading as ahead -- clearing one means removin
 deleting the branch, not opening another PR).
 Lanes:"
   channel="sys"
+fi
+
+# CADENCE. `stop_hook_active` above stops a nudge from SPINNING inside one
+# turn, and that is all it does. Across turns the condition persists, so an
+# unconditional `additionalContext` costs one forced model turn at every single
+# turn-end for as long as the lane exists -- including the two states where
+# there is nothing left to do: the PR is open and CI is running (the session is
+# legitimately WAITING), and the lane was squash-merged with its worktree left
+# behind, which reads as ahead FOREVER. go-to-k/cdkd#2391 measured both, and
+# asks for this fix in all three repos.
+#
+# It is not merely slow. A Stop `additionalContext` travels in the SAME return
+# value as `decision: "block"`, so both spend one budget:
+# `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, 8 consecutive blocks by default, after
+# which the harness overrides the hook and ends the turn anyway. An every-turn
+# nudge therefore burns the cap on a lane that needs nothing.
+#
+# So the model is nudged at most once per distinct SUBJECT, and a repeat of the
+# same subject falls back to `systemMessage`: the user still sees it, the turn
+# ends. The subject is the branch plus whether it is pushed, so:
+#
+#   a lane never nudged in this session -> nudge
+#   the same lane, unpushed -> pushed   -> nudge (a PR should exist now, and a
+#                                          pushed branch with none is the
+#                                          failure this hook is for)
+#   the same lane, same push state      -> quiet
+#   a DIFFERENT lane                    -> nudge (it is a different subject)
+#
+# The commit COUNT is deliberately not in the key: it changes every time the
+# model commits, which would re-arm the nudge on ordinary work and leave the
+# cadence as unbounded as it started.
+#
+# The record lives in the PER-WORKTREE git dir, so lanes never share one and
+# removing a worktree takes its record with it -- the same resolution markgate
+# uses for its marker store. One file rewritten in place, not one per session:
+# a per-session file would accumulate with nobody to clean it up. A concurrent
+# session in the same worktree can therefore clobber it, which costs an EXTRA
+# nudge rather than a missed one, the safe direction.
+if [ "$channel" = "ctx" ]; then
+  git_dir=$(git -C "$session_root" rev-parse --absolute-git-dir 2>/dev/null || true)
+  if [ -n "$git_dir" ]; then
+    state_file="${git_dir}/stop-nudge-lane"
+    subject="${self_branch}:${push_state}"
+    prev_sid=""
+    prev_subject=""
+    if [ -r "$state_file" ]; then
+      IFS="$TAB" read -r prev_sid prev_subject _ <"$state_file" 2>/dev/null || true
+    fi
+    if [ "$prev_sid" = "$sid" ] && [ "$prev_subject" = "$subject" ]; then
+      channel="sys"
+    else
+      tmp="${state_file}.$$"
+      if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" >"$tmp" 2>/dev/null; then
+        mv -f "$tmp" "$state_file" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+      else
+        rm -f "$tmp" 2>/dev/null || true
+      fi
+    fi
+  fi
 fi
 
 MSG="$msg

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -73,8 +73,13 @@ git rev-parse --verify origin/main >/dev/null 2>&1 || exit 0
 # canonicalised and these rows are not.
 lanes=""
 lane_paths=""
+# EVERY worktree, not only the lanes: the no-lane exit below has to be able
+# to clear a cadence record wherever one was left.
+all_worktrees=""
 while IFS= read -r wt; do
   [ -n "$wt" ] || continue
+  all_worktrees="${all_worktrees}${wt}
+"
   br=$(git -C "$wt" branch --show-current 2>/dev/null) || continue
   [ -n "$br" ] || continue
   case "$br" in main | master) continue ;; esac
@@ -86,7 +91,47 @@ while IFS= read -r wt; do
 "
 done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print substr($0, 10)}')
 
-[ -n "$lanes" ] || exit 0
+if [ -z "$lanes" ]; then
+  # The condition has CLEARED: no worktree in this repo is ahead of
+  # `origin/main`. Drop every cadence record, so the NEXT lane starts ARMED.
+  #
+  # Without this the record outlived the condition, and the miss is reachable
+  # by the very remedy this hook prints. Measured: nudge (ctx), repeat (sys),
+  # `git switch --detach origin/main` so nothing is a lane, re-attach and
+  # commit again in the SAME session -> `sys`, never `ctx`. The subject is
+  # `<branch>:<push state>`, so returning to the same branch in the same push
+  # state reproduces the stored subject exactly and the nudge is SWALLOWED --
+  # a MISSED nudge, which this file and `.claude/rules/hooks.md` both call the
+  # unsafe direction. `stop-warn.sh` in the sibling repo has always dropped its
+  # record on the clean-tree exit for exactly this reason.
+  #
+  # EVERY worktree's record is dropped, including other sessions'. "No lane is
+  # ahead" is a REPO-GLOBAL fact, so no session has anything left to be quiet
+  # about; and the cost of being wrong is one EXTRA nudge, which is the trade
+  # the record's own concurrent-clobber comment already accepts.
+  #
+  # The git dir is derived without forking -- a main worktree has `.git` as a
+  # DIRECTORY, a linked one has it as a FILE holding `gitdir: <path>`. This
+  # runs on the silent path, which is most turns, so a `git rev-parse` per
+  # worktree here would be a per-turn cost paid by every clean session.
+  while IFS= read -r wt; do
+    [ -n "$wt" ] || continue
+    wt_git_dir=""
+    if [ -d "$wt/.git" ]; then
+      wt_git_dir="$wt/.git"
+    elif [ -f "$wt/.git" ]; then
+      IFS=' ' read -r _ wt_git_dir <"$wt/.git" 2>/dev/null || wt_git_dir=""
+    fi
+    # git writes an ABSOLUTE `gitdir:`; a relative one would resolve against
+    # this hook's own cwd and the `rm -f` would simply find nothing, which is
+    # the safe direction (an extra nudge, never a missed one).
+    [ -n "$wt_git_dir" ] || continue
+    rm -f "$wt_git_dir/stop-nudge-lane" 2>/dev/null || true
+  done <<CLEAR_RECORDS_EOF
+$all_worktrees
+CLEAR_RECORDS_EOF
+  exit 0
+fi
 
 # Everything past here builds a payload with `python3`. Without it the script
 # would end on a `command not found` and exit 127 -- on every turn, for a hook
@@ -217,6 +262,9 @@ done <<LANE_ROWS
 $lane_paths
 LANE_ROWS
 
+# Declared here, outside the branch: the not-mine arm never composes a user
+# text with a tail, and `set -u` aborts on the substitution below otherwise.
+user_tail=""
 if [ -n "$self_branch" ]; then
   # Whether the branch has been PUSHED is NOT used to decide the channel -- the
   # discriminator go-to-k/cdkd#2391 proposed. It would have gone quiet on a
@@ -259,10 +307,18 @@ Every unmerged lane in this checkout:"
   # emitting one string on both channels reproduces it on three paths instead of
   # one. So this says what is true for a person: which lane, what state it is
   # in, and that the agent has already been told.
+  # The CLOSING CLAUSE is per DOWNGRADE PATH. "The agent has already been told"
+  # is true on exactly ONE of the three: on the RESUMED path this pass may be
+  # the first time the condition holds at all, and on the UNPERSISTABLE-RECORD
+  # path `arm` is forced 0 on EVERY turn, so the agent is never told and the
+  # user was being assured otherwise forever. One string across all three
+  # re-committed, in the user's own voice, the very defect the channel split
+  # exists to fix. The default below is the repeat-subject path; the two
+  # overrides sit at the lines that force `arm=0`.
+  user_tail="The agent has already been told about this lane in this session, so this is a status line for you rather than another nudge."
   msg_user="NOTE: this session's worktree is on '$self_branch', which is committed but not on origin/main.
 $push_line_user
-The agent has already been told about this lane in this session, so this is a status line for you rather
-than another nudge. If '$self_branch' is in fact already merged (this repo SQUASH-merges, so a merged
+__USER_TAIL__ If '$self_branch' is in fact already merged (this repo SQUASH-merges, so a merged
 branch keeps reading as ahead), clearing it means removing the worktree and deleting the branch.
 Every unmerged lane in this checkout:"
   channel="ctx"
@@ -380,10 +436,19 @@ if [ "$channel" = "ctx" ]; then
     if [ "$resumed" != "1" ]; then
       tmp="${state_file}.$$"
       if printf '%s\t%s\t%s\n' "$sid" "$subject" "$(date +%s)" 2>/dev/null >"$tmp"; then
-        if mv -f "$tmp" "$state_file" 2>/dev/null; then
+        # `mv -f <file> <dir>` returns SUCCESS -- it moves the tmp INSIDE the
+        # directory -- so `mv` alone certified a record that was never written.
+        # The readback next turn then found nothing, `persisted` was 1 anyway,
+        # and every later turn re-armed: the UNBOUNDED model channel this whole
+        # cadence exists to remove, arriving through the success check.
+        # Measured: `mv -f <file> <dir>` -> rc 0, file inside the directory.
+        # So the destination is confirmed to be a regular FILE, and the tmp the
+        # non-move left inside it is swept -- otherwise the git dir grows one
+        # orphan per turn.
+        if mv -f "$tmp" "$state_file" 2>/dev/null && [ -f "$state_file" ]; then
           persisted=1
         else
-          rm -f "$tmp" 2>/dev/null || true
+          rm -f "$tmp" "$state_file/${tmp##*/}" 2>/dev/null || true
         fi
       else
         rm -f "$tmp" 2>/dev/null || true
@@ -393,16 +458,30 @@ if [ "$channel" = "ctx" ]; then
 
   # A resumed pass suppresses the ARM and nothing else -- the warning still
   # leaves, on the user channel.
-  [ "$resumed" = "1" ] && arm=0
   # A nudge that cannot be RECORDED cannot be bounded, and an unbounded one is
   # what this mechanism exists to remove -- so an unresolvable or unwritable git
   # dir costs the MODEL channel, not the warning.
-  [ "$persisted" = "1" ] || arm=0
+  if [ "$persisted" != "1" ]; then
+    arm=0
+    user_tail="The agent has NOT been told: this hook could not record the nudge here (unresolvable or unwritable git dir), so it stays on this channel every turn."
+  fi
+  # LAST, so it wins the wording: a resumed pass never writes the record either,
+  # so `persisted` is 0 on every one of them and the clause above would
+  # otherwise mislabel every continuation as an unwritable git dir.
+  if [ "$resumed" = "1" ]; then
+    arm=0
+    user_tail="The turn has already been continued once, so the agent is not being interrupted again on this pass."
+  fi
   [ "$arm" = "1" ] || channel="sys"
 fi
 
 # The channel decides WHICH TEXT, not just where it goes. A downgrade means the
 # reader changed from the agent to a person, so the message changes with it.
+# The tail is substituted at EMIT time, not built into `msg_user` above: the
+# downgrade paths that decide which tail is true are evaluated after the text is
+# composed, so an already-expanded string could not be corrected.
+msg_user="${msg_user/__USER_TAIL__/$user_tail}"
+
 if [ "$channel" = "ctx" ]; then
   out_msg="$msg"
 else

--- a/.claude/hooks/stop-unmerged-lane-warn.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.sh
@@ -152,7 +152,17 @@ print(data.get("cwd") or "")
 # against `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`. Measured with a payload carrying no
 # `session_id`: a plain value gave `ctx, sys, sys` while a leading tab, an
 # embedded tab and an embedded newline each gave `ctx, ctx, ctx`.
-sid = data.get("session_id") or os.environ.get("ENV_SID") or "shared"
+# The TYPE is checked, not just the truthiness. `session_id` arrives from the
+# harness as JSON, so nothing stops it being a number or a list, and `.replace`
+# on one raises -- which killed this block before it printed line 3. The shell
+# below still reached the right answer (an empty line 3 falls back to `shared`),
+# so the verdict was never wrong; what it printed was a Python TRACEBACK on the
+# stderr of this hook, on EVERY turn. A Stop hook that spews a traceback each time the
+# turn ends is its own defect, whatever the verdict.
+sid = data.get("session_id")
+if not isinstance(sid, str):
+    sid = ""
+sid = sid or os.environ.get("ENV_SID") or "shared"
 sid = sid.replace("\t", " ").replace("\n", " ").replace("\r", " ")
 print(sid or "shared")
 ')

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -33,7 +33,25 @@ check() {
 # The hook now READS the Stop event's JSON from stdin, so every invocation has
 # to feed it one. Left unfed, `cat` inherits this script's stdin and a case can
 # hang instead of failing -- and a Stop hook that hangs never lets a turn end.
+# Every call starts from a CLEAN nudge record unless a case opts out with
+# `run_hook_keep`. Since go-to-k/cdkd#2391 the hook nudges the model at most
+# once per subject per session and downgrades a repeat to the user channel, so
+# without this reset the cases below would each depend on how many earlier ones
+# happened to share their branch -- and the cases that assert `ctx` would pass
+# or fail on their POSITION in the file rather than on the hook's behaviour.
+# Measured on the port: with the reset removed, six of them flip to `sys`.
+clear_nudge_records() {
+  find "$SANDBOX" -name 'stop-nudge-lane' -type f -delete 2>/dev/null || true
+}
+
 run_hook() {
+  clear_nudge_records
+  run_hook_keep "$@"
+}
+
+# The same call WITHOUT the reset -- for the cadence cases, which are precisely
+# about what a second invocation does.
+run_hook_keep() {
   local dir="$1" hook="$2" stdin="${3-}"
   [ "$#" -ge 3 ] || stdin='{}'
   printf '%s' "$stdin" | (cd "$dir" && bash "$hook")
@@ -397,6 +415,106 @@ check "cwd outside any repo stays user-facing" "sys" "$(channel_of "$out")"
 check "...and still exits 0" "0" "$(rc_of)"
 out=$(run_hook "$REPO" "$RUN" "{\"cwd\": \"$REPO\"}")
 check "cwd in the main tree stays user-facing" "sys" "$(channel_of "$out")"
+
+# --- CADENCE (go-to-k/cdkd#2391, ported here). `stop_hook_active` stops a nudge
+# spinning INSIDE one turn; nothing stopped it firing again at every later
+# turn-end for as long as the lane existed. That is not merely slow: a Stop
+# `additionalContext` spends the same `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` budget
+# as a `decision: "block"`, 8 consecutive by default, so an every-turn nudge
+# burns the cap on a lane that needs nothing. Every case here fails against the
+# pre-port hook, which had no record to consult and answered `ctx`
+# unconditionally.
+#
+# These build their OWN lanes rather than reusing the ones above. Borrowing one
+# risks a worktree an earlier case has removed -- so the case would measure the
+# not-my-lane branch and pass or fail on where it sits in the file, exactly the
+# order-dependence `clear_nudge_records` exists to remove. They are also the
+# only cases that must NOT reset the record, so they call `run_hook_keep`.
+git -C "$REPO" worktree add -q "$REPO/wt-cad-a" -b feat/cad-a HEAD
+git -C "$REPO/wt-cad-a" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+git -C "$REPO" worktree add -q "$REPO/wt-cad-b" -b feat/cad-b HEAD
+git -C "$REPO/wt-cad-b" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+
+A1="{\"cwd\": \"$REPO/wt-cad-a\", \"session_id\": \"sess-one\"}"
+A2="{\"cwd\": \"$REPO/wt-cad-a\", \"session_id\": \"sess-two\"}"
+B1="{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-one\"}"
+
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "first sight of a lane nudges the model" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "the same lane again does NOT force a second turn" "sys" "$(channel_of "$out")"
+# The downgrade must not be a MUTE. Choosing `systemMessage` over silence is the
+# whole point -- the human keeps seeing the lane -- and a hook that simply
+# exited would also read as "not ctx" and pass the line above.
+if printf '%s' "$out" | grep -q 'feat/cad-a'; then
+  pass=$((pass + 1)); printf 'OK   ...but the user is still told which lane\n'
+else
+  fail=$((fail + 1)); fail_log+="FAIL the downgraded warning still names the lane\n"; printf 'FAIL the downgraded warning still names the lane\n'
+fi
+
+# A different LANE is a different subject, so it re-arms. Without this the first
+# lane of a session would silence every later one -- strictly worse than the
+# bounded cost being paid here. The two lanes keep SEPARATE records, since each
+# lives in its own worktree git dir, so this cannot be satisfied by a single
+# shared slot.
+out=$(run_hook_keep "$REPO" "$RUN" "$B1")
+check "a different lane in the same session nudges again" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...and the first lane stays quiet, records being per-worktree" "sys" "$(channel_of "$out")"
+
+# A different SESSION gets its own one nudge. It also overwrites the record --
+# one file per worktree, not one per session, so nothing accumulates in the git
+# dir with no one to clean it up. The cost is that the earlier session re-arms
+# once, which is an EXTRA nudge rather than a missed one; that direction is the
+# reason the trade is acceptable, so it is pinned rather than left to be
+# rediscovered as a bug.
+out=$(run_hook_keep "$REPO" "$RUN" "$A2")
+check "a DIFFERENT session gets its own one nudge" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...and a concurrent session's write costs an extra nudge, not a lost one" "ctx" "$(channel_of "$out")"
+
+# --- PUSH STATE. It is in the SUBJECT (so unpushed -> pushed re-arms exactly
+# once) and in the TEXT (so the message names which half of the work is left) --
+# but NOT in the channel decision. go-to-k/cdkd#2391 proposed making it the
+# discriminator; that would go quiet on a branch pushed with NO PR, which is a
+# real failure and one of the two this hook exists to catch.
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "an unpushed lane says so in the text" "yes" "$(printf '%s' "$out" | grep -qF 'no upstream yet' && echo yes || echo no)"
+
+# `remote.origin.fetch` is load-bearing, not boilerplate: without the refspec
+# git refuses `@{u}` with "upstream branch ... not stored as a remote-tracking
+# branch", the hook reads that as unpushed, and the two cases below pass or fail
+# for a reason that has nothing to do with the cadence.
+git -C "$REPO" config remote.origin.url "$REPO"
+git -C "$REPO" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+git -C "$REPO" update-ref "refs/remotes/origin/feat/cad-a" "$(git -C "$REPO" rev-parse feat/cad-a)"
+git -C "$REPO" config "branch.feat/cad-a.remote" origin
+git -C "$REPO" config "branch.feat/cad-a.merge" refs/heads/feat/cad-a
+check "the fixture really did give the lane an upstream" "0" "$(git -C "$REPO/wt-cad-a" rev-list --count '@{u}..' 2>/dev/null || echo MISSING)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "pushing the lane re-arms the nudge once" "ctx" "$(channel_of "$out")"
+check "...and the text switches to the pushed-but-maybe-no-PR wording" "yes" "$(printf '%s' "$out" | grep -qF 'pushed branch with NO PR' && echo yes || echo no)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...and a pushed lane stops nagging again after that one" "sys" "$(channel_of "$out")"
+
+# The continuation flag outranks the cadence: the harness has already resumed
+# once inside this turn, so even a freshly-armed subject must stay silent rather
+# than swap channels and print the same wall of text twice.
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\", \"stop_hook_active\": true}")
+check "a resumed turn stays silent even when armed" "" "$out"
+
+# The detach wording, which is the other half of the go-to-k/cdkd#2391 port: a
+# tree an outer tool owns must not be removed, and a worktree with no current
+# branch is not a lane, so `git switch --detach origin/main` clears it.
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "$B1")
+check "the own-lane message names the detach escape" "yes" "$(printf '%s' "$out" | grep -qF 'git switch --detach origin/main' && echo yes || echo no)"
+
+git -C "$REPO" worktree remove --force "$REPO/wt-cad-a"
+git -C "$REPO" worktree remove --force "$REPO/wt-cad-b"
+clear_nudge_records
 
 printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -49,6 +49,16 @@ run_hook() {
   run_hook_keep "$@"
 }
 
+# The same call with `CLAUDE_CODE_SESSION_ID` set, for the payloads that carry
+# NO `session_id` -- the only shape that reaches the env fallback. Every other
+# case here sends an explicit id, which is exactly why that line had no
+# coverage.
+run_hook_sid() {
+  local envsid="$1" dir="$2" hook="$3" stdin="$4"
+  printf '%s' "$stdin" | (cd "$dir" && CLAUDE_CODE_SESSION_ID="$envsid" bash "$hook")
+  printf '%s' "$?" > "$RC_FILE"
+}
+
 # The same call WITHOUT the reset -- for the cadence cases, which are precisely
 # about what a second invocation does.
 run_hook_keep() {
@@ -80,6 +90,20 @@ if not raw.strip():
 d = json.loads(raw)
 msg = d.get("hookSpecificOutput", {}).get("additionalContext") or d.get("systemMessage") or ""
 print(sum(1 for line in msg.splitlines() if line.startswith("  ")))
+'
+}
+
+# `msg_of <output>` -> the message text, whichever channel carried it. Used by
+# the cases that compare the two channels' WORDING; `channel_of` answers where
+# the payload went, and this answers what it said.
+msg_of() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+raw = sys.stdin.read()
+if not raw.strip():
+    raise SystemExit
+d = json.loads(raw)
+print(d.get("hookSpecificOutput", {}).get("additionalContext") or d.get("systemMessage") or "")
 '
 }
 
@@ -307,16 +331,23 @@ ln -s "$REPO/wt-two" "$SANDBOX/wt-two-link"
 out=$(run_hook "$SANDBOX/wt-two-link" "$SANDBOX/wt-two-link/.claude/hooks/$(basename "$HOOK")")
 check "a symlinked lane path is still the session's own lane" "ctx" "$(channel_of "$out")"
 
-# --- SILENT on the continuation pass. `additionalContext` CONTINUES the turn,
+# --- NO ARM on the continuation pass. `additionalContext` CONTINUES the turn,
 # so a hook that keeps emitting it turns one nudge into a spin: the model is
 # pushed back to work, reaches Stop again with the same unmerged lane, and is
 # pushed again. The harness marks that second pass with `stop_hook_active`, and
 # standing down on it is what bounds this hook to a single forced continuation.
 # Without this case the loop is unfenced -- every case above passes `{}`, where
-# the flag is absent, so the branch could be deleted and the suite stay green. ---
+# the flag is absent, so the branch could be deleted and the suite stay green.
+#
+# This case used to assert total SILENCE, and that was wrong: a lane can be
+# COMMITTED during the continuation, in which case this pass is the FIRST time
+# the condition holds at all and the user would never hear about it. Only the
+# ARM is suppressed now -- a bare `systemMessage` does not continue a turn, so
+# it cannot spin. ---
 out=$(run_hook "$REPO/wt-two" "$REPO/wt-two/.claude/hooks/$(basename "$HOOK")" '{"stop_hook_active": true}')
-check "silent once the harness reports a continuation already happened" "" "$out"
-check "...standing down is exit 0, not a crash" "0" "$(rc_of)"
+check "a continuation does not re-arm the model channel" "sys" "$(channel_of "$out")"
+check "...but the user is still told, in case the lane appeared mid-turn" "2" "$(lanes_in "$out")"
+check "...and standing down is exit 0, not a crash" "0" "$(rc_of)"
 
 # --- ...and NOT silent when the flag is present but false, which is the shape
 # every ordinary turn actually sends. A truthiness check that reads the KEY
@@ -380,12 +411,20 @@ done
 
 # --- `stop_hook_active` as the STRING "false" must not silence the hook. Python
 # treats any non-empty string as truthy, so the naive read makes this the same
-# as `true` -- and since a hook that goes quiet still exits 0, the failure looks
-# exactly like "no lanes" forever. The boolean cases above cannot see it. ---
-out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "false"}')
-check "the string \"false\" does not count as a continuation" "2" "$(lanes_in "$out")"
-out=$(run_hook "$REPO" "$RUN" '{"stop_hook_active": "true"}')
-check "the string \"true\" does count as one" "" "$out"
+# as `true` -- and the boolean cases above cannot see it.
+#
+# Read from a LANE, not from the main tree. The flag now suppresses the ARM
+# rather than the whole payload, so its effect is a channel change -- and the
+# main tree already answers `sys` for the unrelated reason that none of the
+# lanes are its own. Running these there would compare `sys` against `sys` and
+# pass whatever the flag did. ---
+WT2="$REPO/wt-two/.claude/hooks/$(basename "$HOOK")"
+out=$(run_hook "$REPO/wt-two" "$WT2" '{"stop_hook_active": "false"}')
+check "the string \"false\" does not count as a continuation" "ctx" "$(channel_of "$out")"
+out=$(run_hook "$REPO/wt-two" "$WT2" '{"stop_hook_active": "true"}')
+check "the string \"true\" does count as one" "sys" "$(channel_of "$out")"
+check "...and even then the lane is named for the user" "yes" \
+  "$(printf '%s' "$out" | grep -qF 'feat/two' && echo yes || echo no)"
 
 # --- Malformed / absent stdin must not take the warning down with it. The hook
 # reads stdin only to find one flag; a harness that sends nothing parseable is
@@ -498,12 +537,146 @@ check "...and the text switches to the pushed-but-maybe-no-PR wording" "yes" "$(
 out=$(run_hook_keep "$REPO" "$RUN" "$A1")
 check "...and a pushed lane stops nagging again after that one" "sys" "$(channel_of "$out")"
 
+# --- The predicate is DIRECTED. `pushed -> unpushed` is what an ordinary COMMIT
+# looks like, so an undirected `prev != current` re-armed on every commit AND on
+# every push: measured on one lane as `commit ctx, repeat sys, push ctx, repeat
+# sys, commit ctx, push ctx, ...`, two forced continuations per cycle, forever.
+# `feat/cad-a` is pushed and quiet at this point, so committing to it is exactly
+# that transition. ---
+git -C "$REPO/wt-cad-a" -c user.email=t@t -c user.name=t commit -q --allow-empty -m more
+check "the fixture really did make the lane unpushed again" "1" "$(git -C "$REPO/wt-cad-a" rev-list --count '@{u}..' 2>/dev/null || echo MISSING)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "an ordinary COMMIT (pushed -> unpushed) does NOT re-arm" "sys" "$(channel_of "$out")"
+# ...and the MIDDLE push arm: an upstream exists, N commits are unpushed. The
+# fixture above only ever produced the two ENDS (no upstream at all, and fully
+# pushed), so the branch naming the count had no case of its own.
+check "...and the text names the unpushed COUNT, not the no-upstream wording" "yes" \
+  "$(printf '%s' "$out" | grep -qF '1 commit(s) not yet pushed' && echo yes || echo no)"
+# Pushing it again is the ONE transition that re-arms, and exactly once.
+git -C "$REPO" update-ref "refs/remotes/origin/feat/cad-a" "$(git -C "$REPO" rev-parse feat/cad-a)"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "unpushed -> pushed re-arms" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...exactly once" "sys" "$(channel_of "$out")"
+
+# --- A MALFORMED record falls to ARM, which is the safe direction: an extra
+# nudge, never a missed one -- the same direction the concurrent-clobber trade
+# above already accepts. Without the shape check the record is trusted verbatim,
+# so one junk write in the git dir silences the lane for the rest of the
+# session. Every spelling below carries the RIGHT session and the RIGHT branch,
+# so nothing but the shape check can reject it.
+#
+# An EMPTY subject is not among them because it is not representable: bash's
+# `read` with `IFS=<tab>` treats tab as IFS WHITESPACE, so a run of tabs
+# delimits as one and `sid\t\tts` arrives as the TWO-field record below rather
+# than as three fields with an empty middle. Measured, not assumed -- the first
+# draft asserted an empty subject and was passing through the field-count guard
+# under a name that described a path it never took.
+CAD_A_REC="$(git -C "$REPO/wt-cad-a" rev-parse --absolute-git-dir)/stop-nudge-lane"
+printf 'sess-one\tfeat/cad-a:pushed\n' > "$CAD_A_REC"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "a TRUNCATED two-field record arms" "ctx" "$(channel_of "$out")"
+printf 'sess-one\tfeat/cad-a:pushed\t%s\textra\n' "$(date +%s)" > "$CAD_A_REC"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "a record with a FOURTH field arms" "ctx" "$(channel_of "$out")"
+printf 'sess-one\tfeat/cad-a:pushed\tnot-a-number\n' > "$CAD_A_REC"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "a record with a NON-NUMERIC timestamp arms" "ctx" "$(channel_of "$out")"
+# The control: the well-formed record the hook itself just wrote is trusted, so
+# the three above are not passing merely because every record arms.
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "...while the WELL-FORMED record it wrote is still trusted" "sys" "$(channel_of "$out")"
+
+# --- A nudge that cannot be RECORDED cannot be BOUNDED, and an unbounded nudge
+# is what the cadence exists to remove -- so an unwritable git dir costs the
+# MODEL channel, not the warning. Asserted in both halves, because a hook that
+# simply exited would also read as "not ctx". ---
+CAD_A_GITDIR="$(git -C "$REPO/wt-cad-a" rev-parse --absolute-git-dir)"
+clear_nudge_records
+chmod a-w "$CAD_A_GITDIR"
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+chmod u+w "$CAD_A_GITDIR"
+check "an unwritable git dir downgrades to the user channel" "sys" "$(channel_of "$out")"
+check "...but still WARNS about the lane" "yes" \
+  "$(printf '%s' "$out" | grep -qF 'feat/cad-a' && echo yes || echo no)"
+
 # The continuation flag outranks the cadence: the harness has already resumed
-# once inside this turn, so even a freshly-armed subject must stay silent rather
-# than swap channels and print the same wall of text twice.
+# once inside this turn, so even a freshly-armed subject must not force a second
+# continuation. It used to go fully SILENT, and that lost the case where the
+# lane is COMMITTED during the continuation -- that pass is then the first time
+# the condition holds at all, and the user heard nothing. Only the ARM is
+# suppressed now; a bare `systemMessage` does not continue a turn.
 clear_nudge_records
 out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\", \"stop_hook_active\": true}")
-check "a resumed turn stays silent even when armed" "" "$out"
+check "a resumed turn does not arm, even with a fresh subject" "sys" "$(channel_of "$out")"
+check "...and the user is told about it on that pass" "yes" \
+  "$(printf '%s' "$out" | grep -qF 'feat/cad-b' && echo yes || echo no)"
+# ...and it writes NO record. A resumed pass never arms, so recording its
+# subject as SEEN would spend the model's one nudge on a turn the model was
+# never told about -- the next ordinary turn would find the subject already
+# used and downgrade its own first nudge.
+CAD_B_REC="$(git -C "$REPO/wt-cad-b" rev-parse --absolute-git-dir)/stop-nudge-lane"
+check "a resumed pass writes no record" "no" "$([ -e "$CAD_B_REC" ] && echo yes || echo no)"
+out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-three\"}")
+check "...so the next ordinary turn still gets its one nudge" "ctx" "$(channel_of "$out")"
+
+# The same property with an EXISTING record, which is the shape that actually
+# loses a nudge: the subject CHANGES during the continuation (the lane is
+# committed inside it), so a write there records a subject as seen that the
+# model was never told about. Asserting the record is UNCHANGED, not merely
+# absent -- a hook that stopped recording altogether would satisfy "absent".
+printf 'sess-four\tfeat/other:unpushed\t%s\n' "$(date +%s)" > "$CAD_B_REC"
+out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-four\", \"stop_hook_active\": true}")
+check "a resumed pass with a NEW subject stays off the model channel" "sys" "$(channel_of "$out")"
+check "...and leaves the existing record untouched" "feat/other:unpushed" \
+  "$(cut -f2 <"$CAD_B_REC")"
+out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": \"sess-four\"}")
+check "...so the unconsumed nudge survives to the next ordinary turn" "ctx" "$(channel_of "$out")"
+
+# --- The SESSION ID's env fallback. Every case above sends an explicit
+# `session_id`, so the `CLAUDE_CODE_SESSION_ID` path had zero coverage -- and it
+# used to sit in SHELL, after the normalisation that folds tabs and newlines out
+# of the payload's copy. A tab in the id adds a FIELD to the record and a
+# newline ends its line early; either way the read-back shifts, `prev_sid` never
+# matches the value the hook itself just wrote, and the cadence stops bounding:
+# `additionalContext` every turn, against `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`.
+#
+# Each probe asserts the SECOND turn downgrades, not merely that the first
+# fires. A case that only checked turn 1 passes against the broken hook, since
+# the failure is that it never STOPS firing.
+SID_PAYLOAD="{\"cwd\": \"$REPO/wt-cad-b\"}"
+sid_cadence() {
+  local envsid="$1" first second
+  clear_nudge_records
+  first=$(run_hook_sid "$envsid" "$REPO" "$RUN" "$SID_PAYLOAD")
+  second=$(run_hook_sid "$envsid" "$REPO" "$RUN" "$SID_PAYLOAD")
+  printf '%s,%s' "$(channel_of "$first")" "$(channel_of "$second")"
+}
+check "a plain env session id bounds the cadence" "ctx,sys" "$(sid_cadence 's1')"
+check "a LEADING TAB in the env session id still bounds it" "ctx,sys" "$(sid_cadence "$(printf '\tabc')")"
+check "an EMBEDDED TAB in the env session id still bounds it" "ctx,sys" "$(sid_cadence "$(printf 'a\tb')")"
+check "an EMBEDDED NEWLINE in the env session id still bounds it" "ctx,sys" "$(sid_cadence "$(printf 'a\nb')")"
+check "an UNSET env session id still bounds it" "ctx,sys" "$(sid_cadence '')"
+
+# --- The two channels carry DIFFERENT TEXT. A downgrade changes the READER
+# from the agent to a person, so sending the model's wording ("you are not done:
+# rebase, run the gates, open the PR") down `systemMessage` addresses a human as
+# the agent -- which is go-to-k/cdkd#2389's defect, the one this hook's channel
+# split exists to fix, reappearing on the three downgrade paths. Asserted as a
+# difference AND on the specific phrase, so collapsing the two back into one
+# string fails here rather than in a review. ---
+clear_nudge_records
+ctx_out=$(run_hook_keep "$REPO" "$RUN" "$B1")
+sys_out=$(run_hook_keep "$REPO" "$RUN" "$B1")
+check "the two channels really are ctx then sys" "ctx,sys" "$(channel_of "$ctx_out"),$(channel_of "$sys_out")"
+check "...and they do NOT carry the same text" "different" \
+  "$([ "$(msg_of "$ctx_out")" = "$(msg_of "$sys_out")" ] && echo same || echo different)"
+check "...the model text tells the AGENT what to do" "yes" \
+  "$(printf '%s' "$(msg_of "$ctx_out")" | grep -qF 'rebase, run the gates, open the PR' && echo yes || echo no)"
+check "...and the user text does not" "no" \
+  "$(printf '%s' "$(msg_of "$sys_out")" | grep -qF 'rebase, run the gates, open the PR' && echo yes || echo no)"
+check "...while still naming the lane for the user" "yes" \
+  "$(printf '%s' "$(msg_of "$sys_out")" | grep -qF 'feat/cad-b' && echo yes || echo no)"
 
 # The detach wording, which is the other half of the go-to-k/cdkd#2391 port: a
 # tree an outer tool owns must not be removed, and a worktree with no current

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -59,6 +59,16 @@ run_hook_sid() {
   printf '%s' "$?" > "$RC_FILE"
 }
 
+# The same call capturing STDERR alone. Every other helper here discards it, so
+# a hook that prints a traceback on every turn reads as perfectly healthy: the
+# verdict on stdout is what they assert and the verdict can be right while the
+# hook is spewing.
+run_hook_stderr() {
+  local dir="$1" hook="$2" stdin="$3"
+  clear_nudge_records
+  printf '%s' "$stdin" | (cd "$dir" && bash "$hook" 2>&1 >/dev/null)
+}
+
 # The same call WITHOUT the reset -- for the cadence cases, which are precisely
 # about what a second invocation does.
 run_hook_keep() {
@@ -657,6 +667,21 @@ check "a LEADING TAB in the env session id still bounds it" "ctx,sys" "$(sid_cad
 check "an EMBEDDED TAB in the env session id still bounds it" "ctx,sys" "$(sid_cadence "$(printf 'a\tb')")"
 check "an EMBEDDED NEWLINE in the env session id still bounds it" "ctx,sys" "$(sid_cadence "$(printf 'a\nb')")"
 check "an UNSET env session id still bounds it" "ctx,sys" "$(sid_cadence '')"
+
+# `session_id` arrives as JSON, so nothing stops the harness sending a number or
+# a list where a string is expected. `.replace` on one RAISES, and the block
+# died before printing its third line -- the shell fell back to `shared`, so the
+# VERDICT stayed right while a Python traceback went to this hook stderr on
+# every single turn. Asserted on stderr, because no case that reads stdout can
+# see it: the two below both pass against the unguarded hook.
+NONSTR_SID="{\"cwd\": \"$REPO/wt-cad-b\", \"session_id\": 12345}"
+check "a NON-STRING session id prints nothing on stderr" "" \
+  "$(run_hook_stderr "$REPO" "$RUN" "$NONSTR_SID")"
+# ...and the control that keeps it honest: a hook that exited before doing
+# anything would also print nothing, so the same payload must still warn.
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "$NONSTR_SID")
+check "...and still warns about the lane" "ctx" "$(channel_of "$out")"
 
 # --- The two channels carry DIFFERENT TEXT. A downgrade changes the READER
 # from the agent to a person, so sending the model's wording ("you are not done:

--- a/.claude/hooks/stop-unmerged-lane-warn.test.sh
+++ b/.claude/hooks/stop-unmerged-lane-warn.test.sh
@@ -149,6 +149,39 @@ print("BOTH" if ctx and sysm else "ctx" if ctx else "sys" if sysm else "none")
 # defect it was written for (a skip keyed on the hook's own checkout) could be
 # reintroduced and the suite stayed 10/0.
 SANDBOX="$(cd "$(mktemp -d)" && pwd -P)"
+# bash 3.2 is NOT exercised on the HOOK by running THIS FILE under /bin/bash.
+# The hook's shebang is `#!/usr/bin/env bash`, which resolves through PATH and
+# finds whatever bash is first there -- Homebrew 5.x on a dev Mac -- so
+# `/bin/bash <suite>` measured the SUITE under 3.2 and the SUBJECT under 5.x.
+# `HOOK_BASH` puts a `bash` shim first on PATH so the shebang, the explicit
+# `bash "$HOOK"` calls, and any `bash` the hook itself spawns all follow the
+# harness. Proved load-bearing rather than assumed: injecting a `;;&` (a bash
+# 4+ case terminator) into the hook reddens cases only WITH the shim in place.
+# DEFAULTED to `/bin/bash` (3.2 on macOS) rather than left opt-in, matching
+# `gate-command-recognition.test.sh` in this repo: nothing sets `HOOK_BASH` in
+# `vp run test:hooks`, so an opt-in fence measures 5.x in CI forever and the 3.2
+# tally is only ever taken by hand. Override with
+# `HOOK_BASH=/opt/homebrew/bin/bash bash <this file>` to take the 5.x one.
+HOOK_BASH="${HOOK_BASH:-/bin/bash}"
+[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+if [ -n "${HOOK_BASH:-}" ]; then
+  # Resolved to an ABSOLUTE path first: `HOOK_BASH=bash` would otherwise make
+  # `ln -sf bash <shim>/bash` a symlink pointing at ITSELF, and every hook
+  # invocation would die on ELOOP -- a suite-wide red with a cause nowhere near
+  # the hook.
+  HOOK_BASH_BIN="$(command -v "$HOOK_BASH" 2>/dev/null || printf '%s' "$HOOK_BASH")"
+  case "$HOOK_BASH_BIN" in /*) ;; *) HOOK_BASH_BIN="$PWD/$HOOK_BASH_BIN" ;; esac
+  HOOK_BASH_SHIM="$SANDBOX/bash32-shim"
+  mkdir -p "$HOOK_BASH_SHIM"
+  ln -sf "$HOOK_BASH_BIN" "$HOOK_BASH_SHIM/bash"
+  PATH="$HOOK_BASH_SHIM:$PATH"
+  export PATH
+fi
+# PRINTED, not merely honoured: a suite that does not say which interpreter it
+# measured cannot be read as evidence about either one.
+printf 'hook interpreter: %s (bash %s)\n' \
+  "$(command -v bash)" "$(bash -c 'echo "$BASH_VERSION"')"
+
 trap 'rm -rf "$SANDBOX"' EXIT
 
 RC_FILE="$SANDBOX/rc"
@@ -683,6 +716,127 @@ clear_nudge_records
 out=$(run_hook_keep "$REPO" "$RUN" "$NONSTR_SID")
 check "...and still warns about the lane" "ctx" "$(channel_of "$out")"
 
+# --- The record path is a DIRECTORY. `mv -f <file> <dir>` returns SUCCESS -- it
+# moves the tmp INSIDE the directory -- so the write was certified, the readback
+# next turn found nothing, and EVERY turn re-armed `additionalContext` against
+# `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP` while the git dir grew one orphan tmp per
+# turn. That is the unbounded cadence this mechanism exists to remove, arriving
+# through the success check -- the one failure `mv`'s own exit code cannot
+# report, which is why the unwritable-git-dir case above does not cover it.
+# Measured with `mv` alone: `ctx ctx ctx`.
+CAD_A_REC="$(git -C "$REPO/wt-cad-a" rev-parse --absolute-git-dir)/stop-nudge-lane"
+clear_nudge_records
+rm -f "$CAD_A_REC"
+mkdir -p "$CAD_A_REC"
+dir_channels=""
+for _ in 1 2 3; do
+  out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+  dir_channels="${dir_channels}$(channel_of "$out") "
+done
+dir_orphans=$(find "$CAD_A_REC" -type f 2>/dev/null | wc -l | tr -d ' ')
+rm -f "$CAD_A_REC"/* 2>/dev/null || true
+rmdir "$CAD_A_REC" 2>/dev/null || true
+check "a record path that is a DIRECTORY never arms the model channel" "sys sys sys " "$dir_channels"
+check "...and leaves no orphan tmp behind in the git dir" "0" "$dir_orphans"
+
+# --- A failed record write must say nothing on the hook's REAL stderr. The
+# redirect is `2>/dev/null >"$tmp"`, in that order, and the order is the point:
+# redirections apply left to right, and the open that FAILS is the fd-1 open of
+# `$tmp`. Written `>"$tmp" 2>/dev/null` that open happens while fd 2 is still
+# the real stderr, so "Permission denied" is printed there from an ADVISORY
+# hook, on every turn. `run_hook_stderr` exists here for the non-string-sid case
+# and was never pointed at this one.
+clear_nudge_records
+chmod a-w "$CAD_A_GITDIR"
+stderr_on_ro=$(run_hook_stderr "$REPO" "$RUN" "$A1")
+chmod u+w "$CAD_A_GITDIR"
+check "an unwritable git dir prints nothing on the hook's real stderr" "" "$stderr_on_ro"
+
+# --- The env fallback's SOURCE, keyed on the record rather than on the reset.
+# `sid_cadence` clears the record before each value, so it fences the tab /
+# newline FOLD and not the `CLAUDE_CODE_SESSION_ID` line it names: with that
+# source removed every run reads `shared`, and a cleared record makes each
+# value's FIRST run arm regardless. Driving A, B, A through ONE record is what
+# separates them -- three distinct sessions each get their own nudge, while a
+# hook that cannot tell them apart swallows the second and the third.
+clear_nudge_records
+env_src=""
+for esid in 'src-a' 'src-b' 'src-a'; do
+  out=$(run_hook_sid "$esid" "$REPO" "$RUN" "$SID_PAYLOAD")
+  env_src="${env_src}$(channel_of "$out") "
+done
+check "each env-supplied session gets its own nudge" "ctx ctx ctx " "$env_src"
+
+# --- The user text's CLOSING CLAUSE is per downgrade path. "The agent has
+# already been told" is true on exactly ONE of the three: on the RESUMED path
+# this pass may be the first time the condition holds at all, and on the
+# UNPERSISTABLE-RECORD path `arm` is forced 0 every turn, so the agent is never
+# told and the user was assured otherwise forever. One string across all three
+# re-committed, in the user's own voice, the defect the channel split exists to
+# fix. The sibling `stop-cleanup-warn.sh` in the other repo omits the claim
+# entirely; this one states the truth per path instead.
+TOLD='already been told'
+# 1. repeat subject -- the one path where the claim is TRUE.
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+out=$(run_hook_keep "$REPO" "$RUN" "$A1")
+check "the repeat-subject downgrade DOES say the agent was told" "yes" \
+  "$(printf '%s' "$out" | grep -qF "$TOLD" && echo yes || echo no)"
+# 2. resumed pass -- the agent was not interrupted on this pass.
+clear_nudge_records
+out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-a\", \"session_id\": \"sess-voice-res\", \"stop_hook_active\": true}")
+check "the RESUMED downgrade does not claim the agent was told" "no" \
+  "$(printf '%s' "$out" | grep -qF "$TOLD" && echo yes || echo no)"
+check "...and says why it is on this channel instead" "yes" \
+  "$(printf '%s' "$out" | grep -qF 'continued once' && echo yes || echo no)"
+# 3. unpersistable record -- the agent is NEVER told on this path.
+clear_nudge_records
+chmod a-w "$CAD_A_GITDIR"
+out=$(run_hook_keep "$REPO" "$RUN" "{\"cwd\": \"$REPO/wt-cad-a\", \"session_id\": \"sess-voice-nop\"}")
+chmod u+w "$CAD_A_GITDIR"
+check "the UNPERSISTABLE downgrade does not claim the agent was told" "no" \
+  "$(printf '%s' "$out" | grep -qF "$TOLD" && echo yes || echo no)"
+check "...and says the nudge could not be recorded" "yes" \
+  "$(printf '%s' "$out" | grep -qF 'could not record' && echo yes || echo no)"
+
+
+# --- The cadence record must not OUTLIVE the condition. When no worktree is
+# ahead of `origin/main` any more, the stored subject is stale, and returning
+# to the same branch in the same push state reproduces it exactly -- so the
+# next genuine first-sighting is DOWNGRADED. That is a MISSED nudge, the unsafe
+# direction. Reachable through the very remedy this hook prints: nudge, repeat,
+# `git switch --detach origin/main`, re-attach, commit. Its sibling
+# `stop-warn.sh` has always dropped its record on the clean-tree exit.
+#
+# A SEPARATE sandbox repo, because the property is repo-GLOBAL ("no lane
+# anywhere is ahead") and the fixtures above leave other lanes standing.
+CLR_REPO="$SANDBOX/clear-repo"
+mkdir -p "$CLR_REPO/.claude/hooks"
+cp "$HOOK" "$CLR_REPO/.claude/hooks/"
+CLR_RUN="$CLR_REPO/.claude/hooks/$(basename "$HOOK")"
+git -C "$CLR_REPO" init -q .
+git -C "$CLR_REPO" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+git -C "$CLR_REPO" update-ref refs/remotes/origin/main HEAD
+git -C "$CLR_REPO" worktree add -q "$CLR_REPO/wt-clr" -b feat/clr HEAD
+git -C "$CLR_REPO/wt-clr" -c user.email=t@t -c user.name=t commit -q --allow-empty -m work
+CLR_PAYLOAD="{\"cwd\": \"$CLR_REPO/wt-clr\", \"session_id\": \"sess-clr\"}"
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "the clearing fixture arms once" "ctx" "$(channel_of "$out")"
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "...and the repeat is downgraded" "sys" "$(channel_of "$out")"
+# The condition CLEARS: the lane is no longer ahead of origin/main.
+git -C "$CLR_REPO/wt-clr" reset -q --hard origin/main
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "...the hook is silent once nothing is ahead" "" "$out"
+check "...and the stale record is gone" "absent" \
+  "$([ -e "$(git -C "$CLR_REPO/wt-clr" rev-parse --absolute-git-dir)/stop-nudge-lane" ] && echo present || echo absent)"
+# ...and the same subject is a FIRST sighting again.
+git -C "$CLR_REPO/wt-clr" -c user.email=t@t -c user.name=t commit -q --allow-empty -m 'work again'
+out=$(run_hook_keep "$CLR_REPO" "$CLR_RUN" "$CLR_PAYLOAD")
+check "...so the SAME subject nudges the model again" "ctx" "$(channel_of "$out")"
+git -C "$CLR_REPO" worktree remove --force "$CLR_REPO/wt-clr"
+
+
 # --- The two channels carry DIFFERENT TEXT. A downgrade changes the READER
 # from the agent to a person, so sending the model's wording ("you are not done:
 # rebase, run the gates, open the PR") down `systemMessage` addresses a human as
@@ -714,6 +868,18 @@ git -C "$REPO" worktree remove --force "$REPO/wt-cad-a"
 git -C "$REPO" worktree remove --force "$REPO/wt-cad-b"
 clear_nudge_records
 
+
+# A FLOOR on the case total. Every `for` loop above expands a LIST, and emptying
+# one -- or deleting a case -- removes assertions SILENTLY while the tally still
+# reads `fail: 0`. No suite in this repo had one, so the only thing standing
+# between a gutted loop and a green run was somebody noticing the number move.
+# Raise it when cases are added; never lower it to make a red run green.
+CASE_FLOOR=102
+if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
+  fail=$((fail + 1))
+  fail_log+="FAIL case floor: only $((pass + fail)) cases ran, expected at least 102\n"
+  printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
+fi
 printf '\nPass: %d  Fail: %d\n' "$pass" "$fail"
 if [ "$fail" -gt 0 ]; then
   printf '%b' "$fail_log" >&2

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -478,21 +478,73 @@ The hooks split into four classes:
   `git push origin main && git push origin <merged>` blocks whichever
   half is the merged one; the walk stops at the first segment that
   blocks, so an ordinary single push still makes at most one `gh` call.
+  Three separate properties hide behind that one sentence, and each
+  needed its own case because each mutates independently:
+
+  - a segment the parse cannot gate at all (a non-`origin` remote, a
+    `:branch` deletion refspec) must be SKIPPED, not treated as the end
+    of the walk. Turning that `continue` into a `break` left every
+    other case green while `git push upstream feat/x && git push
+    origin <merged>` returned rc=0 — a live bypass, since putting any
+    un-gateable push first buys a free pass for everything behind it.
+  - the walk stops at the first segment that BLOCKS, and the refusal
+    therefore names THAT segment's branch. Deleting the `break` is
+    invisible to an exit-code comparison: the command still blocks, but
+    `git push origin <merged> && git push origin main` then tells the
+    user to replay `main`, which is not the branch in trouble. The case
+    asserts the message text in both directions.
+  - the "gh not installed" note describes a per-COMMAND decision, so a
+    chain of three gateable pushes states it once. `resolve_gh`
+    memoises the FAILED probe as well as the successful one; keying the
+    memo on the resolved path alone re-probed and re-printed per
+    segment.
+
   The `|` / `;` / `&&` strips are gone from the argument parse — a
   segment already ends at those, and a `push` after one is now its own
   turn in the walk — while the REDIRECTION strip stays, since `>x` can
-  still sit inside a segment.
+  still sit inside a segment. That strip only discriminates on a push
+  that OMITS its branch (`git push -u origin >/tmp/log`), where the
+  redirection token would otherwise become the branch; with a branch
+  present it is already consumed. The case is written that way for
+  exactly that reason.
 
   One limit, stated rather than hidden: `target_dir` is resolved ONCE
-  for the whole command, because `gate_target_dir` reports the LAST
-  matching segment's tree and the helper exposes no per-segment answer.
-  Rebuilding a per-segment prefix to ask again was rejected —
-  re-splitting already-segmented text would let a newline inside a
-  quoted argument surface as a `cd` segment, a worse hole than the one
-  it closes. The exposure is narrow: the positional branch comes from
+  for the whole command, because `gate_target_dir` reports the **FIRST**
+  matching segment's tree — it `break`s at the first segment matching
+  the verb ERE — and the helper exposes no per-segment answer. Measured:
+  `gate_target_dir 'git -C /aaa push origin && git -C /bbb push origin'`
+  answers `/aaa`. The BOUND is the same either way, but the direction is
+  not a detail for a reader: the EARLIEST push's tree is in force for
+  every segment, so the LAST `-C` in a command is precisely the one that
+  is not consulted.
+
+  Rebuilding a per-segment prefix to ask again was rejected, but not for
+  the reason once recorded here. That reason — that re-splitting
+  already-segmented text would let a newline inside a quoted argument
+  surface as a `cd` segment — does not reproduce: `gate_segments`
+  flattens a quoted newline to a space, so
+  `gh pr create --body "line1<newline>cd /evil" && git push origin
+  feat/x` splits into two segments and re-splitting either returns it
+  unchanged. Re-splitting is idempotent. The obstacle that does exist is
+  the `break` above: handed a prefix ending at segment N,
+  `gate_target_dir` still answers for the first matching segment in that
+  prefix rather than for N, so the per-segment question cannot be asked
+  without changing the shared helper — a change to every gate that calls
+  it, not just this one.
+
+  The exposure is narrow either way: the positional branch comes from
   the segment itself, so `target_dir` only decides the `symbolic-ref`
   fallback for a push that OMITS its branch, and only when one command
   pushes from two different trees.
+
+  `git push origin --delete <branch>` is **not** a pass-through, despite
+  reading like the `:branch` case. `--delete` is in the valueless-flag
+  list, so `<branch>` lands in the branch slot as an ordinary positional
+  and a merged branch blocks. Deliberate: re-deleting an
+  already-deleted branch is a no-op on GitHub, so the false block costs
+  nothing, whereas teaching the flag list to swallow its argument would
+  hand every `--delete` spelling the pass-through that the `:branch`
+  arm grants only after reading a refspec.
 
 - **`markgate-pipe-gate.sh`** blocks a Bash call in which
   `markgate verify <gate>`, `markgate set <gate>` or `markgate run
@@ -649,9 +701,13 @@ The hooks split into four classes:
   a preceding `cd` can put two segments of one command in two trees.
   Covered by `.claude/hooks/gate-command-recognition.test.sh`, whose
   main-tree block pins the chained blocks, the per-segment allowances,
-  the linked-worktree pass and the quoted-mention pair (149 cases in
+  the linked-worktree pass and the quoted-mention pair (154 cases in
   that file overall, alongside the `post-merge-orphan-push-gate` block
-  added for the same defect).
+  added for the same defect). The interpreter those cases run the hooks
+  under is now explicit: a `bash` symlink at the front of the pinned
+  PATH, defaulting to `/bin/bash` (3.2 on macOS) and overridable with
+  `HOOK_BASH=<path> bash .claude/hooks/gate-command-recognition.test.sh`
+  to take the 5.x tally.
 
 ## 3. Markgate-backed gates
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -238,16 +238,40 @@ The hooks split into four classes:
   contexts (`closes #N` / `(#N)` / fenced code blocks / GitHub URLs
   / backtick code spans) pass through; bare `Must-fix #N` /
   `review-fix #N` / `step #N` / plain `#N` in prose are blocked with
-  line-numbered offender output. When the named body file cannot be
-  READ, or exists but the same command REWRITES it, the gate extracts
-  the HEREDOC BODY the command is about to write there and scans that
-  (go-to-k/cdk-local#637). The hook runs BEFORE the command, so in the
-  one-call `heredoc -> file -> --body-file` publishing shape the path is
-  absent or still holds the PREVIOUS body; skipping was a silent pass,
-  and reading the stale file looked like a working gate while judging
-  text nobody was submitting — in both directions, since a stale file
-  can also BLOCK a clean submission over a line that will not exist,
-  which the author cannot clear.
+  line-numbered offender output.
+
+  What it scans is *the body the command is about to submit*, which is
+  not always the file on disk (go-to-k/cdk-local#637). The hook runs
+  BEFORE the command, so in the one-call `heredoc -> file ->
+  --body-file` publishing shape the path is absent or still holds the
+  PREVIOUS body; skipping was a silent pass, and reading the stale file
+  looked like a working gate while judging text nobody was submitting —
+  in both directions, since a stale file can also BLOCK a clean
+  submission over a line that will not exist, which the author cannot
+  clear. There are THREE write shapes and the gate now distinguishes
+  all three:
+
+  | the command… | scans the heredoc chunks | scans the file |
+  | --- | --- | --- |
+  | REWRITES the path (`>`, `tee` without `-a`) | yes | no — the disk copy is discarded |
+  | APPENDS to it (`>>`, `tee -a`) | yes | yes — the disk copy is the FIRST HALF of the body |
+  | does not write it | n/a | yes |
+
+  The append row is the one that regressed. A first version matched
+  `>>` / `tee -a` with the same predicate as `>` and then scanned the
+  heredoc INSTEAD of the file, which made the gate WEAKER than the code
+  it replaced: an append of a clean chunk onto a file already holding
+  `Must-fix #1` exited 0, where `origin/main` and the branch's own
+  first commit both exited 2.
+
+  Two further properties of the extraction, each pinned by a case.
+  EVERY heredoc writing the path is collected, in command order — the
+  loop used to stop after the first, so a body assembled from two
+  chunks was judged on chunk one alone. And "a heredoc with an EMPTY
+  body" is reported separately from "no heredoc at all" (found-ness
+  rides the exit status, not the emptiness of stdout): inferring one
+  from the other made an empty rewrite of an offending file exit 2,
+  which is the unclearable false block this fallback exists to end.
 
   It does NOT scan the whole command, and that is the one place this
   gate must diverge from the `issue-*-gate.sh` siblings' fallback even
@@ -272,16 +296,18 @@ The hooks split into four classes:
   Two edges worth knowing. The redirect terminator class is
   `[\s;&|)<]` rather than `\s`, because the narrow class missed
   `>f<<EOF` — the TIGHT spelling of the very shape the fallback exists
-  for — as well as `>f;` and `>f&&`. And a body written by something
-  other than a heredoc (`printf > f`, `python3 -c ... > f`) cannot be
-  extracted, so it falls back to whatever is on disk, and to nothing at
-  all when the path is absent; that limit is asserted in both
-  directions rather than left to be rediscovered.
+  for — as well as `>f;` and `>f&&`; all three arms now carry a case,
+  since narrowing the class back to `[\s<]` used to leave the suite
+  green. And a body written by something other than a heredoc
+  (`printf > f`, `python3 -c ... > f`) cannot be extracted, so it falls
+  back to whatever is on disk, and to nothing at all when the path is
+  absent; that limit is asserted in both directions rather than left to
+  be rediscovered.
 
   Note the SAME-repo qualified `go-to-k/cdk-local#N` form is NOT
   allow-listed in a body — `/work-issues` §10-c names a full URL as the
   only body spelling — so it is refused here on purpose. Covered by
-  `.claude/hooks/pr-body-item-number-gate.test.sh` (24 cases).
+  `.claude/hooks/pr-body-item-number-gate.test.sh` (33 cases).
 
 - **`issue-dup-check-gate.sh`** blocks `gh issue create` — and a
   `gh api repos/<owner>/<repo>/issues` that is actually a MINT (an
@@ -561,6 +587,30 @@ The hooks split into four classes:
   names the resolved target dir + the operation + the corrective
   `git worktree add .claude/worktrees/<branch> -b <branch> origin/main`
   recipe.
+
+  The VERDICT is read per SEGMENT, from `gate_verb_args` — the same
+  constant that armed the gate — not from the whole command. It used to
+  be parsed by an awk walker that skipped to the FIRST `git` token and
+  read the subcommand there, so in a chained form that first `git` is a
+  DIFFERENT command: the walker read `sub=fetch`, fell to a fail-open
+  `*)` arm, and exited 0. Measured in the main checkout on `main`:
+
+  ```text
+  git switch -c wt-probe origin/main                       rc=2  BLOCKED
+  git fetch origin && git switch -c wt-probe origin/main    rc=0  PASS   <- bypass
+  git status && git checkout -b wt-probe                    rc=0  PASS   <- bypass
+  ```
+
+  `/work-issues` prints the chained spelling, so the bypass sat on the
+  mandated path. Every matching segment is judged now, not just one, so
+  `git switch main && git switch -c feat` blocks on its second half;
+  the main-tree test and the `.markgate.yml` opt-in are likewise
+  evaluated against the tree THAT segment resolves to, since a `-C` or
+  a preceding `cd` can put two segments of one command in two trees.
+  Covered by `.claude/hooks/gate-command-recognition.test.sh`, whose
+  main-tree block pins the chained blocks, the per-segment allowances,
+  the linked-worktree pass and the quoted-mention pair (135 cases in
+  that file overall).
 
 ## 3. Markgate-backed gates
 
@@ -1312,7 +1362,15 @@ checks, so the path skip was redundant AND the entire defect. Note the
 POLARITY — the same path is right as an IDENTIFIER of the session's own
 lane, which is how it is used now.
 
-Its suite (`.claude/hooks/stop-unmerged-lane-warn.test.sh`, 86 cases)
+The `session_id` the cadence keys on arrives as JSON, so the payload's
+value is checked for TYPE and not merely for truthiness before it is
+normalised. A number or a list raised in the Python block, killing it
+before it printed its third line; the shell then fell back to `shared`,
+so the VERDICT stayed right while a traceback went to the hook's stderr
+on every single turn. A case asserts stderr is empty for that payload —
+no case that reads stdout can see it.
+
+Its suite (`.claude/hooks/stop-unmerged-lane-warn.test.sh`, 88 cases)
 carries five fixture traps worth knowing before editing it, because each
 cost a case a wrong-reason pass:
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -454,6 +454,46 @@ The hooks split into four classes:
   / etc. pass through). Fails open when `gh` is missing or
   unauthenticated.
 
+  The remote and branch are read per SEGMENT, from `gate_verb_args` —
+  the same constant that armed the gate. They used to be read off the
+  WHOLE COMMAND with a leftmost-longest
+  `[[ "$cmd" =~ [[:space:]]push([[:space:]]+(.*))?$ ]]`, cut at the
+  first `&&` / `;` / `|`. Run standalone, that parse gave:
+
+  ```text
+  git push origin feat/x                              args [origin feat/x]
+  echo "remember to push origin main" && git push origin feat/x
+                                                      args [origin main"…]
+  git push origin main && git push origin feat/x      args [origin main…]
+  ```
+
+  A quoted MENTION of push steers the branch to `main"`, and a chained
+  push is judged on the FIRST one. In both cases
+  `gh pr list --head <wrong branch>` finds no merged PR, the gate exits
+  0, and the orphan push proceeds unjudged — the whole failure above.
+  The same defect was reproduced in the sibling repo's copy, which is
+  why it was fixed rather than filed.
+
+  EVERY matching segment is judged, not the last, so
+  `git push origin main && git push origin <merged>` blocks whichever
+  half is the merged one; the walk stops at the first segment that
+  blocks, so an ordinary single push still makes at most one `gh` call.
+  The `|` / `;` / `&&` strips are gone from the argument parse — a
+  segment already ends at those, and a `push` after one is now its own
+  turn in the walk — while the REDIRECTION strip stays, since `>x` can
+  still sit inside a segment.
+
+  One limit, stated rather than hidden: `target_dir` is resolved ONCE
+  for the whole command, because `gate_target_dir` reports the LAST
+  matching segment's tree and the helper exposes no per-segment answer.
+  Rebuilding a per-segment prefix to ask again was rejected —
+  re-splitting already-segmented text would let a newline inside a
+  quoted argument surface as a `cd` segment, a worse hole than the one
+  it closes. The exposure is narrow: the positional branch comes from
+  the segment itself, so `target_dir` only decides the `symbolic-ref`
+  fallback for a push that OMITS its branch, and only when one command
+  pushes from two different trees.
+
 - **`markgate-pipe-gate.sh`** blocks a Bash call in which
   `markgate verify <gate>`, `markgate set <gate>` or `markgate run
   <gate> -- <cmd>` feeds a `|` pipeline, because there `$?` is the LAST
@@ -609,8 +649,9 @@ The hooks split into four classes:
   a preceding `cd` can put two segments of one command in two trees.
   Covered by `.claude/hooks/gate-command-recognition.test.sh`, whose
   main-tree block pins the chained blocks, the per-segment allowances,
-  the linked-worktree pass and the quoted-mention pair (135 cases in
-  that file overall).
+  the linked-worktree pass and the quoted-mention pair (149 cases in
+  that file overall, alongside the `post-merge-orphan-push-gate` block
+  added for the same defect).
 
 ## 3. Markgate-backed gates
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -1,10 +1,11 @@
 # Hooks and Gates
 
-Reference for the `.claude/hooks/*.sh` PreToolUse safety + enforcement
-hooks shipped in cdk-local. Auto-loaded when working on
-`.claude/hooks/**` or `.markgate.yml`.
+Reference for the `.claude/hooks/*.sh` safety + enforcement hooks
+shipped in cdk-local — PreToolUse gates, plus the one `Stop` hook in
+section 4. Auto-loaded when working on `.claude/hooks/**` or
+`.markgate.yml`.
 
-The hooks split into three classes:
+The hooks split into four classes:
 
 1. **Universal-shape one-shot safety hooks** — block known foot-guns
    at the source. Each produces an actionable error with the exact
@@ -16,6 +17,9 @@ The hooks split into three classes:
    the corresponding skill (`/check`, `/check-docs`, `/run-integ`,
    `/review-pr`, `/verify-pr`, `/merge-pr`) to be re-run before the
    gated action can proceed.
+4. **Stop hooks** — fire when a turn is about to end rather than on a
+   tool call, and choose an OUTPUT CHANNEL that decides whether the turn
+   continues. Section 4 covers the channel table and the nudge cadence.
 
 ## 1. Universal-shape safety hooks
 
@@ -234,7 +238,17 @@ The hooks split into three classes:
   contexts (`closes #N` / `(#N)` / fenced code blocks / GitHub URLs
   / backtick code spans) pass through; bare `Must-fix #N` /
   `review-fix #N` / `step #N` / plain `#N` in prose are blocked with
-  line-numbered offender output.
+  line-numbered offender output. When the named body file cannot be
+  READ, or exists but the same command REWRITES it, the gate scans the
+  WHOLE COMMAND instead (go-to-k/cdk-local#637). The hook runs BEFORE
+  the command, so in the one-call `heredoc -> file -> --body-file`
+  publishing shape the path is absent or still holds the PREVIOUS body;
+  skipping was a silent pass, and reading the stale file looked like a
+  working gate while judging text nobody was submitting. Same fallback
+  the two `issue-*-gate.sh` siblings already carry for the same window.
+  Note the SAME-repo qualified `go-to-k/cdk-local#N` form is NOT
+  allow-listed in a body — `/work-issues` §10-c names a full URL as the
+  only body spelling — so it is refused here on purpose.
 
 - **`issue-dup-check-gate.sh`** blocks `gh issue create` — and a
   `gh api repos/<owner>/<repo>/issues` that is actually a MINT (an
@@ -1115,3 +1129,110 @@ call `markgate set integ` directly from a shell.
   side worktree. The `/merge-pr` skill is the ONLY legitimate setter of
   the `merge-pr` marker — never `markgate set merge-pr` directly from a
   shell to bypass this gate.
+
+## 4. Stop hooks
+
+One hook fires on `Stop` rather than on a tool call:
+`.claude/hooks/stop-unmerged-lane-warn.sh`. It catches the quiet half of
+unfinished work — a linked worktree whose branch is COMMITTED but still
+ahead of `origin/main`, a lane that is finished as far as the editor is
+concerned and unfinished as far as the repo is. (The sibling cdkd repo
+pairs it with a `stop-warn.sh` covering the UNCOMMITTED half in the main
+tree; this repo has no such hook, so do not read the pair as coverage
+here.)
+
+On `Stop` the OUTPUT CHANNEL is the behaviour, not formatting:
+
+| channel | who reads it | the turn |
+| --- | --- | --- |
+| `hookSpecificOutput.additionalContext` | the MODEL | CONTINUES — it gets another turn to act |
+| `systemMessage` | the USER only | ends normally |
+| stdout / stderr at exit 0 | nobody (both are discarded on `Stop`) | ends normally |
+
+There is no fourth option that reaches the model WITHOUT continuing the
+turn, which is why the hook has to choose rather than simply emit.
+
+**A continuation is not free, and it is not merely slow.** Read from the
+installed Claude Code (2.1.251): a Stop hook's `additionalContext`
+travels in the SAME `blockingErrors` return value as a
+`decision: "block"`, and the main loop re-queries on either. Both count
+against one budget — `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, default **8**
+consecutive blocks — after which the harness overrides the hook and ends
+the turn. So a hook that nudges on every turn-end spends a budget shared
+with every other Stop hook, and the one spending it is not necessarily
+the one with something urgent to say.
+
+**Channel by OWNERSHIP** (go-to-k/cdkd#2389 / go-to-k/cdkd#2392):
+
+- **this session's own worktree is a lane** → `additionalContext`,
+  subject to the cadence rule below. This is the failure the hook exists
+  for: ending the turn with your own branch committed and no PR.
+- **only OTHER worktrees are lanes** → `systemMessage`. The model cannot
+  act on another session's lane, so a continuation buys one extra reply
+  that can only say "not mine".
+- **`stop_hook_active` set** (the harness already continued once this
+  turn) → silent, so one nudge never becomes a spin.
+
+**The cadence rule** (go-to-k/cdkd#2391, which asks for it in all three
+repos). `stop_hook_active` stops a nudge SPINNING inside one turn, and
+that is all it does. Across turns the condition persists, so an
+unconditional `additionalContext` fires at every turn-end for as long as
+the lane exists — including two states with nothing left to do: the PR
+is open and CI is running (the session is legitimately WAITING), and the
+lane was squash-merged with its worktree left behind, which reads as
+ahead FOREVER. So the model is nudged **at most once per distinct
+SUBJECT**, and a repeat of the same subject falls back to
+`systemMessage`: the user still sees it, the turn ends.
+
+The subject is `<own branch>:<pushed|unpushed>`, chosen so that ORDINARY
+WORK does not change it. Two choices are load-bearing, each arrived at by
+rejecting the obvious alternative:
+
+- NOT the commit COUNT, which changes every time the model commits —
+  re-arming on ordinary work bounds nothing.
+- Push state is NOT the CHANNEL discriminator, the shape go-to-k/cdkd#2391 proposed.
+  That goes quiet on a branch pushed with NO PR, a real failure and one
+  of the two this hook exists for. Push state earns its keep in the
+  SUBJECT (so `unpushed -> pushed` re-arms exactly once) and in the TEXT
+  (so the message names which half of the work is left).
+
+The record is ONE file in the PER-WORKTREE git dir
+(`<git dir>/stop-nudge-lane`) holding `<session id>TAB<subject>TABepoch`,
+written tmp-then-`mv`. Per-worktree because that is where markgate keeps
+its markers too, and because removing a worktree takes its record with
+it. One file rather than one per session, because a per-session file
+would accumulate with nobody to clean it up; a concurrent session in the
+same worktree can therefore clobber it, which costs an EXTRA nudge rather
+than a missed one — the safe direction, pinned by a case rather than left
+to be rediscovered as a bug.
+
+One false positive is expected and is named in the warning text itself:
+this repo squash-merges, so a merged branch never becomes an ancestor of
+`origin/main` and keeps reading as ahead until its worktree is removed.
+The remedy is `git worktree remove` plus `git branch -D`, not another PR
+— and when the tree is one you must NOT remove (an outer tool owns it, or
+you were launched inside it), `git switch --detach origin/main` clears
+the lane, because a worktree with no current branch is not a lane at all.
+
+It shipped INERT for its own primary case once (go-to-k/cdkd#2279): it
+derived its root from `BASH_SOURCE` and SKIPPED the worktree that
+matched, but in a linked worktree `BASH_SOURCE` IS the lane. The main
+tree is identified by BRANCH (`main` / `master`), which the loop already
+checks, so the path skip was redundant AND the entire defect. Note the
+POLARITY — the same path is right as an IDENTIFIER of the session's own
+lane, which is how it is used now.
+
+Its suite (`.claude/hooks/stop-unmerged-lane-warn.test.sh`) carries three
+fixture traps worth knowing before editing it, because each cost a case a
+wrong-reason pass:
+
+- On macOS `mktemp -d` returns a `/var/folders/...` path whose real
+  location is `/private/var/...`, while the hook canonicalises its own
+  root — so the sandbox root must be `cd "$(mktemp -d)" && pwd -P` or any
+  case whose subject IS that equality passes regardless.
+- A push-state fixture needs `remote.origin.fetch` set to
+  `+refs/heads/*:refs/remotes/origin/*`, or `@{u}` fails with "not stored
+  as a remote-tracking branch" and the case measures nothing.
+- `run_hook` resets the nudge record and `run_hook_keep` does not. Without
+  the reset the pre-cadence cases pass or fail on their POSITION in the
+  file rather than on behaviour — measured on the port: six flip.

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -173,7 +173,7 @@ The hooks split into four classes:
   OPEN: the commit proceeds, and the only signal is an error on stderr
   that reads like noise from the hook rather than a refusal.
 
-  `.claude/hooks/control-char-gate.test.sh` (115 cases, run by
+  `.claude/hooks/control-char-gate.test.sh` (118 cases, run by
   `vp run test:hooks`) drives all of the above through the real hook
   against throwaway repositories, in BOTH directions. Two review rounds
   found live blockers behind 52 and then 93 green cases, both times in
@@ -695,19 +695,53 @@ The hooks split into four classes:
 
   `/work-issues` prints the chained spelling, so the bypass sat on the
   mandated path. Every matching segment is judged now, not just one, so
-  `git switch main && git switch -c feat` blocks on its second half;
-  the main-tree test and the `.markgate.yml` opt-in are likewise
-  evaluated against the tree THAT segment resolves to, since a `-C` or
-  a preceding `cd` can put two segments of one command in two trees.
+  `git switch main && git switch -c feat` blocks on its second half.
+
+  The main-tree test and the `.markgate.yml` opt-in are ALSO evaluated
+  against the tree THAT segment resolves to — and this paragraph, and
+  `main_tree_of`'s own header, asserted that before it was true. The
+  tree was in fact resolved ONCE per verb candidate, outside the walk,
+  so segment 1 decided every segment. That is a bypass in one direction
+  and a false block in the other, both live. Measured against the real
+  main checkout and its real linked worktree, payload cwd = the main
+  tree:
+
+  ```text
+  git -C <wt> switch -c a && git switch -c b        rc=0  want 2  <- bypass
+  git -C <wt> checkout -b a && git checkout -b b    rc=0  want 2  <- bypass
+  git switch main && git -C <wt> switch -c a        rc=2  want 0  <- false block
+  ```
+
+  Fixed on 2026-09-01 by `gate_verb_args_dir` in
+  `.claude/hooks/_command-match.sh`, which emits `<dir>TAB<args>` per
+  matching segment out of ONE walk, so the tree and the arguments
+  cannot come from different segments. A `cd` persists into later
+  segments; a `-C` binds only its own command.
+
+  LIMIT, stated rather than hidden: `gate_segments` FLATTENS a subshell,
+  so a `cd` inside one leaks past the closing paren.
+  `(cd <wt> && git switch -c a) && git switch -c b` from the main tree
+  resolves segment 3 to `<wt>` and passes — measured rc=0, want 2, and
+  measured the same on the pre-fix hook, so it is a pre-existing bound
+  rather than one this change introduced. Closing it means teaching the
+  shared segmenter to report subshell depth, which is a change to every
+  gate that calls it.
   Covered by `.claude/hooks/gate-command-recognition.test.sh`, whose
   main-tree block pins the chained blocks, the per-segment allowances,
-  the linked-worktree pass and the quoted-mention pair (154 cases in
+  the linked-worktree pass and the quoted-mention pair (167 cases in
   that file overall, alongside the `post-merge-orphan-push-gate` block
   added for the same defect). The interpreter those cases run the hooks
   under is now explicit: a `bash` symlink at the front of the pinned
   PATH, defaulting to `/bin/bash` (3.2 on macOS) and overridable with
   `HOOK_BASH=<path> bash .claude/hooks/gate-command-recognition.test.sh`
-  to take the 5.x tally.
+  to take the 5.x tally. `pr-body-item-number-gate.test.sh` and
+  `stop-unmerged-lane-warn.test.sh` had NO such shim until
+  2026-09-01, so their hooks ran under whatever bash PATH gave (5.x
+  here) whichever interpreter started the suite; both now default the
+  same way and print the interpreter they measured on their first
+  line. Proved load-bearing rather than assumed: injecting a
+  bash-4-only `;;&` parse error into each hook reddens 16 of 33 and 87
+  of 102 under 3.2 and none of either under 5.3.9.
 
 ## 3. Markgate-backed gates
 
@@ -1467,7 +1501,7 @@ so the VERDICT stayed right while a traceback went to the hook's stderr
 on every single turn. A case asserts stderr is empty for that payload —
 no case that reads stdout can see it.
 
-Its suite (`.claude/hooks/stop-unmerged-lane-warn.test.sh`, 88 cases)
+Its suite (`.claude/hooks/stop-unmerged-lane-warn.test.sh`, 102 cases)
 carries five fixture traps worth knowing before editing it, because each
 cost a case a wrong-reason pass:
 

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -239,16 +239,49 @@ The hooks split into four classes:
   / backtick code spans) pass through; bare `Must-fix #N` /
   `review-fix #N` / `step #N` / plain `#N` in prose are blocked with
   line-numbered offender output. When the named body file cannot be
-  READ, or exists but the same command REWRITES it, the gate scans the
-  WHOLE COMMAND instead (go-to-k/cdk-local#637). The hook runs BEFORE
-  the command, so in the one-call `heredoc -> file -> --body-file`
-  publishing shape the path is absent or still holds the PREVIOUS body;
-  skipping was a silent pass, and reading the stale file looked like a
-  working gate while judging text nobody was submitting. Same fallback
-  the two `issue-*-gate.sh` siblings already carry for the same window.
+  READ, or exists but the same command REWRITES it, the gate extracts
+  the HEREDOC BODY the command is about to write there and scans that
+  (go-to-k/cdk-local#637). The hook runs BEFORE the command, so in the
+  one-call `heredoc -> file -> --body-file` publishing shape the path is
+  absent or still holds the PREVIOUS body; skipping was a silent pass,
+  and reading the stale file looked like a working gate while judging
+  text nobody was submitting — in both directions, since a stale file
+  can also BLOCK a clean submission over a line that will not exist,
+  which the author cannot clear.
+
+  It does NOT scan the whole command, and that is the one place this
+  gate must diverge from the `issue-*-gate.sh` siblings' fallback even
+  though the window is identical. The difference is what each looks
+  for: they need one anchored marker to be PRESENT, so extra text can
+  only make them pass, while this gate objects to content it FINDS, so
+  extra text makes it BLOCK. Two ordinary commands were measured going
+  0 -> 2 against the first, whole-command port — one whose ISSUE TITLE
+  cites an issue number and whose body file is absent, and one whose
+  COMMIT MESSAGE cites a review round ahead of a clean heredoc body:
+
+  ```sh
+  gh issue create --title 'follow-up to #2397 discussion' --body-file "$ABSENT"
+  git commit -m 'address review #3' && cat > "$BODY" <<'EOF'
+  ...clean body...
+  EOF
+  gh pr create --body-file "$BODY"
+  ```
+
+  Both are pinned as cases.
+
+  Two edges worth knowing. The redirect terminator class is
+  `[\s;&|)<]` rather than `\s`, because the narrow class missed
+  `>f<<EOF` — the TIGHT spelling of the very shape the fallback exists
+  for — as well as `>f;` and `>f&&`. And a body written by something
+  other than a heredoc (`printf > f`, `python3 -c ... > f`) cannot be
+  extracted, so it falls back to whatever is on disk, and to nothing at
+  all when the path is absent; that limit is asserted in both
+  directions rather than left to be rediscovered.
+
   Note the SAME-repo qualified `go-to-k/cdk-local#N` form is NOT
   allow-listed in a body — `/work-issues` §10-c names a full URL as the
-  only body spelling — so it is refused here on purpose.
+  only body spelling — so it is refused here on purpose. Covered by
+  `.claude/hooks/pr-body-item-number-gate.test.sh` (24 cases).
 
 - **`issue-dup-check-gate.sh`** blocks `gh issue create` — and a
   `gh api repos/<owner>/<repo>/issues` that is actually a MINT (an
@@ -1171,7 +1204,15 @@ the one with something urgent to say.
   act on another session's lane, so a continuation buys one extra reply
   that can only say "not mine".
 - **`stop_hook_active` set** (the harness already continued once this
-  turn) → silent, so one nudge never becomes a spin.
+  turn) → the ARM is suppressed, so one nudge never becomes a spin, but
+  the warning still leaves on `systemMessage`. Going fully silent was
+  the earlier behaviour and it was wrong: a lane can be COMMITTED
+  DURING the continuation, in which case that pass is the first time
+  the condition holds at all and the user would never be told. A bare
+  `systemMessage` does not continue a turn, so saying it cannot spin.
+  A resumed pass also writes NO record — recording a subject as seen
+  while the model was never told would spend the model's one nudge on a
+  turn it never heard about.
 
 **The cadence rule** (go-to-k/cdkd#2391, which asks for it in all three
 repos). `stop_hook_active` stops a nudge SPINNING inside one turn, and
@@ -1185,8 +1226,8 @@ SUBJECT**, and a repeat of the same subject falls back to
 `systemMessage`: the user still sees it, the turn ends.
 
 The subject is `<own branch>:<pushed|unpushed>`, chosen so that ORDINARY
-WORK does not change it. Two choices are load-bearing, each arrived at by
-rejecting the obvious alternative:
+WORK does not change it. Three choices are load-bearing, each arrived at
+by rejecting the obvious alternative:
 
 - NOT the commit COUNT, which changes every time the model commits —
   re-arming on ordinary work bounds nothing.
@@ -1195,6 +1236,14 @@ rejecting the obvious alternative:
   of the two this hook exists for. Push state earns its keep in the
   SUBJECT (so `unpushed -> pushed` re-arms exactly once) and in the TEXT
   (so the message names which half of the work is left).
+- The comparison against the stored subject is **DIRECTED**, not a plain
+  equality. `pushed -> unpushed` is what an ordinary COMMIT looks like,
+  so `prev != current` re-armed on every commit AND again on every push:
+  measured on one lane as `commit ctx, repeat sys, push ctx, repeat sys,
+  commit ctx, push ctx, ...` — two forced continuations per commit/push
+  cycle, forever, which is the per-commit cadence the design explicitly
+  rejects. It arms on a new session, a lane never seen, a DIFFERENT
+  branch, or `unpushed -> pushed` — and on nothing else.
 
 The record is ONE file in the PER-WORKTREE git dir
 (`<git dir>/stop-nudge-lane`) holding `<session id>TAB<subject>TABepoch`,
@@ -1205,6 +1254,47 @@ would accumulate with nobody to clean it up; a concurrent session in the
 same worktree can therefore clobber it, which costs an EXTRA nudge rather
 than a missed one — the safe direction, pinned by a case rather than left
 to be rediscovered as a bug.
+
+Three properties of the record are as load-bearing as its content:
+
+- It is written on **BOTH** arms — the nudged one and the downgraded one
+  — because it holds the last OBSERVED subject, not the last NUDGED one.
+  Writing only on the arm freezes `prev_push` at `pushed` and silences
+  the next genuine `unpushed -> pushed`.
+- A record that cannot be PERSISTED (an unresolvable or unwritable git
+  dir) downgrades to `systemMessage`. A nudge that cannot be recorded
+  cannot be bounded, and an unbounded nudge is the thing the cadence
+  exists to remove — so the failure costs the MODEL channel, never the
+  warning itself.
+- A MALFORMED record — not exactly three tab-separated fields, or a
+  non-numeric epoch — is treated as NO record and falls to ARM. That is
+  the same safe direction as the concurrent clobber: an extra nudge,
+  never a missed one.
+
+The session id that keys the record comes from the event payload's
+`session_id` OR from `CLAUDE_CODE_SESSION_ID`, and **both are resolved
+and normalised in one place**, inside the Python block. The fold that
+strips tabs and newlines used to apply only to the payload's copy, with
+the env fallback landing after it in shell — so a tab in the env value
+added a FIELD to the record and a newline ended its line early. Either
+way the read-back shifts, `prev_sid` never matches the value the hook
+itself just wrote, and the cadence stops bounding anything. Measured on
+a payload carrying no `session_id`: a plain value gave `ctx, sys, sys`
+across three turns while a leading tab, an embedded tab and an embedded
+newline each gave `ctx, ctx, ctx`. It survived because every suite
+payload named a `session_id`, leaving that line with zero coverage.
+
+**The downgrade changes the TEXT, not only the channel.** Three paths
+reach `systemMessage` on the session's own lane — a repeat subject, a
+resumed pass, and an unpersistable record — and on all three the reader
+is a human. Emitting the model's wording there ("you are not done:
+rebase, run the gates, open the PR") addresses a person as the agent,
+which is go-to-k/cdkd#2389's defect reappearing on three paths instead
+of one. So the own-lane case builds two messages: the imperative one for
+`additionalContext`, and a short status line for `systemMessage` naming
+the lane, its push state, and the fact that the agent has already been
+told. A case asserts the two differ, so collapsing them back into one
+string fails the suite.
 
 One false positive is expected and is named in the warning text itself:
 this repo squash-merges, so a merged branch never becomes an ancestor of
@@ -1222,9 +1312,9 @@ checks, so the path skip was redundant AND the entire defect. Note the
 POLARITY — the same path is right as an IDENTIFIER of the session's own
 lane, which is how it is used now.
 
-Its suite (`.claude/hooks/stop-unmerged-lane-warn.test.sh`) carries three
-fixture traps worth knowing before editing it, because each cost a case a
-wrong-reason pass:
+Its suite (`.claude/hooks/stop-unmerged-lane-warn.test.sh`, 86 cases)
+carries five fixture traps worth knowing before editing it, because each
+cost a case a wrong-reason pass:
 
 - On macOS `mktemp -d` returns a `/var/folders/...` path whose real
   location is `/private/var/...`, while the hook canonicalises its own
@@ -1236,3 +1326,16 @@ wrong-reason pass:
 - `run_hook` resets the nudge record and `run_hook_keep` does not. Without
   the reset the pre-cadence cases pass or fail on their POSITION in the
   file rather than on behaviour — measured on the port: six flip.
+- A hand-written record cannot express an EMPTY subject field. Bash's
+  `read` with `IFS=<tab>` treats tab as IFS *whitespace*, so a run of
+  tabs delimits as one and `sid<TAB><TAB>epoch` arrives as a TWO-field
+  record. The malformed-record cases are written as short / long /
+  non-numeric records for that reason; a case named "empty subject"
+  passes through the field-count guard while claiming to test a path it
+  never takes.
+- Every payload naming an explicit `session_id` leaves the
+  `CLAUDE_CODE_SESSION_ID` fallback with ZERO coverage. The cases that
+  drive it go through `run_hook_sid`, which sends a payload WITHOUT the
+  field and sets the env var — and each asserts that the SECOND turn
+  downgrades, since the defect there is that the nudge never stops
+  firing, not that the first one is missing.


### PR DESCRIPTION
Closes #637

Closes go-to-k/cdk-local#637, and carries the sibling change go-to-k/cdkd#2391
asks all three repos to take. Both are `.claude/hooks/**`, so one PR, one
review, one CI cycle.

`pr-body-item-number-gate.sh` skipped validation entirely when the body file
named by `--body-file` did not exist at hook time. The hook runs BEFORE the
command, so that is every one-call `heredoc -> file -> --body-file` -- an
absent path was a silent pass, and a stale one meant the gate judged text
nobody was submitting while looking like it worked. `issue-dup-check-gate.sh`
and `issue-classification-label-gate.sh` already fall back to scanning the
whole command in that same window, each with a comment saying that failing
closed there would refuse the flow the rules prescribe, so this is a port
rather than a design decision. Both halves are covered: an absent path scans
the command, and an EXISTING path the command rewrites scans it too.

Five other divergences from the sibling's copy were measured and deliberately
NOT ported. The one worth naming is the `owner/repo#N` cross-repo allow arm:
retro.md section 10-c refuses the qualified form in a BODY here on purpose, so
porting it would put the hook in direct contradiction with the skill. That
refusal is now pinned by a case, so a future blind port cannot land silently.

`stop-unmerged-lane-warn.sh` already had the channel split, but not the cadence
rule. `stop_hook_active` only stops a nudge SPINNING inside one turn; across
turns the condition persists, so an unconditional `additionalContext` fires at
every turn-end for as long as the lane exists -- including two states with
nothing left to do (a PR open with CI running, and a squash-merged lane whose
worktree was left behind, which reads as ahead FOREVER).

That is not merely slow. Read from the installed Claude Code (2.1.251): a Stop
hook's `additionalContext` travels in the SAME `blockingErrors` value as a
`decision: "block"`, so both spend one budget --
`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, default 8 consecutive blocks, after which
the harness overrides the hook and ends the turn. An every-turn nudge spends a
budget shared with every other Stop hook.

So the model is nudged at most once per distinct SUBJECT and a repeat falls
back to `systemMessage`: the user still sees it, the turn ends. The subject is
`<own branch>:<pushed|unpushed>` -- NOT the commit count, which changes every
time the model commits and would re-arm on ordinary work. And push state is
deliberately not the CHANNEL discriminator, which is what the issue proposed:
that goes quiet on a branch pushed with NO PR, a real failure and one of the
two this hook exists for. It went into the subject (one re-arm) and into the
message text instead. The record is one file per worktree git dir, written
tmp-then-`mv`; a concurrent session can clobber it, which costs an EXTRA nudge
rather than a missed one, and that direction is pinned by a case.

The message also gains the one remedy the old text lacked: when the tree must
NOT be removed, `git switch --detach origin/main` clears the lane, because a
worktree with no current branch is not a lane at all.

Verification. `pr-body-item-number-gate` gets its first suite; the lane hook
grows from 43 cases. Every count in this body was RE-MEASURED at the final tree
on 2026-09-01, after the consolidated review round described at the end -- the
previous set had gone stale between being written and being committed. Current:
`pr-body-item-number-gate.test.sh` 33, `stop-unmerged-lane-warn.test.sh` 102,
`gate-command-recognition.test.sh` 167, `_command-match.test.sh` 367,
`control-char-gate.test.sh` 118. Green under bash 5.3.9 AND macOS system bash
3.2 -- and under a forced `bash -> <interpreter>` PATH shim, because the suites
invoke the hook through its own shebang, so running the SUITE under 3.2 still
executes the HOOK under 5.3. Mutation-probed rather than asserted: against
`origin/main`'s hooks, exactly the 2 new blocking cases flip in the body-file
suite (every control, including both false-block controls, passes there) and 6
flip in the lane suite. Non-vacuity re-measured too: an always-`exit 0` stub
fails 16 of the body-file suite's 33 cases and an always-`exit 2` stub fails 16
-- so neither direction can pass vacuously.

The harness split (`clear_nudge_records` / `run_hook_keep`) is not cosmetic:
without the reset, six PRE-EXISTING cases flip `ctx` -> `sys` and pass or fail
on their position in the file rather than on behaviour.

`issue-dup-check-gate.sh`'s cross-reference comment claimed the sibling gate
"simply skips the file", which this change made false; it now describes the new
behaviour and why the two fallbacks still differ in direction.

## Review rounds

**Round 1 → commit 2** — the whole-command fallback copied from
`issue-dup-check-gate` FALSE-BLOCKED ordinary commands, because that gate needs
one anchored marker to be PRESENT (extra text can only make it pass) while this
one objects to content it FINDS (extra text makes it block). Measured:
`gh issue create --title 'follow-up to #2397 discussion' --body-file <absent>`
and `git commit -m 'address review #3' && gh pr create --body-file <absent>`
both went 0 → 2. Replaced with heredoc-body extraction, which is what
`gh-body-english-gate` had already chosen for the same reason. The lane hook's
cadence predicate was undirected, so an ordinary commit re-armed it; the record
was written only on the arm, so it froze the push state; an unpersistable record
left the cadence unbounded; and `stop_hook_active` silenced the hook entirely,
losing the case where the lane is committed DURING the continuation.

**Round 2 → commits 3 and 4** — an APPEND was treated as a rewrite, so the
content already on disk went unscanned. That is a REGRESSION, weaker than both
`origin/main` and the round-1 commit: for `cat >> f <<EOF` over a file holding
`Must-fix #1`, both ancestors exit 2 and the tip exited 0. Only the FIRST
heredoc writing a path was collected, and an EMPTY body was indistinguishable
from "no heredoc", so an empty rewrite fell back to the stale file and
false-blocked.

The same round found two LIVE GATE BYPASSES in hooks this lane owns, neither
related to the issue it started from:

- `main-tree-branch-gate.sh` walked to the first `git` token, so
  `git fetch origin && git switch -c <b> origin/main` was read as `sub=fetch`
  and fell through a fail-open arm. Measured on the real main checkout on
  `main`: bare rc=2, chained rc=0. The chained spelling is what this repo's own
  `/work-issues` skill prints, so the shared main checkout was reachable
  unguarded.
- `post-merge-orphan-push-gate.sh` took the LEFTMOST ` push` in the whole
  command, so a quoted mention steered the branch to `main"` and a two-push
  chain was judged on the first — in both cases `gh pr list --head <wrong>`
  finds no merged PR and the orphan push proceeds unjudged.

Both now match in command position and judge the SEGMENT that matched; the push
gate judges EVERY matching segment, since a two-push chain has two real pushes
and picking either end alone leaves the other in the hole just closed.

Green under bash 5.3.9 and real bash 3.2.57. The 3.2 number is earned, and the
probe was re-run at the final tree: injecting a bash-4-only PARSE error (`;;&`)
into each hook reddens 16 of `pr-body-item-number-gate.test.sh`'s 33 cases, 87
of `stop-unmerged-lane-warn.test.sh`'s 102, and -- through
`gate-command-recognition.test.sh` -- 12 and 11 of its 167 for
`main-tree-branch-gate` and `post-merge-orphan-push-gate` respectively, while
every one of those stays green under 5.3.9. A first probe using `${x^^}` was
discarded — on 3.2 that prints "bad substitution" and CONTINUES with rc=0, so it
would have certified a dead shim. `pr-body-item-number-gate.test.sh` and
`stop-unmerged-lane-warn.test.sh` had NO shim at all until the consolidated
round below, so their HOOKS had never run under 3.2; both now default to
`/bin/bash` like `gate-command-recognition.test.sh` and print the interpreter
they measured on their first line.

Every added case is mutation-proven, and six attempts are recorded because they
were NO-OPS rather than clean negatives — a zero-red mutation reads as "the case
is vacuous" when in fact the mutation never landed. Two cases were reshaped so a
compound mutation could actually reach them.

Reported, not fixed, with lines: `commit-msg-heredoc-gate.sh`'s narrowing grep
demands `commit` immediately after `git`, so `git -C /x commit … <<EOF` passes
the trigger and misses the condition; `gh-pr-edit-deprecation-gate.sh` and this
gate's own `extract_files` scan the whole command for flags after a
segment-anchored trigger, which is over-scan (false-block risk) rather than
bypass.


## Consolidated review round (2026-09-01)

Nine reviewers across the three sibling repos produced one brief, applied here
in a single pass.

**Blocker -- `main-tree-branch-gate.sh` was bypassable in one direction and
false-blocking in the other, on a two-tree chain.** The earlier commit made the
VERDICT per segment and `main_tree_of`'s header already said it was called "per
matched segment"; the TREE was still resolved once per verb candidate, OUTSIDE
the walk, so segment 1 decided every segment. Reproduced before the fix by
driving the hook directly with a payload whose `cwd` is the REAL main checkout,
naming the REAL linked worktree, and re-measured after:

```text
                                                    before   after   want
git -C <wt> switch -c a && git switch -c b            rc=0    rc=2    2
git -C <wt> checkout -b a && git checkout -b b        rc=0    rc=2    2
git switch main && git -C <wt> switch -c a            rc=2    rc=0    0
```

The first two are the `git fetch && git switch -c` bypass this PR closed, one
operator further along: segment 1 resolves to a linked worktree, the gate stands
down for the WHOLE command, and segment 2 -- running in the SHARED main tree --
is never judged. The third refuses a branch creation IN a linked worktree, which
is exactly what the worktree convention mandates. Three control rows per repo
(bare create, `switch main`, a lone `-C <wt>` create) are unchanged.

Fixed by `gate_verb_args_dir` in `_command-match.sh`: one walk emitting
`<dir>TAB<args>` per matching segment, so the tree and the arguments cannot come
from different segments. A `cd` persists into later segments; a `-C` binds only
its own command. The gate's fail-closed loader check now names that function
too, because it feeds the loop through a process substitution -- a library
predating it would yield NO lines, the loop body would never run, and the gate
would exit 0 with no error anywhere.

LIMIT, stated rather than hidden: `gate_segments` FLATTENS a subshell, so a `cd`
inside one leaks past the closing paren --
`(cd <wt> && git switch -c a) && git switch -c b` from the main tree resolves
segment 3 to `<wt>` and passes. Measured rc=0 where 2 is wanted, and the SAME
against the pre-fix hook, so it is a pre-existing bound rather than one this
change introduced. `.claude/rules/hooks.md` says so too, replacing a paragraph
that asserted the per-segment property before it was true.

**A one-sided fence, in the dangerous direction.** This repo has no
`main-tree-branch-gate.test.sh`; its coverage lives in
`gate-command-recognition.test.sh`, and every PASS arm was pinned while every
BLOCK arm was free. Measured: deleting `verdict_for`'s plain-switch arm, and
deleting its `show-ref` local-branch arm, each left the suite green. Both now
have a case (plus a non-branch-name control so neither is satisfied by a gate
that blocks every name), and each mutation reddens exactly its own.

**`mv -f <tmp> <record>` reports SUCCESS onto a DIRECTORY.** It moves the tmp
inside it, so `persisted=1` was set, the readback next turn found nothing, and
every later turn re-armed: unbounded `additionalContext` against
`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`, arriving through the success check, plus one
orphan tmp per turn. The consolidated brief named four sites across the three
repos and missed this one -- the lane hook here carries the same line. Fenced by
a case driving three turns with the record path a directory: shipped
`sys sys sys` and 0 orphans, with `mv` alone `ctx ctx ctx` and 3 orphans.

**The cadence record outlived its condition.** When no worktree is ahead of
`origin/main` the stored subject is stale, and returning to the same branch in
the same push state reproduces it exactly -- so the next genuine first sighting
is DOWNGRADED. A MISSED nudge, and reachable through the very remedy this hook
prints: nudge, repeat, `git switch --detach origin/main`, re-attach, commit. The
hook now clears every worktree's record on the no-lane exit ("no lane is ahead"
is a repo-global fact, and the cost of being wrong is one extra nudge, the trade
the record's concurrent-clobber comment already accepts). Reverting the clear
reddens 2 of the new cases.

**Three guards that survived deletion.** Each was reported against the sibling
repo's copy and checked here:

- the env session-id fallback -- the existing loop clears the record between
  values, so it fences the tab/newline FOLD and not the SOURCE it names. Driving
  A, B, A through ONE record separates them: shipped `ctx ctx ctx`, with the env
  source removed `ctx sys sys`, a second concurrent session's nudge SWALLOWED.
- the `2>/dev/null >"$tmp"` redirect ORDER -- swapping it leaks
  "Permission denied" to the hook's REAL stderr from an ADVISORY hook, on every
  turn, and `run_hook_stderr` existed here but was never pointed at it. Now it
  is, and the swap reddens it.
- `sid="shared"` and the record SHAPE CHECK were both already fenced here
  (an UNSET env id case, and four malformed-record cases), so they are left
  alone. This repo's shape check is also why its lane hook is IMMUNE to the
  `IFS=<TAB>` fold that the two siblings had to fix.

**The `</dev/null` that was called unpinnable IS pinnable, on one of its two
arms.** `post-merge-orphan-push-gate.sh` said of both redirects that "no case
can pin it -- the failure it forecloses does not exist yet". True for the
`git symbolic-ref` arm (git is the real binary in the smoke suite). NOT true for
the `gh` arm: the suite owns that stub, so teaching it to `cat >/dev/null` plus
one case (`git push origin feat/live && git push origin feat/merged`)
discriminates exactly -- shipped exit 2, with `</dev/null` removed exit 0
because the stub drained the segment stream the walk was still reading. The
comment now says which half is which.

**A per-COMMAND note printed once per SEGMENT.** The "gh pr list failed or
returned empty" note fired once per gateable segment while `resolve_gh`'s
missing-gh note correctly fires once, and `.claude/rules/hooks.md` states the
note is a per-command decision. Memoised the same way; unguarded, a three-push
command says it three times.

**Nits.** `verdict_for` named a FLAG as the branch (`git switch --create feat/x`
reported the branch as `--create`), now fixed and pinned by two message
assertions; `main_tree_of` parsed the worktree path with `awk '{print $2}'`,
which truncates a path containing a SPACE, and now reads the whole field as the
sibling's copy already did; the `--delete` "re-deleting is a no-op" argument
holds only while the branch is GONE, and the one case where
`git push origin --delete <merged>` is real is deleting an ORPHAN ref this gate
warns about -- the claim is narrowed rather than the behaviour changed; the user
text's closing clause ("the agent has already been told") was true on ONE of
three downgrade paths and is now per path; and the suites gained a FLOOR on
their case totals, because emptying a `for` loop removed assertions silently
while the tally still read `fail: 0`.

**Stale counts corrected.** `.claude/rules/hooks.md` said `control-char-gate`
had 115 cases (measured 118), the main-tree block 154 (now 167), and the lane
suite 88 (now 102). The PR body's own figures were stale in the same way and are
re-derived above.
