### PR TITLE
chore(hooks): parse git's ARGV in main-tree-branch-gate, closing five bypasses and four regressions

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -652,20 +652,273 @@ gate_tokens() {
   [ -z "${rest//[[:space:]]/}" ]
 }
 
+# gate_word_is_literal <word>
+#
+# 0 when this shell WORD provably reaches the command as exactly the text it
+# already carries; 1 when it does not, OR when this function cannot prove that
+# it does. It is the SHELL-side twin of `main-tree-branch-gate.sh`'s "AN
+# INCOMPLETE PARSE MAY NOT ALLOW": that gate refuses to relax a verdict on a GIT
+# OPTION it cannot resolve, and this refuses to hand it a WORD whose expansion
+# it cannot see.
+#
+# THE DEFAULT IS INVERTED, and that is the whole of this function. `gate_argv`
+# below used to ENUMERATE the words the shell owns -- a redirection, a trailing
+# `&`, a `#` comment -- and pass everything else through as an argument. Three
+# rounds of fixes each added another spelling to that list, and each time the
+# next round found the spelling still missing. Measured, in all three repos,
+# with a branch that exists locally and the payload cwd set to the main tree:
+#
+#   git checkout <branch> $EMPTY            rc=0, want 2   HEAD MOVED
+#   git checkout <branch> ${EMPTY}          rc=0, want 2   HEAD MOVED
+#   git checkout <branch> {fd}>/dev/null    rc=0, want 2   HEAD MOVED
+#   git checkout <branch> {fd}<f.txt        rc=0, want 2   HEAD MOVED
+#
+# An empty expansion VANISHES, so the gate counted a positional git never
+# receives; bash's fd-variable redirection is a word git never receives at all.
+# Both turned `git checkout <branch> <word>` into a two-positional FILE RESTORE
+# and PASSED a command that really moves HEAD.
+#
+# So the question here is not "is this word one of the shell forms I know?" but
+# "is every character in it one I can prove the shell leaves alone?".
+#
+# HOW A SHAPE NOBODY HAS THOUGHT OF LANDS ON REFUSE. Every shell construct is
+# SPELLED, and spelled with characters. `GATE_INERT_CHARS` is a CLOSED list of
+# characters that trigger no shell processing at all, so a construct built from
+# anything else -- a syntax added to a future bash, one this file's author never
+# met, one nobody has written down -- necessarily contains a character outside
+# that list, and is refused without anyone having had to think of it. The only
+# way a new construct could pass is by being spelled ENTIRELY in inert
+# characters, which is a contradiction in terms: an inert character is one the
+# shell does not act on. The list, not the construct catalogue, is therefore the
+# thing to audit, and every member carries the reason it is inert.
+#
+# THE INERT SET, one character at a time. `A-Z a-z 0-9` need no argument.
+#
+#   _ - . / :   no shell meaning in any position. A leading `-` only makes the
+#               word look like a flag, which is git's business, not the shell's.
+#   @ +         special only as the extglob prefixes `@(...)` / `+(...)`, which
+#               need `(`, and `(` is NOT inert.
+#   ^           special only inside a `[^...]` bracket expression, which needs
+#               `[`, and `[` is NOT inert. (History's `^old^new` is line-initial
+#               and interactive-only.) `HEAD^` needs it.
+#   %           special only as a JOB SPEC, and only as an argument to `jobs` /
+#               `kill` / `fg` / `bg` -- never to `git`.
+#   ,           special only inside a brace expansion, which needs `{`, and `{`
+#               is NOT inert.
+#   =           an assignment only in the COMMAND-word position, and every word
+#               asked about here is an argument, past the verb. It must be here:
+#               `--create=feat` is an ordinary long option.
+#   #           a comment only as the FIRST character of a word, which is
+#               rejected explicitly below. `has#hash` is a legal branch name and
+#               the shell passes it through untouched.
+#
+# WHAT IS DELIBERATELY OUT, so the cost is visible rather than guessed. `$` and
+# a backtick (an expansion this cannot see). `\` (an escape). `*` `?` `[` `]`
+# (pathname expansion -- and under `nullglob` a non-matching pattern expands to
+# NO words, the vanishing case again). `{` `}` (brace expansion, and the
+# fd-variable redirection prefix `{fd}>`). `~` (tilde expansion). `!` (history
+# expansion: off in a non-interactive shell, but this cannot see which shell it
+# is). Every shell METACHARACTER -- `| & ; ( ) < >` and whitespace -- which the
+# segmenter and tokenizer normally consume, so one arriving here is by
+# definition unaccounted for. Two exclusions are strictly OVER-strict: `a~b` and
+# `feat!` are literal to bash and this refuses them anyway. Over-strict means
+# BLOCK, which is the direction this gate exists to fail in.
+#
+# QUOTING IS TRACKED, because it is what makes the punctuation above reachable.
+# A word may EMBED quoted spans rather than BE one (see GATE_EMBEDDING_TOKEN),
+# so the walk carries a quote state:
+#   - inside a SINGLE-quoted span every character is literal, so nothing is
+#     refused there;
+#   - inside a DOUBLE-quoted span only `$`, a backtick and `\` stay active, so
+#     only those three are refused;
+#   - outside quotes the inert list decides.
+# That is what keeps `git checkout -b 'feat$x'` an ordinary branch creation --
+# a literal `$` in a branch name still behaves -- while an unquoted `$EMPTY` is
+# refused.
+#
+# A word whose quote is still open at the end is refused too: it cannot be split
+# into shell words at all, which is the same thing `gate_tokens` reports.
+#
+# WHAT THIS DOES NOT DECIDE: whether the word is an ARGUMENT. A redirection is
+# spelled with `>` and would be refused here, yet it is perfectly accounted for
+# -- `gate_argv` recognises it and drops it BEFORE asking this. Recognising a
+# shell construct positively and proving a word literal are two different jobs,
+# and only the second one has to fail closed.
+GATE_INERT_CHARS='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-./:@+%,^=#'
+# The same set as a GLOB CLASS, so a whole SPAN is decided in one operation
+# rather than one character at a time. That is not a micro-optimisation: a hook
+# runs on EVERY Bash tool call, and a per-character walk here is quadratic,
+# because `${s:i:1}` in a UTF-8 locale walks to offset `i` every time. Measured
+# on this machine (bash 5.3.9, en_US.UTF-8), an index-only loop over a string:
+# 1 000 chars 0.010 s, 4 000 chars 0.043 s, 16 000 chars 0.478 s -- 16x the
+# input for 48x the time. The chunked form below is 0.032 s at 16 000.
+#
+# `-` is LAST and `^` is not first, which is what keeps both LITERAL inside a
+# bracket expression; `!` negates.
+GATE_NOT_INERT_GLOB='*[!A-Za-z0-9_./:@+%,^=#-]*'
+# Active inside a DOUBLE-quoted span: an expansion, a command substitution, an
+# escape. Written with `$'...'` so the backslash and the backtick survive.
+GATE_DQ_ACTIVE_GLOB=$'*[\\\\$\140]*'
+GATE_QUOTE_CLASS=$'["\047]'
+GATE_SQ=$'\047'
+# The characters that end a scanning chunk. `$'[\\\\"\047#]'` yields `[\\"'#]`,
+# and that doubling is load-bearing: `[\"'#]` does NOT contain a backslash --
+# there the backslash escapes the quote and the class silently loses it.
+# Verified in BOTH bash 3.2.57 and 5.3.9 against `ab\cd`, `ab"cd`, `ab'cd`,
+# `abc#d` and `abcd`.
+GATE_CHUNK_STOP=$'[\\\\"\047#]'
+GATE_CHUNK_STOP_DQ=$'[\\\\"]'
+
+gate_word_is_literal() {
+  local w="$1" rest="$1" chunk q=""
+  [ -n "$w" ] || return 1
+  # A word STARTING with `#` opens a comment: the shell discards it and every
+  # word after it, so it reaches the command as nothing at all.
+  case "$w" in '#'*) return 1 ;; esac
+  # The walk advances by SPANS, not characters: everything up to the next quote
+  # character is tested with one glob, so the number of iterations is the number
+  # of quote characters in the word rather than its length.
+  while [ -n "$rest" ]; do
+    if [ -z "$q" ]; then
+      chunk="${rest%%$GATE_QUOTE_CLASS*}"
+      case "$chunk" in $GATE_NOT_INERT_GLOB) return 1 ;; esac
+      [ "$chunk" = "$rest" ] && break
+      rest="${rest#"$chunk"}"
+      q="${rest%"${rest#?}"}"
+      rest="${rest#?}"
+    elif [ "$q" = "$GATE_SQ" ]; then
+      # Inside a SINGLE-quoted span every character is literal, so there is
+      # nothing to test -- only the closer to find.
+      chunk="${rest%%$GATE_SQ*}"
+      [ "$chunk" = "$rest" ] && break
+      rest="${rest#"$chunk"}"
+      rest="${rest#?}"
+      q=""
+    else
+      chunk="${rest%%\"*}"
+      case "$chunk" in $GATE_DQ_ACTIVE_GLOB) return 1 ;; esac
+      [ "$chunk" = "$rest" ] && break
+      rest="${rest#"$chunk"}"
+      rest="${rest#?}"
+      q=""
+    fi
+  done
+  # A quote still open means the word cannot be split into shell words at all.
+  [ -z "$q" ]
+}
+
+# gate_strip_comment <text>
+#
+# <text> truncated at the first `#` that opens a shell COMMENT -- one at a WORD
+# START (the beginning of the text, or after a space or tab) and outside any
+# quoted span. Prints the text unchanged when there is none.
+#
+# WHY IT RUNS BEFORE THE SPLIT, which is the bug it fixes. `gate_argv` used to
+# ask `gate_tokens` to split the WHOLE text and refuse on an unbalanced quote,
+# then drop the comment inside the walk. An apostrophe INSIDE the comment is
+# therefore weighed as a quote, so
+#
+#   git checkout main # don't switch lanes
+#
+# came back as a truncation and the gate blocked it -- measured rc=2 against a
+# command that leaves HEAD exactly where it was ("Already on 'main'"). The
+# comment justifying that order claimed "the text is a shell syntax error in the
+# first place, so nothing legitimate is lost". That claim is FALSE and is not
+# repeated: `bash -n "git checkout main # don't switch lanes"` reports VALID
+# syntax, because the apostrophe is inside a comment and bash never sees it as a
+# quote either. Cutting the comment first makes this file agree with the shell.
+#
+# The unbalanced-quote refusal it is often confused with survives untouched:
+# `-b agent's-branch` has no comment to cut, so the text reaches `gate_tokens`
+# whole and is still refused.
+#
+# THE SECOND PASS is `gate_segments_raw`'s `ignore_q` trick, for the same reason
+# and with the same shape. If the first walk reaches the end with a quote still
+# open, that character may not have been a quote at all, so the walk is redone
+# with it literal and a comment is looked for again. `'unbalanced # x` then cuts
+# to `'unbalanced `, which `gate_tokens` still refuses -- correctly: bash calls
+# that one "unexpected EOF while looking for matching `''".
+GATE_COMMENT_CUT=""
+GATE_COMMENT_OPENQ=""
+_gate_comment_cut() {
+  local s="$1" iq="$2" rest="$1" pos=0 chunk c q="" prev=" "
+  GATE_COMMENT_CUT="$s"
+  GATE_COMMENT_OPENQ=""
+  # A text with NO `#` anywhere can carry no comment, and that is the shape
+  # essentially every command has. Returning here keeps the walk below off the
+  # hot path entirely -- measured, 16 000 characters go from 0.92 s to 0.002 s.
+  case "$s" in *'#'*) ;; *) return 0 ;; esac
+  # SPANS, not characters, for the reason recorded on GATE_NOT_INERT_GLOB above:
+  # a per-character walk is quadratic here. Each iteration jumps to the next
+  # quote / backslash / `#`, so the iteration count is the number of those
+  # characters rather than the length of the text. Only the CUT OFFSET is
+  # tracked; the text is sliced once, at the end.
+  while [ -n "$rest" ]; do
+    if [ -z "$q" ]; then
+      chunk="${rest%%$GATE_CHUNK_STOP*}"
+    elif [ "$q" = "$GATE_SQ" ]; then
+      chunk="${rest%%$GATE_SQ*}"
+    else
+      chunk="${rest%%$GATE_CHUNK_STOP_DQ*}"
+    fi
+    [ "$chunk" = "$rest" ] && break
+    if [ -n "$chunk" ]; then
+      prev="${chunk#"${chunk%?}"}"
+      pos=$((pos + ${#chunk}))
+      rest="${rest#"$chunk"}"
+    fi
+    c="${rest%"${rest#?}"}"
+    if [ -z "$q" ]; then
+      case "$c" in
+        # An escaped character outside quotes is LITERAL, `\#` included. The
+        # slice is `${rest:2}` rather than `${rest#??}`: with ONE character left
+        # the `##` form matches nothing, leaves `rest` unchanged, and the loop
+        # never terminates.
+        '\') pos=$((pos + 2)); rest="${rest:2}"; prev=x; continue ;;
+        '#') case "$prev" in
+               ' '|'	') GATE_COMMENT_CUT="${s:0:pos}"; return 0 ;;
+             esac ;;
+        '"') [ "$c" = "$iq" ] || q="$c" ;;
+        *) [ "$c" = "$GATE_SQ" ] && { [ "$c" = "$iq" ] || q="$c"; } ;;
+      esac
+    else
+      if [ "$c" = '\' ] && [ "$q" = '"' ]; then
+        pos=$((pos + 2)); rest="${rest:2}"; prev=x; continue
+      fi
+      [ "$c" = "$q" ] && q=""
+    fi
+    prev="$c"
+    pos=$((pos + 1))
+    rest="${rest#?}"
+  done
+  GATE_COMMENT_CUT="$s"
+  GATE_COMMENT_OPENQ="$q"
+  [ -z "$q" ]
+}
+
+gate_strip_comment() {
+  if _gate_comment_cut "$1" ""; then
+    printf '%s' "$GATE_COMMENT_CUT"
+    return 0
+  fi
+  _gate_comment_cut "$1" "$GATE_COMMENT_OPENQ"
+  printf '%s' "$GATE_COMMENT_CUT"
+  return 0
+}
+
 # gate_argv <text>
 #
 # The ARGV a shell would hand the command, one token per line: the SHELL's own
-# words are dropped -- a redirection and, when it is not glued, its target; a
-# trailing `&`; and everything from a comment `#` onwards. Returns 1 having
-# printed nothing when the text cannot be split into words at all (the
-# `gate_tokens` truncation above), so a caller can refuse rather than parse a
-# fragment.
+# words are dropped -- a comment and everything after it, a redirection and,
+# when it is not glued, its target. Returns 1 having printed nothing when the
+# text cannot be split into words at all (the `gate_tokens` truncation), so a
+# caller can refuse rather than parse a fragment.
 #
 # WHY THIS IS A SEPARATE FUNCTION FROM `gate_tokens`, and why an option parse
 # must call THIS one. A gate that reads an option grammar is reading ARGV -- the
 # vector the command itself receives -- and a shell WORD is not an ARGUMENT.
-# `2>/dev/null`, `>`, `/dev/null`, `&` and `# switch lane` are all words, and
-# git never sees any of them. Measured against the gate that first parsed
+# `2>/dev/null`, `>`, `/dev/null` and `# switch lane` are all words, and git
+# never sees any of them. Measured against the gate that first parsed
 # `gate_tokens` output directly, with a branch that existed locally:
 #
 #   git checkout <branch> 2>/dev/null      rc=0, want 2
@@ -677,14 +930,30 @@ gate_tokens() {
 # restore. Callers that genuinely want the shell's words (a `-C` scan, a heredoc
 # probe) keep `gate_tokens`; callers that want git's argv use this.
 #
+# WHAT IT DOES NOT PROMISE, stated because an earlier revision's silence here is
+# the defect round 4 fixed: a line printed by this function is a shell WORD that
+# is not a redirection and not a comment. It is NOT a promise that the word
+# reaches the command as the text printed. `$EMPTY` is printed and reaches the
+# command as NOTHING; `{fd}>/dev/null` is printed and reaches it as nothing
+# either. A caller that COUNTS these words, or compares one against a name, must
+# put every word through `gate_word_is_literal` and refuse to relax its verdict
+# on a word that fails -- which is exactly what `main-tree-branch-gate.sh` does
+# with `parse_certain`. Enumerating more shell forms HERE is the losing move; it
+# was tried three times.
+#
 # The comment strip is deliberately NOT in `gate_segments`: that splitter feeds
 # every gate in this library, and widening it is a change to all of them. Here
 # the effect is bounded to callers that asked for argv.
 GATE_REDIR_TOKEN='^([0-9]*(>>|>[|]|>&|>|<<<|<<-|<<|<&|<)|&>>|&>)(.*)$'
 
 gate_argv() {
-  local words tok want_target=0
-  words=$(gate_tokens "$1") || return 1
+  local words tok want_target=0 text
+  # The comment goes FIRST, before the split, so an apostrophe inside one is
+  # never weighed as a quote (see `gate_strip_comment`). That also makes the
+  # in-loop `'#'*` arm this function used to carry unreachable, so it is gone
+  # rather than left as a second spelling of the same rule.
+  text=$(gate_strip_comment "$1")
+  words=$(gate_tokens "$text") || return 1
   while IFS= read -r tok; do
     # `gate_tokens` never emits an empty token (its pattern needs one character
     # at least), so the single blank line a `printf` of empty output produces is
@@ -692,16 +961,19 @@ gate_argv() {
     [ -n "$tok" ] || continue
     if [ "$want_target" -eq 1 ]; then
       # The spaced target of the redirection operator just seen (`> /dev/null`).
+      # It is dropped WITHOUT asking `gate_word_is_literal`, deliberately: a
+      # redirection target is never an argument whatever it expands to. An empty
+      # expansion there makes bash refuse the command outright ("ambiguous
+      # redirect"), and a multi-word one is the same error -- neither can put a
+      # word into argv.
       want_target=0
       continue
     fi
-    case "$tok" in
-      # A word STARTING with `#` opens a comment, and the shell discards the
-      # rest of the line. Quoting protects a real argument: the token still
-      # carries its quotes here, so `'#branch'` starts with `'` and survives.
-      '#'*) return 0 ;;
-      '&') continue ;;
-    esac
+    # A bare `&`. On the GATE's path this is dead -- `gate_segments_raw` has
+    # already split on it -- and it is kept because a DIRECT caller (this
+    # library's own suite, a future gate parsing a raw fragment) still meets it.
+    # Labelled rather than removed so the next reader does not re-derive that.
+    [ "$tok" = '&' ] && continue
     if [[ "$tok" =~ $GATE_REDIR_TOKEN ]]; then
       # `2>&1` and `>/dev/null` carry their target GLUED; a bare `>` or `2>`
       # takes the next word as its target.

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -615,6 +615,34 @@ gate_unquote() {
   printf '%s' "$p"
 }
 
+# gate_tokens <text>
+#
+# One shell token per line, with a QUOTED span kept WHOLE: `switch "my branch"`
+# yields two tokens, not three. Callers unquote with `gate_unquote` when they
+# want the bare value.
+#
+# It exists so a gate that must PARSE an argument list does not have to match
+# `GATE_EMBEDDING_TOKEN` itself. Matching it in a hook is the go-to-k/cdkd#2200
+# coupling: the hook reads a positional `${BASH_REMATCH[N]}` out of a pattern
+# built from a SHARED constant, so widening that constant shifts the index and
+# silently re-opens the gate. `unresolved-target-class.test.sh` fence 4 refuses
+# that shape by name; the sanctioned answer is to pass the pattern to a helper,
+# which is this. `gate_verb_rest` gives the same guarantee for the verb prefix.
+#
+# No `set -f` dance around the loop, unlike `gate_pr_selector`'s: that function
+# feeds its tokens to `set --`, which word-splits and globs. This one only ever
+# prints `"${BASH_REMATCH[1]}"`, and `[[ =~ ]]` does not glob, so a stray `*` in
+# the text has nothing to expand against.
+gate_tokens() {
+  local rest="$1"
+  while [[ "$rest" =~ ^[[:space:]]*$GATE_EMBEDDING_TOKEN([[:space:]]+(.*))?$ ]]; do
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    rest="${BASH_REMATCH[4]}"
+    [ -n "$rest" ] || break
+  done
+  return 0
+}
+
 # gate_verb_args <cmd> <verb-ere>
 #
 # Print, one line per matching segment, the text that FOLLOWS the matched verb

--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -640,8 +640,82 @@ gate_tokens() {
     rest="${BASH_REMATCH[4]}"
     [ -n "$rest" ] || break
   done
+  # TRUNCATION IS REPORTED, not swallowed. An UNBALANCED quote cannot be split
+  # into words at all: `"[^"]*"` needs its closing quote and the bare-run
+  # alternative excludes quote characters, so the pattern stops dead at the
+  # opening one. Measured before this line existed: `gate_tokens "a'unbalanced"`
+  # printed NOTHING and returned 0, and `gate_tokens "-b agent's-branch"`
+  # printed only `-b` -- so a caller parsing an option grammar saw a command
+  # with no arguments and allowed it. Silence is the one answer that is wrong
+  # here; a caller can now refuse, or fall back to a coarser scan, but it can no
+  # longer mistake a truncation for a short command line.
+  [ -z "${rest//[[:space:]]/}" ]
+}
+
+# gate_argv <text>
+#
+# The ARGV a shell would hand the command, one token per line: the SHELL's own
+# words are dropped -- a redirection and, when it is not glued, its target; a
+# trailing `&`; and everything from a comment `#` onwards. Returns 1 having
+# printed nothing when the text cannot be split into words at all (the
+# `gate_tokens` truncation above), so a caller can refuse rather than parse a
+# fragment.
+#
+# WHY THIS IS A SEPARATE FUNCTION FROM `gate_tokens`, and why an option parse
+# must call THIS one. A gate that reads an option grammar is reading ARGV -- the
+# vector the command itself receives -- and a shell WORD is not an ARGUMENT.
+# `2>/dev/null`, `>`, `/dev/null`, `&` and `# switch lane` are all words, and
+# git never sees any of them. Measured against the gate that first parsed
+# `gate_tokens` output directly, with a branch that existed locally:
+#
+#   git checkout <branch> 2>/dev/null      rc=0, want 2
+#   git checkout <branch> >/dev/null 2>&1  rc=0, want 2
+#   git checkout <branch> # switch lane    rc=0, want 2
+#
+# -- every one a command that really moves HEAD, waved through because the extra
+# WORDS were counted as extra ARGUMENTS and the command therefore read as a file
+# restore. Callers that genuinely want the shell's words (a `-C` scan, a heredoc
+# probe) keep `gate_tokens`; callers that want git's argv use this.
+#
+# The comment strip is deliberately NOT in `gate_segments`: that splitter feeds
+# every gate in this library, and widening it is a change to all of them. Here
+# the effect is bounded to callers that asked for argv.
+GATE_REDIR_TOKEN='^([0-9]*(>>|>[|]|>&|>|<<<|<<-|<<|<&|<)|&>>|&>)(.*)$'
+
+gate_argv() {
+  local words tok want_target=0
+  words=$(gate_tokens "$1") || return 1
+  while IFS= read -r tok; do
+    # `gate_tokens` never emits an empty token (its pattern needs one character
+    # at least), so the single blank line a `printf` of empty output produces is
+    # the only thing this skips.
+    [ -n "$tok" ] || continue
+    if [ "$want_target" -eq 1 ]; then
+      # The spaced target of the redirection operator just seen (`> /dev/null`).
+      want_target=0
+      continue
+    fi
+    case "$tok" in
+      # A word STARTING with `#` opens a comment, and the shell discards the
+      # rest of the line. Quoting protects a real argument: the token still
+      # carries its quotes here, so `'#branch'` starts with `'` and survives.
+      '#'*) return 0 ;;
+      '&') continue ;;
+    esac
+    if [[ "$tok" =~ $GATE_REDIR_TOKEN ]]; then
+      # `2>&1` and `>/dev/null` carry their target GLUED; a bare `>` or `2>`
+      # takes the next word as its target.
+      [ -n "${BASH_REMATCH[3]}" ] || want_target=1
+      continue
+    fi
+    printf '%s\n' "$tok"
+  done <<EOF
+$words
+EOF
   return 0
 }
+
+
 
 # gate_verb_args <cmd> <verb-ere>
 #

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -977,7 +977,118 @@ argv_case "a token spelling the heredoc delimiter survives" " EOF -- x" "$(print
 # reads `fail: 0`. No suite in this repo had one, so the only thing standing
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
-CASE_FLOOR=396
+# --- gate_word_is_literal -------------------------------------------------------
+#
+# The INVERTED default. `gate_argv` above splits words; this answers whether a
+# word reaches the command as the text it carries, and it answers NO by default.
+# Three rounds of `main-tree-branch-gate` fixes each taught the stripper one more
+# shell form and each time the next round found the form still missing -- last
+# `$EMPTY` (an empty expansion VANISHES, so the gate counted a positional git
+# never receives) and `{fd}>/dev/null` (bash's fd-variable redirection, a word
+# git never receives at all). Both turned a real branch switch into a two-
+# positional file restore and PASSED.
+#
+# The cases below are therefore in two halves, and the SECOND half is what makes
+# the first mean anything: if the inert list quietly shrank, the refusals would
+# all still pass while every ordinary command started blocking.
+lit_case() { # name, word, want-rc
+  local name="$1" word="$2" wantrc="$3" gotrc
+  gate_word_is_literal "$word"; gotrc=$?
+  if [ "$gotrc" = "$wantrc" ]; then
+    pass=$((pass + 1)); printf 'OK   gate_word_is_literal: %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL gate_word_is_literal: %s\n  word: [%s]\n  want rc=%s got rc=%s\n' \
+      "$name" "$word" "$wantrc" "$gotrc"
+  fi
+}
+# REFUSED -- every one of these is a word the shell may rewrite or remove.
+lit_case "an unquoted \$ expansion is refused" '$EMPTY' 1
+lit_case "a braced \$ expansion is refused" '${EMPTY}' 1
+lit_case "a \$ inside DOUBLE quotes is still refused" '"$f"' 1
+lit_case "a backtick substitution is refused" '`date`' 1
+lit_case "a backslash escape is refused" 'a\b' 1
+lit_case "the fd-variable redirection prefix is refused" '{fd}>/dev/null' 1
+lit_case "a brace word is refused" '{a,b}' 1
+lit_case "a glob star is refused" '*.ts' 1
+lit_case "a glob question mark is refused" 'a?b' 1
+lit_case "a bracket expression is refused" 'a[bc]' 1
+lit_case "a leading tilde is refused" '~/x' 1
+lit_case "a history bang is refused" 'a!b' 1
+lit_case "a metacharacter that reached here is refused" 'a;b' 1
+lit_case "a pipe is refused" 'a|b' 1
+lit_case "a redirection character is refused" '>x' 1
+lit_case "a subshell paren is refused" '(x)' 1
+lit_case "a leading # is refused (it opens a comment)" '#branch' 1
+lit_case "an unbalanced quote is refused" "'open" 1
+lit_case "the empty word is refused" '' 1
+# ADMITTED -- the other half. Each of these is an ordinary git argument, and the
+# gate's ALLOW arms are unreachable without them.
+lit_case "a plain name is literal" 'feat' 0
+lit_case "a slashed, dotted, dashed name is literal" 'feat/x-1.2' 0
+lit_case "a glued long-option value is literal" '--create=feat' 0
+lit_case "a caret revision is literal" 'HEAD^' 0
+lit_case "a # INSIDE a word is literal" 'has#hash' 0
+lit_case "a comma is literal without a brace" 'a,b' 0
+lit_case "a colon and an at-sign are literal" 'a:b@c' 0
+lit_case "a plus and a percent are literal" 'a+b%c' 0
+lit_case "a SINGLE-quoted \$ is literal" "'feat\$x'" 0
+lit_case "a single-quoted space is literal" "'my branch'" 0
+lit_case "a DOUBLE-quoted plain word is literal" '"main"' 0
+lit_case "an embedded quoted span is literal" 'core.pager="less"' 0
+
+# --- gate_strip_comment ---------------------------------------------------------
+#
+# The cut happens BEFORE the split, which is the whole fix: an apostrophe inside
+# a comment used to be weighed as a quote, so `git checkout main # don't switch
+# lanes` came back a truncation and the gate blocked a command bash calls valid
+# and git answers with "Already on 'main'".
+cut_case() { # name, text, want
+  local name="$1" text="$2" want="$3" got
+  got=$(gate_strip_comment "$text")
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   gate_strip_comment: %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL gate_strip_comment: %s\n  text: [%s]\n  want: [%s]\n  got : [%s]\n' \
+      "$name" "$text" "$want" "$got"
+  fi
+}
+cut_case "a comment is cut at the word start" 'main # switch lane' 'main '
+cut_case "an APOSTROPHE inside the comment does not poison it" \
+  "main # don't switch lanes" 'main '
+cut_case "a # mid-word is not a comment" 'feat#1' 'feat#1'
+cut_case "a # inside a quoted span is not a comment" "main -- 'a#b'" "main -- 'a#b'"
+# The DISCRIMINATING half of that pair: with a SPACE before it, the `#` sits at
+# what would be a word start if the quotes were not tracked, so a cut here is
+# exactly what dropping the quote state produces. The case above cannot see
+# that -- its `#` is preceded by `a` either way.
+cut_case "a # at a word start INSIDE quotes is still not a comment" \
+  "main -- 'a #b' tail" "main -- 'a #b' tail"
+cut_case "an escaped # is not a comment" 'main \# x' 'main \# x'
+cut_case "text with no comment is unchanged" '-b feat' '-b feat'
+# The SECOND PASS, the `ignore_q` trick `gate_segments_raw` already uses: the
+# leading `'` never closes, so on the retry it is treated as literal and the
+# comment is found. The result is still unsplittable, and `gate_argv` still
+# refuses it -- correctly, since bash calls that text a syntax error.
+cut_case "an unclosed quote is retried with the quote literal" \
+  "'unbalanced # x" "'unbalanced "
+
+# --- gate_argv: round 4 ---------------------------------------------------------
+argv_case "a comment carrying an apostrophe no longer truncates" \
+  " main # don't switch lanes" "main"
+# SPACED redirection operators. Each of these drops BOTH words; dropping an
+# operator from GATE_REDIR_TOKEN makes the operator itself read as an argument,
+# which is the FAIL-OPEN direction (an extra positional relaxes the gate's
+# verdict to "file restore").
+argv_case "a spaced append redirection drops its target" " feat 2>> log" "feat"
+argv_case "a spaced clobber redirection drops its target" " feat >| out" "feat"
+argv_case "a spaced dup-out redirection drops its target" " feat >& out" "feat"
+argv_case "a spaced dup-in redirection drops its target" " feat <& 3" "feat"
+argv_case "a spaced &> redirection drops its target" " feat &> out" "feat"
+argv_case "a spaced &>> redirection drops its target" " feat &>> out" "feat"
+
+CASE_FLOOR=442
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -919,12 +919,65 @@ tok_case "an unquoted glob is not expanded" " *" "*"
 tok_case "runs of spaces collapse" " a     b" "$(printf -- 'a\nb')"
 
 
+# --- gate_argv ------------------------------------------------------------------
+#
+# `gate_tokens` splits SHELL WORDS; this splits git's ARGV, which is what an
+# option parse actually reads. The difference is not cosmetic: a redirection, its
+# spaced target, a trailing `&` and a `#` comment are all WORDS and none of them
+# is an ARGUMENT, and counting them as arguments is what made
+# `git checkout <branch> 2>/dev/null` read as a two-positional file restore and
+# PASS through main-tree-branch-gate (measured rc=0, want 2, on a command that
+# really moves HEAD).
+argv_case() { # name, text, expected newline-joined argv, expected rc
+  local name="$1" text="$2" want="$3" wantrc="${4:-0}" got gotrc
+  got=$(gate_argv "$text"); gotrc=$?
+  if [ "$got" = "$want" ] && [ "$gotrc" = "$wantrc" ]; then
+    pass=$((pass + 1)); printf 'OK   gate_argv: %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL gate_argv: %s\n  text: [%s]\n  want: [%s] rc=%s\n  got : [%s] rc=%s\n' \
+      "$name" "$text" "$want" "$wantrc" "$got" "$gotrc"
+  fi
+}
+argv_case "plain words are argv unchanged" " -b feat" "$(printf -- '-b\nfeat')"
+argv_case "a glued redirection is dropped" " feat 2>/dev/null" "feat"
+argv_case "two glued redirections are dropped" " feat >/dev/null 2>&1" "feat"
+argv_case "an append redirection is dropped" " feat 2>>log" "feat"
+argv_case "a SPACED redirection drops its target too" " feat > /dev/null" "feat"
+argv_case "a numbered spaced redirection drops its target" " feat 2> log" "feat"
+argv_case "an input redirection is dropped" " feat < in" "feat"
+argv_case "a trailing & is dropped" " feat &" "feat"
+argv_case "a comment ends the argv" " feat # switch lane" "feat"
+argv_case "a comment ends it even mid-list" " a # b -- c" "a"
+# The COMMENT rule keys on an UNQUOTED leading `#`. A quoted one is an argument
+# the shell passes through, and the token still carries its quotes here.
+argv_case "a QUOTED # is an argument, not a comment" " '#branch'" "'#branch'"
+argv_case "a # inside a word is not a comment" " feat#1" "feat#1"
+# CONTROLS: the things that look like the above and are NOT shell syntax.
+argv_case "a bare -- survives" " feat -- README.md" "$(printf -- 'feat\n--\nREADME.md')"
+argv_case "a digit-only word is not a redirection" " --unified 3 feat" "$(printf -- '--unified\n3\nfeat')"
+argv_case "a quoted span survives whole" ' -c "wt feat new"' "$(printf -- '-c\n"wt feat new"')"
+# An UNBALANCED quote cannot be split at all. Reporting it is the whole point:
+# `gate_tokens` used to return the prefix it managed and rc=0, so `-b
+# agent's-branch` yielded the single token `-b` and the gate read a bare
+# `git checkout`.
+argv_case "an unbalanced quote returns 1 and nothing" " -b agent's-branch" "" 1
+argv_case "an unbalanced quote at the start returns 1" " a'unbalanced" "" 1
+argv_case "empty text is not a truncation" "" "" 0
+# CONTROL, not a fence: `gate_argv` feeds its loop from a HEREDOC, and a heredoc
+# delimiter is matched in the SCRIPT text rather than in an expansion -- so a
+# token that happens to spell the delimiter cannot end the body early. Nothing
+# reddens this today; it is here so a rewrite that re-scans the value (an `eval`,
+# a here-string built from it) has a case to fail.
+argv_case "a token spelling the heredoc delimiter survives" " EOF -- x" "$(printf -- 'EOF\n--\nx')"
+
+
 # A FLOOR on the case total. Every `for` loop above expands a LIST, and emptying
 # one -- or deleting a case -- removes assertions SILENTLY while the tally still
 # reads `fail: 0`. No suite in this repo had one, so the only thing standing
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
-CASE_FLOOR=377
+CASE_FLOOR=396
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -890,12 +890,41 @@ want_lines "/fallback${TAB}origin a" "an unexpanded -C falls back, not to a lite
 
 
 
+# --- gate_tokens ---------------------------------------------------------------
+#
+# The argument-list splitter main-tree-branch-gate parses options with. It lives
+# HERE rather than in the gate because matching `GATE_EMBEDDING_TOKEN` inside a
+# hook and then reading a positional `${BASH_REMATCH[N]}` out of it is the
+# go-to-k/cdkd#2200 coupling: widening the shared constant shifts the index and
+# silently re-opens the gate. Pinned here so the gate can rely on it.
+tok_case() { # name, text, expected newline-joined tokens
+  local name="$1" text="$2" want="$3" got
+  got=$(gate_tokens "$text")
+  if [ "$got" = "$want" ]; then
+    pass=$((pass + 1)); printf 'OK   gate_tokens: %s\n' "$name"
+  else
+    fail=$((fail + 1))
+    printf 'FAIL gate_tokens: %s\n  text: [%s]\n  want: [%s]\n  got : [%s]\n' "$name" "$text" "$want" "$got"
+  fi
+}
+tok_case "plain words" " -b feat" "$(printf -- '-b\nfeat')"
+tok_case "leading and trailing space" "   feat   " "feat"
+tok_case "empty text yields nothing" "" ""
+tok_case "only whitespace yields nothing" "    " ""
+tok_case "a double-quoted span stays ONE token" ' -c "wt feat new"' "$(printf -- '-c\n"wt feat new"')"
+tok_case "a single-quoted span stays ONE token" " -c 'wt feat new'" "$(printf -- "-c\n'wt feat new'")"
+tok_case "a glued flag value is not split" " --orphan=feat" "--orphan=feat"
+tok_case "a bare -- survives as its own token" " some-feature -- README.md" "$(printf -- 'some-feature\n--\nREADME.md')"
+tok_case "an unquoted glob is not expanded" " *" "*"
+tok_case "runs of spaces collapse" " a     b" "$(printf -- 'a\nb')"
+
+
 # A FLOOR on the case total. Every `for` loop above expands a LIST, and emptying
 # one -- or deleting a case -- removes assertions SILENTLY while the tally still
 # reads `fail: 0`. No suite in this repo had one, so the only thing standing
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
-CASE_FLOOR=367
+CASE_FLOOR=377
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -288,6 +288,21 @@ git -C "$repo" worktree add -q -b wt-lane "$MT_WT" 2>/dev/null
 # bare word `HEAD`, and `git checkout HEAD` creates nothing, so a DWIM list that
 # keeps it false-blocks a read-only command.
 MT_SHA=$(git -C "$repo" rev-parse HEAD)
+# The remotes must be CONFIGURED, not merely have refs under their prefix: git
+# DWIMs `<name>` only for a remote it knows about. Measured -- with
+# `refs/remotes/ghostremote/ghost` present and no `ghostremote` remote,
+# `git checkout ghost` answers "pathspec 'ghost' did not match any file(s) known
+# to git" and HEAD stays. A URL is enough; nothing is ever fetched here.
+git -C "$repo" remote add origin https://example.invalid/origin.git
+# A remote whose NAME contains a SLASH. `git remote add a/b <url>` is accepted
+# (measured), and `deep-only` on it lands at `refs/remotes/a/b/deep-only`, which
+# a fixed `lstrip=3` renders as `b/deep-only` while git DWIMs plain `deep-only`
+# ("Switched to a new branch 'deep-only'", HEAD moved) -- a FAIL-OPEN.
+git -C "$repo" remote add a/b https://example.invalid/ab.git
+git -C "$repo" update-ref refs/remotes/a/b/deep-only "$MT_SHA"
+# A ref under a remote that is NOT configured -- what a removed remote or a hand
+# `update-ref` leaves behind. Real git does not DWIM it (see above).
+git -C "$repo" update-ref refs/remotes/ghostremote/ghost "$MT_SHA"
 git -C "$repo" update-ref refs/remotes/origin/remote-only "$MT_SHA"
 git -C "$repo" update-ref refs/remotes/origin/topic/nested-remote-only "$MT_SHA"
 git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/remote-only
@@ -452,18 +467,17 @@ run_case_msg "main-tree-branch: bundled -fb <b> names the branch" 2 main-tree-br
 # consume the branch that follows it.
 run_case "main-tree-branch: --conflict <style> <branch> blocked"       2 main-tree-branch-gate.sh 'git checkout --conflict merge feature'
 run_case "main-tree-branch: --conflict=<style> <branch> blocked"       2 main-tree-branch-gate.sh 'git checkout --conflict=merge feature'
-run_case "main-tree-branch: --pathspec-from-file <f> <branch> blocked" 2 main-tree-branch-gate.sh 'git checkout --pathspec-from-file /dev/null feature'
+# `--pathspec-from-file` is a RESTORE marker, not merely a value-taking flag, and
+# this row used to pin the opposite: the pathspecs come FROM THE FILE, so the
+# trailing token is the tree-ish to restore FROM. Measured with a real one-line
+# pathspec file -- "Updated 1 path from <sha>", HEAD stayed on `main`, for both
+# the spaced and the `=` spelling.
+run_case "main-tree-branch: --pathspec-from-file <f> <branch> is a restore" 0 main-tree-branch-gate.sh 'git checkout --pathspec-from-file /dev/null feature'
+run_case "main-tree-branch: --pathspec-from-file=<f> <branch> is a restore" 0 main-tree-branch-gate.sh 'git checkout --pathspec-from-file=/dev/null feature'
 run_case "main-tree-branch: --recurse-submodules <branch> blocked"     2 main-tree-branch-gate.sh 'git checkout --recurse-submodules feature'
 # CONTROL: consuming a flag value must not turn an ALLOWED target into a block.
 run_case "main-tree-branch: --conflict <style> main still allowed"     0 main-tree-branch-gate.sh 'git checkout --conflict merge main'
 
-# --- RESTORE MODES MUST NOT BE BLOCKED ----------------------------------------
-#
-# `-p` / `--ours` / `--theirs` restore FILES -- measured, `git checkout -p feat`
-# printed a diff and left HEAD on `main`, and `--ours` / `--theirs` printed
-# "Updated 0 paths from the index". Blocking them is the same false block as the
-# `<branch> -- <paths>` one, and it is exactly what the naive fix for the `-f`
-# defect ("any single positional after flags is a switch target") introduces.
 # --- THE CHECKOUT ERE MUST CARRY THE FLAG RUN ---------------------------------
 #
 # Every checkout case above puts the DECISIVE segment in a `git checkout ...`
@@ -499,10 +513,242 @@ run_case_msg "main-tree-branch: -c \"<name with a space>\" kept whole" 2 main-tr
 run_case_msg "main-tree-branch: switch @{-1} is the previous branch" 2 main-tree-branch-gate.sh \
   'git switch @{-1}' "previous branch"
 
+# --- RESTORE MODES MUST NOT BE BLOCKED ----------------------------------------
+#
+# `-p` / `--ours` / `--theirs` restore FILES -- measured, `git checkout -p feat`
+# printed a diff and left HEAD on `main`, and `--ours` / `--theirs` are refused
+# outright without paths. Blocking them is the same false block as the
+# `<branch> -- <paths>` one, and it is exactly what the naive fix for the `-f`
+# defect ("any single positional after flags is a switch target") introduces.
+# The header used to sit ~40 lines above with no cases under it at all.
+#
+# The PATHSPEC in the last four is a real LOCAL BRANCH NAME on purpose. With
+# `README.md` the `--ours` / `--theirs` rows were vacuous -- deleting them from
+# the restore list left the suite green, because `README.md` resolves to no
+# branch and the command passed on the ordinary "not a branch" arm.
 run_case "main-tree-branch: checkout -p <branch> is a restore"         0 main-tree-branch-gate.sh 'git checkout -p feature'
 run_case "main-tree-branch: checkout --patch <branch> is a restore"    0 main-tree-branch-gate.sh 'git checkout --patch feature'
-run_case "main-tree-branch: checkout --ours <path>"                    0 main-tree-branch-gate.sh 'git checkout --ours README.md'
-run_case "main-tree-branch: checkout --theirs <path>"                  0 main-tree-branch-gate.sh 'git checkout --theirs README.md'
+run_case "main-tree-branch: checkout --ours <branch-named path>"       0 main-tree-branch-gate.sh 'git checkout --ours feature'
+run_case "main-tree-branch: checkout --theirs <branch-named path>"     0 main-tree-branch-gate.sh 'git checkout --theirs feature'
+run_case "main-tree-branch: checkout -2 <branch-named path>"           0 main-tree-branch-gate.sh 'git checkout -2 feature'
+run_case "main-tree-branch: checkout -3 <branch-named path>"           0 main-tree-branch-gate.sh 'git checkout -3 feature'
+
+# --- SHELL WORDS ARE NOT ARGUMENTS --------------------------------------------
+#
+# `gate_tokens` splits SHELL WORDS, and a redirection, a trailing `&` and a `#`
+# comment are all words the SHELL owns -- git never sees any of them. Feeding
+# them to an option parse inflated the positional count and read a real switch as
+# a file restore. Every command below moves HEAD for real (measured against git
+# 2.53.0 with HEAD printed before and after: `main` -> `feature`, and
+# `main` -> `other` for the `-` one), and the first three were scored rc=0 by the
+# gate while its own `origin/main` predecessor scored them 2 -- a REGRESSION.
+run_case "git checkout <branch> 2>/dev/null blocked" 2 main-tree-branch-gate.sh \
+  'git checkout feature 2>/dev/null'
+run_case "git checkout <branch> >/dev/null 2>&1 blocked" 2 main-tree-branch-gate.sh \
+  'git checkout feature >/dev/null 2>&1'
+run_case "git checkout <branch> # <comment> blocked" 2 main-tree-branch-gate.sh \
+  'git checkout feature # switch lane'
+run_case "git checkout -q <branch> 2>&1 blocked" 2 main-tree-branch-gate.sh \
+  'git checkout -q feature 2>&1'
+run_case "git checkout - 2>/dev/null blocked" 2 main-tree-branch-gate.sh \
+  'git checkout - 2>/dev/null'
+# The SPACED redirection target is a separate word and must be dropped WITH its
+# operator; dropping only the `>` leaves `/dev/null` as a phantom pathspec.
+run_case "git checkout <branch> > /dev/null (spaced target) blocked" 2 main-tree-branch-gate.sh \
+  'git checkout feature > /dev/null'
+run_case "git checkout <branch> 2>>log blocked" 2 main-tree-branch-gate.sh \
+  'git checkout feature 2>>log'
+# CONTROL, and it is what stops "drop every word after the first positional":
+# a real restore beside a redirection must STILL pass.
+run_case "git checkout <branch> -- <path> 2>/dev/null still allowed" 0 main-tree-branch-gate.sh \
+  'git checkout feature -- README.md 2>/dev/null'
+run_case "git checkout <branch> <path> # <comment> still allowed" 0 main-tree-branch-gate.sh \
+  'git checkout feature README.md # restore one file'
+# A QUOTED `#` is an argument, not a comment, so a branch name that starts with
+# one must still be judged rather than swallowed.
+run_case "git checkout '#not-a-comment' allowed (quoted # is an argument)" 0 main-tree-branch-gate.sh \
+  "git checkout '#not-a-comment'"
+
+# --- A `--` WITH NOTHING AFTER IT IS NOT A PATHSPEC ---------------------------
+#
+# Measured: `git checkout feature --` prints "Switched to branch
+# 'feature'" and HEAD moves, while `git checkout feature -- f.txt`
+# updates the file and HEAD stays. So the rule is "a pathspec OPERAND exists",
+# not "a `--` was seen" -- the reading that shipped one fix earlier.
+run_case "git checkout <branch> -- (nothing after) blocked" 2 main-tree-branch-gate.sh \
+  'git checkout feature --'
+run_case "git checkout main -- (nothing after) allowed" 0 main-tree-branch-gate.sh \
+  'git checkout main --'
+run_case "git checkout -- (no positional at all) allowed" 0 main-tree-branch-gate.sh \
+  'git checkout --'
+# `git switch` has NO pathspec form (`usage: git switch [<options>] [<branch>]`),
+# so `--` there only ends the options. Measured: `git switch -- main` prints
+# "Already on 'main'" and `git switch -- feature` switches. Applying
+# checkout's grammar to both verbs made the first a FALSE BLOCK ("no resolvable
+# target") in all three repos, including the `origin/main` predecessor.
+run_case "git switch -- main allowed (switch has no pathspec form)" 0 main-tree-branch-gate.sh \
+  'git switch -- main'
+run_case "git switch -- <feature> blocked (it really switches)" 2 main-tree-branch-gate.sh \
+  'git switch -- feature'
+
+# --- GIT ACCEPTS UNAMBIGUOUS PREFIXES OF A LONG NAME --------------------------
+#
+# `git checkout -h` does not show it, but git's parse-options resolves any
+# unambiguous prefix. Measured: `--orph newb` and `--or newb` both print
+# "Switched to a new branch 'newb'"; `--trac origin/remote-only` creates local
+# `remote-only`; `git switch --creat newb` creates `newb`. All four scored rc=0
+# against the gate before the option table carried the whole grammar.
+run_case_msg "git checkout --orph <b> blocked (prefix of --orphan)" 2 main-tree-branch-gate.sh \
+  'git checkout --orph newb' "creates new feature branch 'newb'"
+run_case_msg "git checkout --or <b> blocked (shortest unambiguous prefix)" 2 main-tree-branch-gate.sh \
+  'git checkout --or newb' "creates new feature branch 'newb'"
+run_case_msg "git checkout --trac <remote-ref> blocked (prefix of --track)" 2 main-tree-branch-gate.sh \
+  'git checkout --trac origin/remote-only' "creates new feature branch 'remote-only'"
+run_case_msg "git switch --creat <b> blocked (prefix of --create)" 2 main-tree-branch-gate.sh \
+  'git switch --creat newb' "creates new feature branch 'newb'"
+# The prefix table has to work in the ALLOW direction too, or it is only a
+# fail-closed accident: both of these resolve to a restore / a no-DWIM read and
+# must pass. Without prefix resolution they would be unknown options and block.
+run_case "git checkout --pathspec-from-f <f> <branch> allowed (prefix, restore)" 0 main-tree-branch-gate.sh \
+  'git checkout --pathspec-from-f /dev/null feature'
+run_case "git checkout --no-gu <remote-only> allowed (prefix of --no-guess)" 0 main-tree-branch-gate.sh \
+  'git checkout --no-gu remote-only'
+
+# --- AN OPTION THE GRAMMAR CANNOT RESOLVE MAY NOT ALLOW -----------------------
+#
+# The general form of the two defects a positional COUNT produced: an unmodelled
+# flag moves every positional after it, so the walk does not know where the
+# switch target is. Every ALLOWING arm depends on that knowledge and the blocking
+# arms do not, so an unresolved option blocks. Today it fires only on commands
+# git itself refuses -- measured, `--creat` under checkout is "error: unknown
+# option `creat'" and `--pat` is "error: ambiguous option: pat" -- so it costs
+# nothing now; it is what keeps a FUTURE git option from re-opening the hole.
+run_case_msg "git checkout --frobnicate main blocked (unknown long option)" 2 main-tree-branch-gate.sh \
+  'git checkout --frobnicate main' "cannot resolve"
+run_case_msg "git checkout --pat main blocked (AMBIGUOUS prefix)" 2 main-tree-branch-gate.sh \
+  'git checkout --pat main' "cannot resolve"
+run_case_msg "git checkout -Z main blocked (unknown short letter)" 2 main-tree-branch-gate.sh \
+  'git checkout -Z main' "cannot resolve"
+run_case_msg "git checkout --creat main blocked (switch-only name under checkout)" 2 main-tree-branch-gate.sh \
+  'git checkout --creat main' "cannot resolve"
+# CONTROLS: a KNOWN option beside `main` must still pass, in the long, the
+# negated and the short spelling. Without these, "block whenever any flag is
+# present" scores green on the four cases above.
+run_case "git checkout --quiet main allowed" 0 main-tree-branch-gate.sh \
+  'git checkout --quiet main'
+run_case "git checkout --no-overwrite-ignore main allowed (negated form)" 0 main-tree-branch-gate.sh \
+  'git checkout --no-overwrite-ignore main'
+run_case "git checkout -q main allowed" 0 main-tree-branch-gate.sh \
+  'git checkout -q main'
+run_case "git switch --discard-changes main allowed (switch-only name)" 0 main-tree-branch-gate.sh \
+  'git switch --discard-changes main'
+
+# --- EVERY VALUE-TAKING FLAG, NOT A SAMPLE OF THE ARM -------------------------
+#
+# `--conflict` and `--pathspec-from-file` had cases while `--unified` and
+# `--inter-hunk-context` -- the other two members of the same arity class under
+# `checkout` -- had none, and `-U` had none either. A value-taking flag with no
+# case is an untested member of a class that has produced three defects. Each
+# command below really switches (the flag's value is consumed by git, so the
+# trailing name is the branch); if the table gives the flag arity 0 instead, the
+# value becomes a phantom positional and the command reads as a restore.
+run_case "git checkout --unified 3 <branch> blocked (value consumed)" 2 main-tree-branch-gate.sh \
+  'git checkout --unified 3 feature'
+run_case "git checkout --unified=3 <branch> blocked (glued value)" 2 main-tree-branch-gate.sh \
+  'git checkout --unified=3 feature'
+run_case "git checkout --inter-hunk-context 2 <branch> blocked (value consumed)" 2 main-tree-branch-gate.sh \
+  'git checkout --inter-hunk-context 2 feature'
+run_case "git checkout -U 3 <branch> blocked (short value consumed)" 2 main-tree-branch-gate.sh \
+  'git checkout -U 3 feature'
+run_case "git checkout -U3 <branch> blocked (short glued value)" 2 main-tree-branch-gate.sh \
+  'git checkout -U3 feature'
+run_case "git switch --conflict merge <branch> blocked (value consumed)" 2 main-tree-branch-gate.sh \
+  'git switch --conflict merge feature'
+# ...and the CONTROL for the whole arity class: an ALLOWED command must not be
+# turned into a block by the consumption. `git checkout --unified 3 main` really
+# stays on main.
+run_case "git checkout --unified 3 main allowed" 0 main-tree-branch-gate.sh \
+  'git checkout --unified 3 main'
+
+# --- OPTIONAL-VALUE FLAGS CONSUME NOTHING -------------------------------------
+#
+# `-t` / `--track` / `--recurse-submodules` take an OPTIONAL value, so the SPACED
+# form does NOT eat the next token -- measured, `git checkout -t
+# origin/remote-only` creates local `remote-only`, i.e. the ref is a start-point
+# POSITIONAL. The glued and `=` spellings were fenced; the SPACED `--track` was
+# not.
+run_case_msg "git checkout --track <remote-ref> (spaced) blocked" 2 main-tree-branch-gate.sh \
+  'git checkout --track origin/remote-only' "creates new feature branch 'remote-only'"
+run_case_msg "git switch --track <remote-ref> (spaced) blocked" 2 main-tree-branch-gate.sh \
+  'git switch --track origin/remote-only' "creates new feature branch 'remote-only'"
+
+# --- THE DWIM LIST IS THE CONFIGURED REMOTES, STRIPPED PER REMOTE -------------
+#
+# A remote NAME may contain a slash, so a fixed `lstrip=3` is wrong: `deep-only`
+# on remote `a/b` lstrips to `b/deep-only` while git DWIMs plain `deep-only`
+# (measured: "Switched to a new branch 'deep-only'", HEAD moved) -- a FAIL-OPEN.
+# And a ref under a remote that is not CONFIGURED is not DWIMmed at all
+# (measured: "pathspec 'ghost' did not match any file(s) known to git", HEAD
+# stays) -- a FALSE BLOCK for a `refs/remotes/` scan.
+run_case "git checkout <branch on a SLASH-named remote> blocked" 2 main-tree-branch-gate.sh \
+  'git checkout deep-only'
+run_case "git checkout <ref under an UNCONFIGURED remote> allowed" 0 main-tree-branch-gate.sh \
+  'git checkout ghost'
+# `--no-guess` turns the DWIM off, so git answers "pathspec did not match" and
+# HEAD stays -- measured against the SAME name that moves HEAD without the flag.
+# It does not disable the LOCAL branch lookup: `--no-guess feature` switches.
+run_case "git checkout --no-guess <remote-only> allowed" 0 main-tree-branch-gate.sh \
+  'git checkout --no-guess remote-only'
+run_case "git checkout --no-guess <local branch> still blocked" 2 main-tree-branch-gate.sh \
+  'git checkout --no-guess feature'
+run_case "git checkout --guess <remote-only> blocked (the default)" 2 main-tree-branch-gate.sh \
+  'git checkout --guess remote-only'
+run_case "git checkout --no-guess --guess <remote-only> blocked (last wins)" 2 main-tree-branch-gate.sh \
+  'git checkout --no-guess --guess remote-only'
+
+# --- A BLOCK MUST NOT NAME AN OPERATION GIT WILL NOT PERFORM ------------------
+#
+# `git checkout -d <branch>` / `--detach <branch>` DETACHES (measured: HEAD went
+# to a raw sha, not to the branch), and the block announced it as "switches to
+# feature branch '<b>'". The VERDICT was right and is unchanged; the wording was
+# describing something git does not do.
+run_case_msg "git checkout -d <local branch> is reported as a detach" 2 main-tree-branch-gate.sh \
+  'git checkout -d feature' "detaches HEAD" "switches to feature branch"
+run_case_msg "git checkout --detach <local branch> is reported as a detach" 2 main-tree-branch-gate.sh \
+  'git checkout --detach feature' "detaches HEAD" "switches to feature branch"
+run_case_msg "git checkout --detach <remote-only> is reported as a detach" 2 main-tree-branch-gate.sh \
+  'git checkout --detach remote-only' "detaches HEAD" "switches to it"
+# The `d` cluster letter under SWITCH had no case either, only the long spelling.
+run_case_msg "git switch -d blocked and reported as a detach" 2 main-tree-branch-gate.sh \
+  'git switch -d' "detaches HEAD"
+# The documented ASYMMETRY, kept deliberately: the sha form under checkout passes.
+run_case "git checkout --detach <sha> allowed (documented asymmetry)" 0 main-tree-branch-gate.sh \
+  "git checkout --detach $MT_SHA"
+
+# --- A BARE `git switch` ------------------------------------------------------
+#
+# A git error, but blocked conservatively rather than reasoned about. It had no
+# case, so deleting the arm was invisible.
+run_case_msg "bare git switch blocked conservatively" 2 main-tree-branch-gate.sh \
+  'git switch' "no resolvable target"
+
+# --- AN UNSPLITTABLE ARGUMENT LIST IS REFUSED, NOT TRUNCATED ------------------
+#
+# An UNBALANCED quote cannot be split into shell words at all, and the splitter
+# used to return the prefix it managed silently: `-b agent's-branch` yielded the
+# single token `-b`, which read as a bare `git checkout` and PASSED -- a
+# FAIL-OPEN on a command that creates a branch (measured: `git checkout -b
+# agent\'s-br` prints "Switched to a new branch 'agent's-br'"). Refusing is the
+# deliberate choice: the text is a shell syntax error in the first place
+# (measured: "unexpected EOF while looking for matching `''").
+run_case_msg "git checkout -b <unbalanced quote> blocked, not truncated" 2 main-tree-branch-gate.sh \
+  "git checkout -b agent's-branch" "unbalanced quote"
+run_case_msg "git checkout <branch>'s blocked (fails CLOSED)" 2 main-tree-branch-gate.sh \
+  "git checkout feature's" "unbalanced quote"
+# CONTROL: a BALANCED quote around a name with an apostrophe in it is ordinary
+# and must reach the normal arms, not the refusal.
+run_case "git checkout \"main\" (balanced quotes) still allowed" 0 main-tree-branch-gate.sh \
+  'git checkout \"main\"'
 
 # --- FAIL-CLOSED on a library that predates GATE_EMBEDDING_TOKEN --------------
 #
@@ -945,7 +1191,7 @@ done
 # reads `fail: 0`. No suite in this repo had one, so the only thing standing
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
-CASE_FLOOR=213
+CASE_FLOOR=269
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -279,6 +279,18 @@ run_case "branch-gate: commit on a feature branch" 0 branch-gate.sh 'git commit 
 # the chained spelling, so the bypass was on the mandated path.
 MT_WT="$TMPDIR/wt-lane"
 git -C "$repo" worktree add -q -b wt-lane "$MT_WT" 2>/dev/null
+# REMOTE-tracking refs with no local branch behind them: the shape a lane's
+# branch has in a fresh checkout, and the one `git checkout <name>` DWIMs into a
+# local branch + switch. The NESTED one is here because a `*` does not cross a
+# `/` in for-each-ref, so a `refs/remotes/*/*` pattern silently misses it while
+# git DWIMs it identically. The SYMBOLIC `refs/remotes/origin/HEAD` that every
+# clone carries is here for the opposite reason: `lstrip=3` renders it as the
+# bare word `HEAD`, and `git checkout HEAD` creates nothing, so a DWIM list that
+# keeps it false-blocks a read-only command.
+MT_SHA=$(git -C "$repo" rev-parse HEAD)
+git -C "$repo" update-ref refs/remotes/origin/remote-only "$MT_SHA"
+git -C "$repo" update-ref refs/remotes/origin/topic/nested-remote-only "$MT_SHA"
+git -C "$repo" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/remote-only
 run_case "main-tree-branch: bare switch -c"        2 main-tree-branch-gate.sh 'git switch -c feat/x origin/main'
 run_case "main-tree-branch: CHAINED switch -c"     2 main-tree-branch-gate.sh 'git fetch origin && git switch -c feat/x origin/main'
 run_case "main-tree-branch: CHAINED checkout -b"   2 main-tree-branch-gate.sh 'git status && git checkout -b feat/x'
@@ -341,6 +353,180 @@ run_case_msg "main-tree-branch: --create names the branch" 2 main-tree-branch-ga
   'git switch --create feat/x' "feat/x" "'--create'"
 run_case_msg "main-tree-branch: --detach is not a branch name" 2 main-tree-branch-gate.sh \
   'git switch --detach origin/main' "detaches HEAD" "feature branch '--detach'"
+
+# --- ARGUMENT SHAPES THE TWO-TOKEN READING GOT WRONG (2026-09-01) -------------
+#
+# `verdict_for` read token 1 and token 2 rather than PARSING the options, so a
+# leading flag was mistaken for the branch name and a trailing pathspec for a
+# switch target. Every wanted verdict below was settled against real git first
+# (git 2.53.0), printing HEAD and the local branch list before and after:
+#
+#   git checkout <branch> -- <paths>  BLOCKED, must not be. It restores FILES;
+#     HEAD stayed `main`. The form WITHOUT the `--` behaves identically
+#     ("Updated 1 path from ..."), which is why the rule is "two or more
+#     positionals is a restore" rather than "a `--` was seen".
+#   git checkout -f <branch>          ALLOWED, must not be: `-f` was read AS the
+#     branch name and `refs/heads/-f` does not resolve. Measured, it switches.
+#   git checkout --orphan <branch>    ALLOWED: `--orphan` read as the name.
+#   git checkout - / @{-1}            ALLOWED while `git switch -` blocked.
+#   git switch --help                 BLOCKED: it prints text and moves nothing.
+run_case "main-tree-branch: <branch> -- <path> is a restore"        0 main-tree-branch-gate.sh 'git checkout feature -- README.md'
+run_case "main-tree-branch: <branch> <path> is a restore too"       0 main-tree-branch-gate.sh 'git checkout feature README.md'
+run_case "main-tree-branch: checkout -f <branch> blocked"           2 main-tree-branch-gate.sh 'git checkout -f feature'
+run_case "main-tree-branch: checkout - blocked"                     2 main-tree-branch-gate.sh 'git checkout -'
+run_case "main-tree-branch: checkout @{-1} blocked"                 2 main-tree-branch-gate.sh 'git checkout @{-1}'
+run_case "main-tree-branch: switch --help allowed"                  0 main-tree-branch-gate.sh 'git switch --help'
+run_case "main-tree-branch: checkout --help allowed"                0 main-tree-branch-gate.sh 'git checkout --help'
+run_case "main-tree-branch: checkout -B <branch> blocked"           2 main-tree-branch-gate.sh 'git checkout -B feat/x'
+# Under `switch` a leading flag blocks EITHER WAY -- the old reading takes `-f`
+# for the branch name and blocks because it is not main/master -- so the exit
+# code fences nothing here. The MESSAGE is the product of a block: it names the
+# branch to replay elsewhere.
+run_case_msg "main-tree-branch: switch -f names the branch, not the flag" 2 main-tree-branch-gate.sh \
+  'git switch -f feature' "feature" "feature branch '-f'"
+# Assert the whole PHRASE for the create flags. A walk that drops the create
+# flag falls through to the positional arm, which ALSO names the branch
+# correctly and merely calls the creation a switch -- so a name-only assertion
+# is a control, not a fence.
+run_case_msg "main-tree-branch: switch --orphan names the branch" 2 main-tree-branch-gate.sh \
+  'git switch --orphan feat/x' "creates new feature branch 'feat/x'" "'--orphan'"
+run_case_msg "main-tree-branch: checkout --orphan names the branch" 2 main-tree-branch-gate.sh \
+  'git checkout --orphan feat/x' "creates new feature branch 'feat/x'" "'--orphan'"
+run_case_msg "main-tree-branch: --force-create names the branch" 2 main-tree-branch-gate.sh \
+  'git switch --force-create feat/x' "creates new feature branch 'feat/x'" "'--force-create'"
+
+# --- DWIM / --track: a branch that exists only on a REMOTE --------------------
+#
+# Both shapes CREATE a local branch and switch to it -- measured on a real
+# clone, HEAD went `main` -> `feat` with "Switched to a new branch". A local-only
+# `show-ref` was blind to the way a lane's branch usually FIRST appears in a
+# checkout. The nested case pins the ref PATTERN: `refs/remotes/*/*` does not
+# list `origin/topic/nested` because a `*` does not cross a `/` there, and git
+# DWIMs it identically.
+run_case "main-tree-branch: checkout of a remote-only branch blocked"  2 main-tree-branch-gate.sh 'git checkout remote-only'
+run_case "main-tree-branch: checkout of a NESTED remote-only branch"   2 main-tree-branch-gate.sh 'git checkout topic/nested-remote-only'
+run_case_msg "main-tree-branch: -t origin/<b> names the LOCAL branch" 2 main-tree-branch-gate.sh \
+  'git checkout -t origin/remote-only' "creates new feature branch 'remote-only'" "origin/remote-only'"
+run_case_msg "main-tree-branch: --track=direct still names the branch" 2 main-tree-branch-gate.sh \
+  'git checkout --track=direct origin/remote-only' "creates new feature branch 'remote-only'" "origin/remote-only'"
+# CONTROLS for the DWIM arm. A name on no remote is a pathspec / sha and passes;
+# without them, "block any bare token" scores green on the cases above.
+run_case "main-tree-branch: a name on no remote either still passes"   0 main-tree-branch-gate.sh 'git checkout remote-onl'
+# `refs/remotes/origin/HEAD` renders as the bare word `HEAD` under `lstrip=3`,
+# and `git checkout HEAD` creates nothing -- measured, "Your branch is up to
+# date", HEAD stayed put. Matching it would refuse a read-only command.
+run_case "main-tree-branch: checkout HEAD is not a DWIM create"        0 main-tree-branch-gate.sh 'git checkout HEAD'
+run_case "main-tree-branch: checkout HEAD -- <path> allowed"           0 main-tree-branch-gate.sh 'git checkout HEAD -- README.md'
+
+# --- GLUED FLAG SPELLINGS -----------------------------------------------------
+#
+# git's parse-options accepts a short flag's value GLUED to it and bundles short
+# flags: `-bfeat` is `-b feat`, `-qbfeat` is `-q -b feat`. Measured -- each
+# printed "Switched to a new branch" and the branch appeared. A walk knowing only
+# the SPACED spelling sees one unknown flag, counts zero positionals, and reads
+# the command as a bare `git checkout`: allowed.
+run_case "main-tree-branch: glued -bfeat blocked"                      2 main-tree-branch-gate.sh 'git checkout -bfeat'
+run_case "main-tree-branch: glued -Bfeat blocked"                      2 main-tree-branch-gate.sh 'git checkout -Bfeat'
+run_case_msg "main-tree-branch: --orphan=<b> names the branch" 2 main-tree-branch-gate.sh \
+  'git checkout --orphan=feat' "creates new feature branch 'feat'" "'--orphan=feat'"
+run_case_msg "main-tree-branch: glued -c<b> names the branch" 2 main-tree-branch-gate.sh \
+  'git switch -cfeat' "creates new feature branch 'feat'" "'-cfeat'"
+run_case_msg "main-tree-branch: glued -C<b> names the branch" 2 main-tree-branch-gate.sh \
+  'git switch -Cfeat' "creates new feature branch 'feat'" "'-Cfeat'"
+run_case_msg "main-tree-branch: --create=<b> names the branch" 2 main-tree-branch-gate.sh \
+  'git switch --create=feat' "creates new feature branch 'feat'" "'--create=feat'"
+run_case_msg "main-tree-branch: --force-create=<b> names the branch" 2 main-tree-branch-gate.sh \
+  'git switch --force-create=feat' "creates new feature branch 'feat'" "'--force-create=feat'"
+run_case_msg "main-tree-branch: bundled -qb<b> names the branch" 2 main-tree-branch-gate.sh \
+  'git checkout -qbfeat' "creates new feature branch 'feat'" "'-qbfeat'"
+run_case_msg "main-tree-branch: bundled -fb <b> names the branch" 2 main-tree-branch-gate.sh \
+  'git checkout -fb feat' "creates new feature branch 'feat'" "'-fb'"
+
+# --- A POSITIONAL COUNT IS NOT A PARSE ----------------------------------------
+#
+# `git checkout --conflict merge <branch>` SWITCHES -- measured, "Switched to
+# branch 'feat'". Counting positionals without consuming a value-taking flag's
+# argument counted `merge` as one and read the switch as a restore. The flag list
+# comes from `git checkout -h` / `git switch -h`, not from memory;
+# `--recurse-submodules` has an OPTIONAL value, so its spaced form must NOT
+# consume the branch that follows it.
+run_case "main-tree-branch: --conflict <style> <branch> blocked"       2 main-tree-branch-gate.sh 'git checkout --conflict merge feature'
+run_case "main-tree-branch: --conflict=<style> <branch> blocked"       2 main-tree-branch-gate.sh 'git checkout --conflict=merge feature'
+run_case "main-tree-branch: --pathspec-from-file <f> <branch> blocked" 2 main-tree-branch-gate.sh 'git checkout --pathspec-from-file /dev/null feature'
+run_case "main-tree-branch: --recurse-submodules <branch> blocked"     2 main-tree-branch-gate.sh 'git checkout --recurse-submodules feature'
+# CONTROL: consuming a flag value must not turn an ALLOWED target into a block.
+run_case "main-tree-branch: --conflict <style> main still allowed"     0 main-tree-branch-gate.sh 'git checkout --conflict merge main'
+
+# --- RESTORE MODES MUST NOT BE BLOCKED ----------------------------------------
+#
+# `-p` / `--ours` / `--theirs` restore FILES -- measured, `git checkout -p feat`
+# printed a diff and left HEAD on `main`, and `--ours` / `--theirs` printed
+# "Updated 0 paths from the index". Blocking them is the same false block as the
+# `<branch> -- <paths>` one, and it is exactly what the naive fix for the `-f`
+# defect ("any single positional after flags is a switch target") introduces.
+# --- THE CHECKOUT ERE MUST CARRY THE FLAG RUN ---------------------------------
+#
+# Every checkout case above puts the DECISIVE segment in a `git checkout ...`
+# with no leading `git -C <path>`, so dropping `${GATE_FLAGS}` from
+# `GATE_RE_GIT_CHECKOUT` was invisible: measured, that mutation left the whole
+# suite green while `git -C <main> checkout -b x` run from a worktree went from
+# rc=2 to rc=0. These make a `-C`-carrying checkout the ONLY matching segment,
+# with the false-block control aimed at the worktree.
+run_case_cwd "main-tree-branch: -C main tree checkout -b from a worktree" 2 \
+  main-tree-branch-gate.sh "$MT_WT" "git -C $repo checkout -b feat/x"
+run_case_cwd "main-tree-branch: -C main tree checkout <branch> from a worktree" 2 \
+  main-tree-branch-gate.sh "$MT_WT" "git -C $repo checkout feature"
+run_case "main-tree-branch: -C worktree checkout -b from the main tree" 0 \
+  main-tree-branch-gate.sh "git -C $MT_WT checkout -b feat/x"
+
+# --- A QUOTED BRANCH NAME, AND THE PREVIOUS-BRANCH MESSAGE --------------------
+#
+# The branch name used to come out of a COLLAPSED quoted span, so
+# `git switch "main"` compared `"main"` (quotes included) against `main` and
+# FALSE-BLOCKED, while `git checkout "feature"` failed
+# `show-ref refs/heads/"feature"` and PASSED. Measured against the pre-fix hook
+# in the real main checkout: rc=2 and rc=0 respectively. The option parse keeps a
+# quoted span as ONE token and unquotes it, so both directions are now right --
+# and dropping the unquote left this whole suite green until these landed.
+run_case "main-tree-branch: quoted main allowed"                       0 main-tree-branch-gate.sh 'git switch \"main\"'
+run_case "main-tree-branch: single-quoted main allowed"                0 main-tree-branch-gate.sh "git switch 'main'"
+run_case "main-tree-branch: quoted local branch blocked"               2 main-tree-branch-gate.sh 'git checkout \"feature\"'
+run_case_msg "main-tree-branch: -c \"<name with a space>\" kept whole" 2 main-tree-branch-gate.sh \
+  'git switch -c \"wt feat new\"' "creates new feature branch 'wt feat new'"
+# `git switch @{-1}` blocked before this only by falling through the catch-all,
+# which names it a feature branch rather than the previous one; the exit code
+# cannot tell the two apart, so the MESSAGE is the fence.
+run_case_msg "main-tree-branch: switch @{-1} is the previous branch" 2 main-tree-branch-gate.sh \
+  'git switch @{-1}' "previous branch"
+
+run_case "main-tree-branch: checkout -p <branch> is a restore"         0 main-tree-branch-gate.sh 'git checkout -p feature'
+run_case "main-tree-branch: checkout --patch <branch> is a restore"    0 main-tree-branch-gate.sh 'git checkout --patch feature'
+run_case "main-tree-branch: checkout --ours <path>"                    0 main-tree-branch-gate.sh 'git checkout --ours README.md'
+run_case "main-tree-branch: checkout --theirs <path>"                  0 main-tree-branch-gate.sh 'git checkout --theirs README.md'
+
+# --- FAIL-CLOSED on a library that predates GATE_EMBEDDING_TOKEN --------------
+#
+# The option parse interpolates that CONSTANT into its `[[ =~ ]]`. A library
+# without it leaves the pattern EMPTY, the match then succeeds on any input with
+# `${BASH_REMATCH[1]}` empty, and the walk yields NO tokens -- so every command
+# looks like a bare `git checkout` and PASSES. `declare -F` cannot see a missing
+# constant, which is why the gate's guard names it separately.
+mtbg_const_guard() {
+  local tmp out rc
+  tmp=$(mktemp -d)
+  cp "$HOOKS"/*.sh "$tmp/" 2>/dev/null
+  grep -v '^GATE_EMBEDDING_TOKEN=' "$HOOKS/_command-match.sh" > "$tmp/_command-match.sh"
+  out=$(printf '{"tool_name":"Bash","cwd":"%s","tool_input":{"command":"git switch -c feat/x"}}' "$repo" \
+    | env PATH="$SHIM:/usr/bin:/bin" MARKGATE_RC=1 "$tmp/main-tree-branch-gate.sh" 2>&1); rc=$?
+  rm -rf "$tmp"
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF 'GATE_EMBEDDING_TOKEN'; then
+    pass=$((pass + 1)); printf 'OK   %-46s %s\n' "main-tree-branch: no GATE_EMBEDDING_TOKEN fails closed" "(exit $rc)"
+  else
+    fail=$((fail + 1)); printf 'FAIL main-tree-branch: must exit 2 naming GATE_EMBEDDING_TOKEN (got %s)\n  out: %s\n' "$rc" "$out"
+  fi
+}
+mtbg_const_guard
+
 
 # post-merge-orphan-push-gate blocks a push to a branch whose PR already merged.
 # Same defect as main-tree-branch-gate above and fixed the same way: it read the
@@ -759,7 +945,7 @@ done
 # reads `fail: 0`. No suite in this repo had one, so the only thing standing
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
-CASE_FLOOR=167
+CASE_FLOOR=213
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/hooks/gate-command-recognition.test.sh
+++ b/.claude/hooks/gate-command-recognition.test.sh
@@ -1191,7 +1191,184 @@ done
 # reads `fail: 0`. No suite in this repo had one, so the only thing standing
 # between a gutted loop and a green run was somebody noticing the number move.
 # Raise it when cases are added; never lower it to make a red run green.
-CASE_FLOOR=269
+# --- ROUND 4: A WORD THE STRIPPER CANNOT ACCOUNT FOR MAY NOT ALLOW ------------
+#
+# Three earlier rounds each taught `gate_argv` one more shell form and each time
+# the next round found the form still missing. These cases pin the INVERSION
+# that replaced that chase: a word is an argument only when every character in
+# it is one the shell provably does not act on, and one that is not sets
+# `parse_certain=0`. Measured against real git 2.53.0 first, HEAD printed before
+# and after, in a scratch repo whose `<branch>` EXISTS locally -- a made-up name
+# never reaches the local-branch arm and measures nothing. This fixture's local
+# branch is `feature`; the probe's was `some-feature`:
+#
+#   git checkout <branch> $EMPTY               HEAD main -> <branch>
+#   git checkout <branch> ${EMPTY}             HEAD main -> <branch>
+#   git checkout <branch> {fd}>/dev/null       HEAD main -> <branch>
+#   git checkout <branch> {fd}<f.txt           HEAD main -> <branch>
+#
+# All four scored rc=0 against this gate before the inversion: the extra WORD
+# was counted as a second positional, so a real branch switch read as a file
+# restore. `$EMPTY` is the realistic one -- an unset variable holding optional
+# flags.
+#
+# THE APOSTROPHE IS BUILT rather than written, and that is a bash 3.2 defect
+# rather than style. Under 3.2.57 a `'` inside a double-quoted word inside a
+# `$(...)` loses the quoting on the NEXT single-quoted argument, which is then
+# BRACE-EXPANDED: measured, a jq filter came back as two words (`cwd:$d` and
+# `tool_input:{command:$c}`) where 5.3.9 kept it whole. This suite's helper
+# takes the command as a plain argument and is immune, but the variable keeps
+# the cases portable to the sibling suites that are not.
+R4_AP=$(printf '\047')
+
+run_case_msg "an unquoted \$EMPTY after a branch blocks (it can VANISH)" 2 main-tree-branch-gate.sh 'git checkout feature $EMPTY' \
+  "whose expansion this gate cannot see"
+run_case "an unquoted \${EMPTY} after a branch blocks" 2 main-tree-branch-gate.sh 'git checkout feature ${EMPTY}'
+run_case_msg "the bash fd-variable redirection {fd}> blocks" 2 main-tree-branch-gate.sh 'git checkout feature {fd}>/dev/null' \
+  "whose expansion this gate cannot see"
+run_case "the bash fd-variable redirection {fd}< blocks" 2 main-tree-branch-gate.sh 'git checkout feature {fd}<f.txt'
+# A SHAPE NO ARM NAMES. Nothing in the gate or in this suite mentions a glob,
+# and it lands on BLOCK anyway, because `*` is not on the inert list. That is
+# not over-caution: with `nullglob` set a non-matching pattern expands to NO
+# words, and the command really switches -- measured, `shopt -s nullglob; git
+# checkout some-feature *nomatch*` answered "Switched to branch 'some-feature'"
+# (HEAD moved), against "pathspec did not match" with nullglob off. The hook
+# cannot see which shell option is set.
+run_case "a GLOB word blocks -- a shape no arm names" 2 main-tree-branch-gate.sh 'git checkout feature *nomatch*'
+# OVER-STRICT BY DESIGN, and labelled so rather than dressed up as a bypass:
+# real git leaves HEAD alone here (`~` expands to $HOME, "is outside repository",
+# HEAD stayed `main`). The gate blocks because `~` is not on the inert list. A
+# false block costs one message; the alternative is deciding case by case which
+# expansions are safe, which is the enumeration this round removed.
+run_case "a TILDE word blocks (over-strict, stated)" 2 main-tree-branch-gate.sh 'git checkout feature ~'
+# THE OTHER POLARITY. A `$` that is QUOTED is an ordinary character in a branch
+# name and must still reach the normal arms. Measured: `git checkout -b
+# 'feat\$x'` prints "Switched to a new branch 'feat\$x'" and HEAD moved, and
+# `git checkout main -- 'a\$b.txt'` leaves HEAD on main.
+run_case_msg "a quoted literal \$ in a branch name still NAMES the branch" 2 main-tree-branch-gate.sh "git checkout -b ${R4_AP}feat\$x${R4_AP}" \
+  "creates new feature branch ${R4_AP}feat\$x${R4_AP}" \
+  "whose expansion this gate cannot see"
+run_case "a quoted literal \$ in a pathspec is still a restore" 0 main-tree-branch-gate.sh "git checkout main -- ${R4_AP}a\$b.txt${R4_AP}"
+# CONTROL on the inert list itself: `#` mid-word is NOT a comment, and a branch
+# name may contain one. If the list stopped admitting `#` this would block.
+run_case "a # inside a word is inert, not a comment" 0 main-tree-branch-gate.sh 'git checkout main -- has#hash'
+
+# --- ROUND 4: AN APOSTROPHE INSIDE A `#` COMMENT MUST NOT POISON THE PARSE ----
+#
+# The splittability rc came from tokenizing the WHOLE text while the comment was
+# dropped later, inside the walk -- so a `'` after a `#` was weighed as a quote
+# and the command was refused as unbalanced. Measured against real git:
+# `git checkout main # don't switch lanes` answers "Already on 'main'" and HEAD
+# stays, and `bash -n` calls the text VALID SYNTAX. The comment justifying the
+# old order claimed the opposite in as many words.
+run_case "a comment containing an apostrophe no longer false-blocks" 0 main-tree-branch-gate.sh "git checkout main # don${R4_AP}t switch lanes"
+run_case "a restore with an apostrophe in its comment is allowed" 0 main-tree-branch-gate.sh "git checkout main -- f.txt # agent${R4_AP}s file"
+# The DISCRIMINATOR: the comment is still dropped, so a real switch behind one
+# still blocks. Without this the case above would pass on a gate that stopped
+# reading comments at all.
+run_case_msg "a comment does not hide a real switch" 2 main-tree-branch-gate.sh 'git checkout feature # switch lane' \
+  "switches to feature branch"
+
+# --- ROUND 4: THREE OPTIONS GIT ACCEPTS AND THE GATE USED TO BLOCK ------------
+#
+# `parse_certain` was documented as firing "only on commands git itself
+# refuses". Measured against git 2.53.0 that was FALSE for three that run:
+#
+#   git checkout --end-of-options main       rc=0  "Already on 'main'"
+#   git checkout --end-of-options -- f.txt   rc=0  restores, HEAD stays
+#   git checkout --git-completion-helper     rc=0  prints the completion list
+#
+# `--end-of-options` must NOT be mapped onto the `--` arm: it ends OPTION
+# parsing without giving what follows checkout's pathspec meaning, and
+# `git checkout --end-of-options some-feature` really switches (measured, HEAD
+# moved). The third case below is what fails if the two are merged.
+run_case "--end-of-options main is allowed" 0 main-tree-branch-gate.sh 'git checkout --end-of-options main'
+run_case "--end-of-options -- <path> is a restore, allowed" 0 main-tree-branch-gate.sh 'git checkout --end-of-options -- f.txt'
+run_case_msg "--end-of-options <branch> still SWITCHES, blocked" 2 main-tree-branch-gate.sh 'git checkout --end-of-options feature' \
+  "switches to feature branch"
+run_case "--git-completion-helper is allowed" 0 main-tree-branch-gate.sh 'git checkout --git-completion-helper'
+run_case "switch --end-of-options main is allowed" 0 main-tree-branch-gate.sh 'git switch --end-of-options main'
+
+# --- ROUND 4: THE FENCE NOW COMES BEFORE `--help` -----------------------------
+#
+# `saw_help` returned ahead of the `parse_certain` check, which made the help
+# arm the ONE relaxing verdict that skipped the fence the design rests on.
+# Harmless in this spelling -- git answers "unknown option `frobnicate'" and
+# HEAD stays -- but an exemption with no argument behind it is what the next
+# round finds.
+run_case_msg "an unresolvable option blocks even WITH --help" 2 main-tree-branch-gate.sh 'git checkout --frobnicate --help' \
+  "cannot resolve"
+
+# --- ROUND 4: ARMS THAT WERE UNFENCED (a reviewer's mutation sweep) -----------
+#
+# Each of these leaves the suite green when its arm is deleted, while the live
+# command flips. Every `want` measured against real git 2.53.0:
+#
+#   git checkout @{-1} -- f.txt                rc=0, HEAD stays (a restore)
+#   git checkout --track main -- f.txt         rc=128 "missing branch name", HEAD stays
+#   git checkout -2 f.txt                      rc=0  "Updated 0 paths", HEAD stays
+#   git checkout -b feat-r4 --conflict merge   rc=0  created feat-r4, HEAD MOVED
+#
+# The `@{-1}` restore is also the discriminator for the ONE exemption the
+# literal-word check carries: without the exemption this blocks.
+run_case "@{-1} with a pathspec is a restore, allowed" 0 main-tree-branch-gate.sh 'git checkout @{-1} -- README.md'
+run_case "--track with a pathspec is a restore, allowed" 0 main-tree-branch-gate.sh 'git checkout --track origin/remote-only -- README.md'
+# The `pending` distinction: `value` is the branch name, `skip` is some other
+# flag's argument. Making `skip` assign too leaves the suite green and makes the
+# block name `merge` -- the "blocks for the right reason, names the wrong thing"
+# class this gate has already shipped once.
+run_case_msg "-b <branch> --conflict <style> names the BRANCH, not the style" 2 main-tree-branch-gate.sh 'git checkout -b feat-r4 --conflict merge' \
+  "creates new feature branch ${R4_AP}feat-r4${R4_AP}" \
+  "${R4_AP}merge${R4_AP}"
+# `-h` under both verbs: real git prints the usage and exits 129 with HEAD
+# unmoved, so the gate must allow. Deleting the `*:h` cluster arm leaves the
+# rest of this suite green while these two flip 0 -> 2 through `parse_certain`,
+# so only the SHORT form is fenced here -- the long `--help` already was.
+run_case "checkout -h <local branch> allowed (the short help)" 0 main-tree-branch-gate.sh 'git checkout -h feature'
+run_case "switch -h <local branch> allowed (the short help)" 0 main-tree-branch-gate.sh 'git switch -h feature'
+
+# --- ROUND 4: THE ARGV CAPTURE IS READ THROUGH A HERE-STRING -------------------
+#
+# `verdict_for` used to call `gate_argv` twice -- once for the rc, once to feed
+# the walk through a process substitution -- which is two parses of one text and
+# two chances for them to disagree. It captures once now and reads the capture,
+# and that changes one thing: a here-doc over an EMPTY capture still yields one
+# BLANK line. Counted as a positional, that made a bare `git checkout` read as
+# `git checkout ''`, and the DWIM probe `grep -qxF -- ""` matches every remote
+# branch name there is -- so the gate blocked a command that leaves HEAD alone
+# (measured: `git checkout` alone prints the status and stays on `main`).
+run_case "a bare git checkout is still allowed (empty argv)" 0 main-tree-branch-gate.sh 'git checkout'
+run_case_msg "a bare git switch is still blocked" 2 main-tree-branch-gate.sh 'git switch' \
+  "no resolvable target"
+# CONTROL, not a fence: the here-doc delimiter is matched in the SCRIPT text
+# rather than in the expansion, so an argument that happens to spell `EOF`
+# cannot end the body early. Nothing reddens this today; it exists so a rewrite
+# that re-scans the capture (an `eval`, a here-string built from it) has a case
+# to fail. The shared library carries the same control for `gate_argv`.
+run_case "an argument spelling the here-doc delimiter survives" 0 main-tree-branch-gate.sh 'git checkout EOF -- README.md'
+
+# --- ROUND 4: THREE CASES THAT PASSED FOR NO REASON ----------------------------
+#
+# A reviewer's mutation sweep found each of these arms unfenced.
+#
+# The QUOTED `#` case above compares exit codes only, and under `checkout` both
+# arms answer 0 -- treating `'#not-a-comment'` as a comment leaves no positional,
+# which also passes. Its twin under SWITCH is discriminating, because switch has
+# no "no positional" allow: the message either NAMES the argument or says "no
+# resolvable target". Real git: `git switch '#not-a-branch'` answers "fatal:
+# invalid reference: #not-a-branch" with HEAD unmoved, so the block is the
+# conservative arm either way and only the WORDING carries the fact.
+run_case_msg "a quoted # reaches SWITCH as an argument, and is named" 2 main-tree-branch-gate.sh "git switch ${R4_AP}#not-a-branch${R4_AP}" \
+  "#not-a-branch"
+# The `--track` arm's guard is `saw_restore == 0 && pathspec_seen == 0 &&
+# npos == 1`, and all three were droppable with the suite staying green. The
+# pathspec half is fenced above; this fences the COUNT half. Real git: `git
+# checkout -t` alone answers "fatal: --track needs a branch name" with HEAD
+# unmoved, so allowing it is correct -- and without `npos == 1` the arm fires on
+# `first_pos=""` and blocks a command git refuses to run.
+run_case "a bare checkout -t is allowed (no start-point to name)" 0 main-tree-branch-gate.sh 'git checkout -t'
+
+CASE_FLOOR=297
 if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -21,14 +21,23 @@
 #   3. The hook's `cwd` field.
 #   4. $PWD.
 #
-# Gate scope:
-#   - Block: `git switch <not-main>`, `git switch -c <branch>`,
-#     `git checkout -b <branch>`, `git checkout <not-main>` (when
-#     `<not-main>` is a local branch name).
-#   - Pass: `git switch main`, `git switch master`, `git checkout
-#     main`, `git checkout master`, every `git checkout <pathspec>`
-#     (file restore), `git checkout <sha>` (detached HEAD), `git
-#     worktree add ...` (the sanctioned path).
+# Gate scope. The arguments are read by a TOKEN WALK, so a leading FLAG is never
+# mistaken for the branch name and a trailing pathspec is never mistaken for a
+# switch -- see verdict_for's header for the five shapes the earlier
+# "token 1 and token 2" reading got wrong, each settled against real git.
+#   - Block: `git switch <not-main>`, `git switch -c|-C|--create|--force-create
+#     <branch>`, `git switch --orphan <branch>`, `git switch -`,
+#     `git switch --detach`, `git checkout -b|-B|--orphan <branch>`,
+#     `git checkout -t|--track <remote-ref>`, `git checkout -`, and
+#     `git checkout <not-main>` when `<not-main>` is the ONLY positional AND
+#     names either a LOCAL branch or a branch on some REMOTE (git DWIMs the
+#     second into a create + switch).
+#   - Pass: `git switch main` / `master`, `git checkout main` / `master`,
+#     `git checkout [<tree-ish>] -- <pathspec>` and `git checkout <tree-ish>
+#     <pathspec>` (file restores -- measured, HEAD stays put),
+#     `git checkout <sha>` (detached HEAD), `git checkout HEAD`, `--help`,
+#     `git worktree add ...` (the sanctioned path), and everything in a LINKED
+#     worktree, which is where the convention wants feature branches.
 #
 # Bypass: agents that legitimately need to operate in the main tree
 # (e.g. release tooling, history surgery) can `cd <subdir>` first
@@ -55,13 +64,23 @@ fi
 # shellcheck source=/dev/null
 . "$_gate_lib"
 if ! declare -F gate_matches >/dev/null 2>&1 \
-  || ! declare -F gate_verb_args_dir >/dev/null 2>&1; then
+  || ! declare -F gate_verb_args_dir >/dev/null 2>&1 \
+  || ! declare -F gate_unquote >/dev/null 2>&1 \
+  || ! declare -F gate_tokens >/dev/null 2>&1 \
+  || [ -z "${GATE_EMBEDDING_TOKEN:-}" ]; then
   # `gate_verb_args_dir` is named too, not only `gate_matches`: it feeds the
   # segment loop through a process substitution, so a library that predates it
   # yields NO lines, the loop body never runs, and the gate exits 0 -- a silent
   # bypass with no error anywhere. That is precisely what this fail-closed
   # check exists to stop.
-  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches / gate_verb_args_dir is undefined (truncated or stale file?)." >&2
+  #
+  # `GATE_EMBEDDING_TOKEN` is a CONSTANT, not a function, and it is named here
+  # because the shared `gate_tokens` interpolates it into the `[[ =~ ]]` that splits
+  # the argument text. A library predating it leaves the pattern EMPTY, the match
+  # then succeeds on any input with `${BASH_REMATCH[1]}` empty, and the token
+  # walk yields nothing -- so every command would look like a bare
+  # `git checkout` and pass. `declare -F` cannot see that; only this can.
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches / gate_verb_args_dir / gate_unquote / gate_tokens / GATE_EMBEDDING_TOKEN is undefined (truncated or stale file?)." >&2
   exit 2
 fi
 
@@ -153,86 +172,360 @@ main_tree_of() {
   printf '%s' "$main_tree"
 }
 
+
 # verdict_for <verb> <args> <dir>
-# 0 = the segment must be BLOCKED (with `target_branch` / `block_reason` set),
+# 0 = this segment must be BLOCKED (with `target_branch` / `block_reason` set),
 # 1 = allowed. <args> is everything after the matched verb, flags included,
 # because the verb ERE already consumed the leading `git -C … ` flag run.
 #
-#   `git switch <main|master>`         → allow
-#   `git checkout <main|master>`       → allow
-#   `git switch -c <branch>`           → block
-#   `git switch <other-branch>`        → block
-#   `git checkout -b <branch>`         → block
-#   `git checkout <other-branch>`      → block (only when <other-branch> is a
-#                                        local branch — file-path / sha
-#                                        checkouts pass through)
-#   `git checkout -- <pathspec>`       → allow (file restore)
-#   `git checkout <sha>`               → allow (detached HEAD, rare in agent
-#                                        workflows but legitimate)
+#   `git switch <main|master>`             -> allow
+#   `git checkout <main|master>`           -> allow
+#   `git switch -c|-C|--create|--force-create <branch>` -> block
+#   `git switch|checkout --orphan <branch>`             -> block
+#   `git switch <other-branch>`            -> block
+#   `git switch|checkout -` / `@{-1}`      -> block (previous branch, unknowable)
+#   `git switch --detach`                  -> block
+#   `git checkout -b|-B <branch>`          -> block
+#   `git switch|checkout -t|--track <remote-ref>` -> block (DWIM create + switch)
+#   `git checkout <other-branch>`          -> block when it is the ONLY
+#                                            positional AND names a LOCAL branch
+#                                            or a branch on some REMOTE
+#   `git checkout [<tree-ish>] -- <paths>` -> allow (file restore)
+#   `git checkout <tree-ish> <paths>`      -> allow (file restore, no `--`)
+#   `git checkout -p|--ours|--theirs …`    -> allow (restore modes)
+#   `git checkout <sha>` / `HEAD`          -> allow (detached HEAD / a rev)
+#   `git switch|checkout --help`           -> allow
+#
+# A REAL OPTION PARSE, not "read token 1 and token 2", and not a token walk that
+# only knows the SPACED spelling of a flag. The option grammar comes from
+# `git checkout -h` / `git switch -h` (git 2.53.0) rather than from memory:
+#
+#   value-taking, BOTH verbs   --conflict <style>
+#   value-taking, checkout     -b -B <branch>, -U/--unified <n>,
+#                              --inter-hunk-context <n>,
+#                              --pathspec-from-file <file>
+#   value-taking, switch       -c -C / --create --force-create <branch>
+#   value-taking, both         --orphan <new-branch>
+#   OPTIONAL value             -t/--track[=(direct|inherit)],
+#                              --recurse-submodules[=<checkout>]
+#                              -- the SPACED form does NOT consume the next token
+#   restore modes, checkout    -p/--patch, -2/--ours, -3/--theirs
+#
+# Every wanted verdict below was settled against real git first, printing HEAD
+# and the local branch list before and after the command. The defects this
+# replaces, in the order they were found:
+#
+#   git checkout <branch> -- <paths>   was BLOCKED, and must not be: it restores
+#     FILES and leaves HEAD alone. Measured -- HEAD stayed `main`, f.txt took the
+#     other branch's content. `git checkout <branch> <paths>` without the `--`
+#     behaves identically ("Updated 1 path from …"), which is why the rule is
+#     "two or more positionals is a restore" rather than "a `--` was seen".
+#     go-to-k/cdk-real-drift MANDATES the `--` spelling for its integration step,
+#     so the old reading refused a sibling repo's own documented flow.
+#
+#   git checkout -f <branch>           was ALLOWED, and must not be: `-f` was
+#     read AS the branch name, `refs/heads/-f` does not resolve, and the gate
+#     passed. Measured -- "Switched to branch 'feat'". ANY flag before the branch
+#     did this.
+#
+#   git checkout --orphan <branch>     was ALLOWED: `--orphan` was read as the
+#     branch name. Measured -- "Switched to a new branch 'wt-new'".
+#
+#   git checkout <name> / -t origin/<name>
+#     were ALLOWED. With no LOCAL `<name>` but a remote carrying it, both CREATE
+#     the local branch and switch -- measured on a real clone, HEAD went
+#     `main` -> `feat`, git printing "Switched to a new branch". That is how a
+#     lane's branch usually FIRST appears in a checkout, so a local-only
+#     `show-ref` was blind to the commonest spelling of what this gate guards.
+#
+#   git checkout -  /  git checkout @{-1}   were ALLOWED while `git switch -`
+#     blocked. Measured -- both print "Switched to branch 'other'" and move HEAD.
+#     `@{-1}` was allowed under `checkout` only; `switch` blocked it by falling
+#     through its catch-all, i.e. by accident rather than by rule.
+#
+#   GLUED flag spellings were ALL invisible: `-bfeat`, `-Bfeat`, `-cfeat`,
+#     `-Cfeat`, `--create=feat`, `--force-create=feat`, `--orphan=feat`. Each was
+#     measured creating the branch and switching to it. A short flag is now
+#     parsed as a CLUSTER (`-qbfeat` = `-q -b feat`), so the glued and spaced
+#     spellings cannot diverge again, and a long flag is split on its first `=`.
+#
+#   git checkout --conflict merge <branch>   was ALLOWED: a positional COUNT is
+#     not a parse. `merge` inflated the count to 2 and the command was read as a
+#     restore. Measured -- it switches. Value-taking flags now CONSUME their
+#     argument, from the list above, so the count is a count of true positionals.
+#
+#   git checkout HEAD                  is a FALSE BLOCK waiting to happen, and it
+#     is closed here rather than shipped: the DWIM list comes from `refs/remotes/`
+#     and every clone carries the SYMBOLIC `refs/remotes/origin/HEAD`, which
+#     `lstrip=3` renders as the bare word `HEAD`. Measured -- `git checkout HEAD`
+#     prints "Your branch is up to date" and creates nothing.
+#
+#   git checkout -p <branch> / --ours / --theirs   would be FALSE BLOCKS for the
+#     same reason as the `<branch> -- <paths>` restore. Measured -- `-p` prints a
+#     diff and leaves HEAD on `main`; `--ours` / `--theirs` print "Updated 0
+#     paths from the index".
+#
+# `--detach` stays asymmetric between the verbs: `git switch --detach` blocks
+# while `git checkout <sha>` / `git checkout --detach <sha>` passes. That is the
+# behaviour this gate shipped with, kept rather than silently changed here --
+# but the rationale it shipped with, "the sha form is read-only inspection", is
+# FALSE and is not repeated. `git checkout <sha>` REWRITES the shared working
+# tree and leaves a detached HEAD, and the detached HEAD then disarms the
+# sibling gate: `branch-gate.sh` reads
+# `git -C <dir> symbolic-ref --short HEAD`, which is EMPTY while detached, and
+# falls through to its `exit 0`. Measured in a throwaway repo carrying a
+# `.markgate.yml`, driving branch-gate with `git commit -m x`: rc=2 on `main`,
+# rc=0 once detached. So allowing the sha form leaves a two-step path to an
+# ungated commit in the main checkout. Changing the verdict is a behaviour
+# change with its own blast radius (it would refuse a legitimate inspection
+# spelling in three repos) and belongs in its own PR, not smuggled into a parse
+# fix -- recorded here and in .claude/rules/hooks.md so the next reader inherits
+# the measurement rather than the old claim.
 verdict_for() {
-  local verb="$1" rest="$2" dir="$3" first_token second_token
-  first_token=$(printf '%s' "$rest" | awk '{print $1}')
-  second_token=$(printf '%s' "$rest" | awk '{print $2}')
+  local verb="$1" rest="$2" dir="$3"
+  local tok pending="" create_val="" create_flag="" detach_flag=""
+  local saw_help=0 saw_ddash=0 track_flag=0 restore_flag=0
+  local npos=0 first_pos="" lname lval lhas letters ch
   target_branch=""
   block_reason=""
+  while IFS= read -r tok; do
+    tok=$(gate_unquote "$tok")
+    if [ -n "$pending" ]; then
+      # `value` is a branch name; `skip` is some other flag's argument, consumed
+      # only so it cannot be miscounted as a positional.
+      [ "$pending" = value ] && create_val="$tok"
+      pending=""
+      continue
+    fi
+    case "$tok" in
+      # Everything after `--` is a pathspec, never a branch. Under `checkout`
+      # the token BEFORE it is then a tree-ish to restore FROM, not a switch
+      # target. Remembered rather than just broken out of, because the leading
+      # positional has already been counted by the time we get here.
+      --) saw_ddash=1; break ;;
+      --*)
+        # A long flag. Split on the FIRST `=`, so the glued and spaced spellings
+        # of a value-taking flag reach the same arm. `--no-<x>` negations fall to
+        # the catch-all and are valueless, which is what git does with them.
+        case "$tok" in
+          --*=*) lname="${tok%%=*}"; lval="${tok#*=}"; lhas=1 ;;
+          *)     lname="$tok";       lval="";          lhas=0 ;;
+        esac
+        case "$lname" in
+          --help) saw_help=1 ;;
+          --create|--force-create)
+            # `switch`'s create pair. `checkout` has no long create flag.
+            if [ "$verb" = switch ]; then
+              create_flag="$lname"
+              if [ "$lhas" = 1 ]; then create_val="$lval"; else pending=value; fi
+            fi
+            ;;
+          --orphan)
+            create_flag="$lname"
+            if [ "$lhas" = 1 ]; then create_val="$lval"; else pending=value; fi
+            ;;
+          --track)
+            # OPTIONAL value (`--track=direct`), so the SPACED form must not
+            # consume the next token -- that token is the remote start-point,
+            # and the branch git creates is its last segment.
+            track_flag=1
+            ;;
+          --detach)
+            [ "$verb" = switch ] && detach_flag="$lname"
+            ;;
+          --patch|--ours|--theirs)
+            [ "$verb" = checkout ] && restore_flag=1
+            ;;
+          --conflict|--pathspec-from-file|--unified|--inter-hunk-context)
+            # Value-taking. Consume the argument when it is not glued, so it is
+            # not counted as a positional and read as a restore's pathspec.
+            [ "$lhas" = 0 ] && pending=skip
+            ;;
+          *) : ;;
+        esac
+        ;;
+      -)
+        # `git switch -` / `git checkout -` = the previous branch, which cannot
+        # be known without running git. Counted as a positional and judged below.
+        npos=$((npos + 1))
+        [ "$npos" -eq 1 ] && first_pos="-"
+        ;;
+      -?*)
+        # A SHORT flag CLUSTER: git's parse-options accepts `-qbfeat` as
+        # `-q -b feat`, so the letters are walked one at a time and a
+        # value-taking letter takes the REST of the token as its value, or the
+        # next token when nothing is left. Parsing only the whole token missed
+        # every glued spelling -- `-bfeat`, `-Bfeat`, `-cfeat`, `-Cfeat` -- each
+        # measured creating the branch and switching to it.
+        letters="${tok#-}"
+        while [ -n "$letters" ]; do
+          ch="${letters%"${letters#?}"}"
+          letters="${letters#?}"
+          case "$ch" in
+            h) saw_help=1 ;;
+            b|B)
+              if [ "$verb" = checkout ]; then
+                create_flag="-$ch"
+                if [ -n "$letters" ]; then create_val="$letters"; letters=""
+                else pending=value; fi
+              else
+                letters=""
+              fi
+              ;;
+            c|C)
+              if [ "$verb" = switch ]; then
+                create_flag="-$ch"
+                if [ -n "$letters" ]; then create_val="$letters"; letters=""
+                else pending=value; fi
+              else
+                # `-c` after `checkout` is not an option at all; the leading
+                # `git -c <k>=<v>` run was consumed by the verb ERE.
+                letters=""
+              fi
+              ;;
+            t) track_flag=1 ;;
+            d) [ "$verb" = switch ] && detach_flag="-d" ;;
+            p|2|3) [ "$verb" = checkout ] && restore_flag=1 ;;
+            U)
+              if [ "$verb" = checkout ]; then
+                if [ -n "$letters" ]; then letters=""; else pending=skip; fi
+              fi
+              ;;
+            q|l|m|f) : ;;
+            *)
+              # An unrecognised letter. Stop reading the cluster rather than
+              # guess: a wrong guess about a VALUE is what the `--conflict merge`
+              # defect was.
+              letters=""
+              ;;
+          esac
+        done
+        ;;
+      *)
+        npos=$((npos + 1))
+        [ "$npos" -eq 1 ] && first_pos="$tok"
+        ;;
+    esac
+  done < <(gate_tokens "$rest")
+
+  [ "$saw_help" -eq 1 ] && return 1
+  if [ -n "$create_flag" ]; then
+    target_branch="$create_val"
+    block_reason="creates new feature branch '$target_branch'"
+    return 0
+  fi
+  if [ "$track_flag" = 1 ]; then
+    # `git checkout -t origin/feat` / `git switch --track origin/feat` CREATE a
+    # local `feat` and switch to it -- measured, and the local branch appeared.
+    # The name is the start-point's LAST segment, so `origin/topic/x` yields `x`.
+    target_branch="${first_pos##*/}"
+    block_reason="creates new feature branch '$target_branch'"
+    return 0
+  fi
+  if [ -n "$detach_flag" ]; then
+    # Detaching HEAD moves the SHARED tree off `main` exactly as a branch switch
+    # does, so the verdict is unchanged; only the wording is, since there is no
+    # branch to name.
+    target_branch=""
+    block_reason="detaches HEAD in the main tree (\`git switch $detach_flag\`)"
+    return 0
+  fi
+
   case "$verb" in
     switch)
-      # `git switch <name>` / `git switch -c <name>` / `git switch -C <name>`
-      # (force-create), and the LONG forms of both. Reading only `-c` / `-C` got
-      # the verdict right and the TEXT wrong: `git switch --create feat/x`
-      # blocked while naming the branch `--create`, which is the name the
-      # message then tells you to replay in a worktree.
-      if [[ "$first_token" == "-c" || "$first_token" == "-C" \
-         || "$first_token" == "--create" || "$first_token" == "--force-create" ]]; then
-        target_branch="$second_token"
-        block_reason="creates new feature branch '$target_branch'"
-        return 0
-      fi
-      # `--detach` moves the SHARED tree off `main` exactly as a branch switch
-      # does, so the verdict is unchanged; only the wording is, since there is
-      # no branch to name.
-      if [[ "$first_token" == "--detach" || "$first_token" == "-d" ]]; then
-        target_branch=""
-        block_reason="detaches HEAD in the main tree (\`git switch $first_token\`)"
-        return 0
-      fi
-      target_branch="$first_token"
-      if [[ "$target_branch" == "main" || "$target_branch" == "master" ]]; then
-        return 1
-      fi
-      # `git switch -` (switch back to previous branch) — cannot be known
-      # without running git. Conservatively block; agents should not be using
-      # `git switch -` in the main tree anyway.
-      if [[ "$target_branch" == "-" ]]; then
-        block_reason="switches to previous branch (\`git switch -\`); resolved branch unknown — block conservatively"
-      else
-        block_reason="switches to feature branch '$target_branch'"
-      fi
-      return 0
+      case "$first_pos" in
+        main|master) return 1 ;;
+        -|@{-*)
+          # The pattern is the PREFIX `@{-`, without the closing brace, and that
+          # is measured rather than sloppy: `gate_segments` TRUNCATES a segment
+          # at a `}`, so the shared walk hands this gate `git checkout @{-1`
+          # (brace gone) for an input of `git checkout @{-1}`. A pattern
+          # requiring the `}` matched nothing and the shape stayed fail-open.
+          target_branch="$first_pos"
+          block_reason="switches to the previous branch (\`git switch $first_pos\`); resolved branch unknown -- block conservatively"
+          return 0
+          ;;
+        "")
+          # A bare `git switch` with no branch and no create flag. It is a git
+          # error, but block conservatively rather than reason about a shape
+          # nothing legitimate produces.
+          target_branch=""
+          block_reason="runs \`git switch\` in the main tree with no resolvable target -- block conservatively"
+          return 0
+          ;;
+        *)
+          target_branch="$first_pos"
+          block_reason="switches to feature branch '$first_pos'"
+          return 0
+          ;;
+      esac
       ;;
     checkout)
-      # `git checkout <name>` / `git checkout -b <name>` / `git checkout --
-      # <pathspec>` / `git checkout <sha>`.
-      if [[ "$first_token" == "-b" || "$first_token" == "-B" ]]; then
-        target_branch="$second_token"
-        block_reason="creates new feature branch '$target_branch'"
-        return 0
-      fi
-      # File restore — pass through.
-      [[ "$first_token" == "--" ]] && return 1
-      [[ "$first_token" == "main" || "$first_token" == "master" ]] && return 1
-      # `git checkout` with no args — defaults to file restore in some versions,
-      # a NOP in others. Pass through.
-      [[ -z "$first_token" ]] && return 1
-      # Could be a branch name or a sha. If it resolves to a local branch via
-      # `git show-ref refs/heads/<name>`, treat as a branch switch (block).
-      # Otherwise treat as sha / pathspec (pass).
-      if git -C "$dir" show-ref --verify --quiet "refs/heads/$first_token" 2>/dev/null; then
-        target_branch="$first_token"
-        block_reason="switches to feature branch '$first_token'"
-        return 0
-      fi
-      return 1
+      # `-p` / `--ours` / `--theirs` are RESTORE modes: measured, `-p <branch>`
+      # prints a diff and leaves HEAD on `main`, and `--ours` / `--theirs` print
+      # "Updated 0 paths from the index". Blocking them would be a false block of
+      # the same family as the `<branch> -- <paths>` one.
+      [ "$restore_flag" = 1 ] && return 1
+      # A `--` makes everything after it a pathspec and the leading positional a
+      # tree-ish to restore FROM: a file restore, whatever it names.
+      [ "$saw_ddash" -eq 1 ] && return 1
+      # No positional: a bare `git checkout` is a NOP or a restore depending on
+      # the git version. TWO OR MORE: `<tree-ish> <paths...>`, the same restore
+      # without the `--`. The count is of TRUE positionals -- every value-taking
+      # flag above consumed its own argument first.
+      [ "$npos" -ne 1 ] && return 1
+      case "$first_pos" in
+        main|master) return 1 ;;
+        -|@{-*)
+          # Measured: both print "Switched to branch 'other'" and move HEAD. They
+          # were ALLOWED here while the identical `git switch -` blocked.
+          target_branch="$first_pos"
+          block_reason="switches to the previous branch (\`git checkout $first_pos\`); resolved branch unknown -- block conservatively"
+          return 0
+          ;;
+        *)
+          # A branch name or a sha. A name resolving to a LOCAL branch is a
+          # branch switch; so is one that resolves only on a REMOTE (the DWIM
+          # arm below). A sha or a pathspec passes. Both questions are asked of
+          # the SEGMENT's own tree, since that is where the command would run.
+          if git -C "$dir" show-ref --verify --quiet "refs/heads/$first_pos" 2>/dev/null; then
+            target_branch="$first_pos"
+            block_reason="switches to feature branch '$first_pos'"
+            return 0
+          fi
+          # DWIM. With no LOCAL `<name>` but a remote carrying it,
+          # `git checkout <name>` CREATES the local branch and switches to it.
+          #
+          # The pattern is the PREFIX `refs/remotes/`, NOT `refs/remotes/*/*`. A
+          # `*` does not cross a `/` in for-each-ref, so the two-star form lists
+          # `origin/feat` and MISSES `origin/topic/nested` -- measured on a real
+          # clone, where `--format='%(refname:lstrip=3)' 'refs/remotes/*/*'`
+          # printed `HEAD feat main` while the prefix form printed
+          # `HEAD feat main topic/nested`, and git DWIMs the nested name just the
+          # same ("Switched to a new branch 'topic/nested'"). Slashed names are
+          # most of them in this flow, so the two-star form is fail-open here.
+          #
+          # `HEAD` is EXCLUDED, and that is measured rather than defensive: the
+          # list comes from `refs/remotes/`, which holds the SYMBOLIC
+          # `refs/remotes/origin/HEAD` in essentially every clone -- `lstrip=3`
+          # renders it as the bare word `HEAD`, and both cdkd and cdk-local carry
+          # it. But `git checkout HEAD` resolves HEAD as a rev and creates
+          # nothing -- measured, "Your branch is up to date", HEAD stayed `main`
+          # -- so matching it would refuse a read-only command in the main tree.
+          # A branch cannot be NAMED `HEAD` (`git branch HEAD` is fatal), so
+          # nothing real is lost. `grep -qxF` is an exact whole-LINE match, so a
+          # name that is merely a SUBSTRING of a remote branch does not
+          # false-block either.
+          if [ "$first_pos" != HEAD ] \
+            && git -C "$dir" for-each-ref --format='%(refname:lstrip=3)' 'refs/remotes/' 2>/dev/null \
+              | grep -qxF -- "$first_pos"; then
+            target_branch="$first_pos"
+            block_reason="creates a local branch tracking remote '$first_pos' and switches to it"
+            return 0
+          fi
+          return 1
+          ;;
+      esac
       ;;
   esac
   return 1

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -68,6 +68,7 @@ if ! declare -F gate_matches >/dev/null 2>&1 \
   || ! declare -F gate_unquote >/dev/null 2>&1 \
   || ! declare -F gate_tokens >/dev/null 2>&1 \
   || ! declare -F gate_argv >/dev/null 2>&1 \
+  || ! declare -F gate_word_is_literal >/dev/null 2>&1 \
   || [ -z "${GATE_EMBEDDING_TOKEN:-}" ] \
   || [ -z "${GATE_REDIR_TOKEN:-}" ]; then
   # `gate_verb_args_dir` is named too, not only `gate_matches`: it feeds the
@@ -89,7 +90,14 @@ if ! declare -F gate_matches >/dev/null 2>&1 \
   # everything. The conclusion -- name the constants, fail closed -- is right,
   # and the loop terminates only because `gate_tokens` breaks on an empty rest.)
   # `declare -F` cannot see a missing constant; only this can.
-  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches / gate_verb_args_dir / gate_unquote / gate_tokens / gate_argv / GATE_EMBEDDING_TOKEN / GATE_REDIR_TOKEN is undefined (truncated or stale file?)." >&2
+  #
+  # `gate_word_is_literal` is named for a third reason: it is the ONLY thing
+  # standing between the walk and a word whose expansion this gate cannot see.
+  # A library predating it makes the `if ! gate_word_is_literal ...` call exit
+  # 127, which `!` reads as TRUE, so every word would look unaccountable and the
+  # gate would block everything -- loud, but a gate that refuses `git checkout
+  # main` is as unusable as one that allows a switch. Refusing here says why.
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches / gate_verb_args_dir / gate_unquote / gate_tokens / gate_argv / gate_word_is_literal / GATE_EMBEDDING_TOKEN / GATE_REDIR_TOKEN is undefined (truncated or stale file?)." >&2
   exit 2
 fi
 
@@ -283,7 +291,43 @@ remote_dwim_names() {
 # takes no value and carries no effect -- measured: `git checkout --no-orphan
 # some-feature` and `git checkout --no-conflict some-feature` both switch, so the
 # name after them is a positional.
+#
+# `-h` IS NOT THE WHOLE GRAMMAR, and reading it as though it were is what made
+# this gate block commands git runs. Four options are accepted and not printed
+# there, three of them with rc=0 (measured, git 2.53.0, HEAD printed before and
+# after):
+#
+#   --end-of-options              rc=0;   stops option parsing (gitcli(7))
+#   --git-completion-helper       rc=0;   prints the completion list
+#   --git-completion-helper-all   rc=0;   prints it including hidden entries
+#   --help-all                    rc=129; prints the usage, HEAD unmoved
+#
+# All four are `parse-options` built-ins rather than checkout's own, so they
+# exist under BOTH verbs -- confirmed for each, e.g. `git switch
+# --end-of-options main` answers "Already on 'main'". They are at arity 0.
+#
+# THREE ARITIES HERE ARE INERT, and that is deliberate rather than an oversight:
+# `create:1`, `force-create:1` and `orphan:1` never take effect, because the
+# arity line sets `pending=skip` and the effect arm for those three immediately
+# overrides it with `pending=value` (the token IS the branch name, and it has to
+# be captured rather than merely consumed). They are written at their true arity
+# anyway, because this table's job is to state git's grammar -- lowering them to
+# 0 to match the code path would make the table lie about git and would break
+# the moment the effect arm changed.
+#
+# NOTHING PINS THESE TABLES TO THE INSTALLED GIT, stated as a residual rather
+# than hidden. A wholly NEW option name lands on `parse_certain=0` and blocks
+# (verified with `--frobnicate`), and a newly AMBIGUOUS prefix is moot because
+# git refuses the command as well. What would pass silently is an ARITY CHANGE
+# to a name already here -- `--track` going from optional to required, say --
+# because the walk would then consume the wrong token and could ALLOW.
+# Regenerating from `--git-completion-helper-all` would catch a new NAME but not
+# an arity change, so it is not the fix it looks like.
 GATE_CHECKOUT_LONG_OPTS='help:0
+help-all:0
+end-of-options:0
+git-completion-helper:0
+git-completion-helper-all:0
 guess:0
 no-guess:0
 overlay:0
@@ -324,6 +368,10 @@ pathspec-file-nul:0
 no-pathspec-file-nul:0'
 
 GATE_SWITCH_LONG_OPTS='help:0
+help-all:0
+end-of-options:0
+git-completion-helper:0
+git-completion-helper-all:0
 create:1
 no-create:0
 force-create:1
@@ -453,10 +501,71 @@ EOF
 #    general form of the two defects that a POSITIONAL COUNT produced -- first
 #    `--conflict merge <branch>` (a value read as a positional), then
 #    `<branch> 2>/dev/null` (a shell word read as a positional). Both were the
-#    count RELAXING a verdict on a parse that was not complete. Today the arm
-#    fires only on commands git itself refuses ("error: unknown option" /
-#    "error: ambiguous option"), so it costs nothing now; it is what keeps a
-#    FUTURE git option from re-opening the same hole silently.
+#    count RELAXING a verdict on a parse that was not complete.
+#
+#    IT DOES NOT COST NOTHING, and the claim that it did was measured FALSE. The
+#    arm was documented as firing "only on commands git itself refuses". Against
+#    git 2.53.0 it also fired on three git ACCEPTS: `git checkout
+#    --end-of-options main` (rc=0, HEAD stays), `--end-of-options -- f.txt`
+#    (rc=0, restores) and `--git-completion-helper` (rc=0, prints the list).
+#    Those are in the tables now. The residual trade is stated instead of
+#    denied: an option this gate has never heard of is blocked even when git
+#    would run it, because the alternative is to GUESS an arity, and a wrong
+#    arity moves every positional after it. A false block costs one message
+#    naming the option; a false allow costs a switched shared main tree.
+#
+# 4. A WORD THE SHELL OWNS MAY NOT RELAX EITHER. Property 3 is stated for git's
+#    OPTIONS, and for three rounds `gate_argv` did the opposite for the shell's
+#    WORDS: it enumerated the forms it recognised -- a redirection, a trailing
+#    `&`, a `#` comment -- and passed everything else through as an argument.
+#    Each round added a spelling and the next round found the one still missing.
+#    Last time that was `$EMPTY` / `${EMPTY}` (an empty expansion VANISHES, so a
+#    positional git never receives was counted) and `{fd}>/dev/null` (bash's
+#    fd-variable redirection, a word git never receives at all). Both made
+#    `git checkout <branch> <word>` read as a two-positional FILE RESTORE and
+#    PASS -- measured rc=0 where 2 is wanted, on commands that really move HEAD.
+#
+#    The default is therefore INVERTED rather than the list extended. Every word
+#    goes through `gate_word_is_literal`, which admits one only when each of its
+#    characters is on a closed list of characters the shell does not act on, and
+#    a word that fails sets `parse_certain=0`.
+#
+#    HOW WE KNOW A SHAPE NOBODY HAS THOUGHT OF LANDS ON BLOCK. Every shell
+#    construct is SPELLED, and spelled with characters. A construct outside that
+#    closed list -- one added to a future bash, one nobody here has met, one not
+#    written down anywhere -- necessarily contains a character the list does not
+#    hold, and is refused without anyone having enumerated it. The only escape
+#    would be a construct spelled ENTIRELY in inert characters, and an inert
+#    character is by definition one the shell does not act on. So the surface to
+#    audit is the LIST (in the shared library, with a reason recorded per
+#    member), not a catalogue of shell forms.
+#
+#    THE COST IS OVER-STRICTNESS, and it is real: `git checkout main -- "$f"` is
+#    a file restore, and this gate now blocks it, because it cannot see what
+#    `$f` holds. That cost was MEASURED rather than assumed, because inverting a
+#    default trades a silent class of bypasses for a loud class of false
+#    refusals and the trade is only defensible if the second number is known.
+#    Every `git checkout` / `git switch` in the three sibling repos' committed
+#    files was replayed through the hook before and after (payload cwd = a real
+#    main checkout, `<branch>` a branch that exists there):
+#
+#      corpus                                       206 distinct texts
+#      verdict changed 0 -> 2 (newly blocked)        32
+#        ...of those, documentation metasyntax
+#           (`<branch>`, `[<options>]`, table rows)  30
+#        ...runnable commands                         2
+#      verdict changed 2 -> 0 (newly allowed)         2   the `#`-comment fix
+#
+#    Narrowed to lines that actually EXECUTE -- excluding `*.test.sh` and
+#    comment lines -- the three repos hold exactly two `git checkout`
+#    invocations between them, both `git checkout -- "${WATCH_SRC}"` inside
+#    `tests/integration/local-start-api/verify.sh`. Neither is reachable by this
+#    hook: they run from a fixture subdirectory rather than the main worktree
+#    top level, and they run INSIDE a script, where a PreToolUse hook sees only
+#    `bash .../verify.sh`. So the measured false-block count on commands this repo
+#    actually runs is ZERO, and the escape when it is not is named in the
+#    message: spell the path literally, or run from outside the main tree, which
+#    is what the convention asks for anyway.
 #
 # The positional structure this parse still reads is the one GIT reads, and it is
 # a boolean rather than a tally: `first_pos` (the switch target) and
@@ -556,9 +665,9 @@ EOF
 verdict_for() {
   local verb="$1" rest="$2" dir="$3"
   local tok pending="" create_val="" create_flag="" detach_flag="" track_flag=""
-  local prev_ref="" bad_opt=""
-  local saw_help=0 saw_restore=0 end_opts=0 no_guess=0 detach_seen=0
-  local pathspec_seen=0 parse_certain=1 is_pos=0
+  local prev_ref="" bad_opt="" bad_word="" raw_tok="" argv="" argv_rc=0
+  local saw_help=0 saw_restore=0 end_opts=0 dashdash_seen=0 no_guess=0
+  local detach_seen=0 pathspec_seen=0 parse_certain=1 is_pos=0
   local npos=0 first_pos="" name lval lhas letters ch rc
   target_branch=""
   block_reason=""
@@ -567,17 +676,59 @@ verdict_for() {
   # a quote is unbalanced, and `gate_argv` reports that rather than returning a
   # truncation -- `-b agent's-branch` used to yield the single token `-b`, which
   # read as a bare `git checkout` and PASSED. Refusing is the deliberate choice
-  # over a coarser second scan: the text is a shell syntax error in the first
-  # place (measured: "unexpected EOF while looking for matching `''"), so nothing
-  # legitimate is lost, and the message says exactly why.
-  if ! gate_argv "$rest" >/dev/null 2>&1; then
+  # over a coarser second scan: bash refuses to run that text at all ("unexpected
+  # EOF while looking for matching `''"), so nothing legitimate is lost, and the
+  # message says exactly why.
+  #
+  # A `#` COMMENT IS NO LONGER PART OF THAT QUESTION. `gate_argv` cuts one before
+  # it splits, so an apostrophe inside a comment is never weighed as a quote:
+  # `git checkout main # don't switch lanes` blocked here until round 4, on a
+  # command bash calls valid and git answers with "Already on 'main'".
+  #
+  # CAPTURED ONCE. This used to call `gate_argv` for the rc and again to feed the
+  # walk -- two parses of one text, and two chances for them to disagree.
+  argv=$(gate_argv "$rest")
+  argv_rc=$?
+  if [ "$argv_rc" -ne 0 ]; then
     target_branch=""
     block_reason="carries an argument list this gate cannot split into shell words (unbalanced quote), so its target cannot be read -- block conservatively"
     return 0
   fi
 
-  while IFS= read -r tok; do
-    tok=$(gate_unquote "$tok")
+  while IFS= read -r raw_tok; do
+    # A here-string over an EMPTY capture still yields one blank line, and a
+    # blank word must not be counted as a positional: it made a bare
+    # `git checkout` read as `git checkout ''`, whose DWIM probe
+    # (`grep -qxF -- ""`) matches every remote branch name there is.
+    [ -n "$raw_tok" ] || continue
+    # EVERY WORD IS PROVED LITERAL BEFORE ANY ARM READS IT -- property 4 in the
+    # header, the same "an incomplete parse may not ALLOW" fence applied to the
+    # SHELL's grammar instead of git's. `gate_argv` prints the words that are
+    # neither a redirection nor a comment; it does not promise they reach git as
+    # the text printed, and `$EMPTY` / `{fd}>/dev/null` are two measured shapes
+    # where they do not.
+    #
+    # ONE SHAPE IS EXEMPT, and the exemption is PROVED rather than assumed: a
+    # word beginning with the literal characters `@{-`. No expansion can produce
+    # or remove those three characters, so such a word always survives as at
+    # least one word -- it can never VANISH, which is the only direction that
+    # turns a switch into a file restore. Its verdict here is the previous-branch
+    # BLOCK, and the only thing that relaxes that is MORE positionals, which an
+    # expansion can only add. Without the exemption the walk would still block
+    # `git checkout @{-1}` (right) but also `git checkout @{-1} -- README.md`,
+    # which restores a file and leaves HEAD alone -- measured, and a case in this
+    # suite. `gate_segments` truncates the segment at the `}`, so the word
+    # arriving here is `@{-1`; the pattern is the prefix for that reason.
+    case "$raw_tok" in
+      '@{-'*) : ;;
+      *)
+        if ! gate_word_is_literal "$raw_tok"; then
+          parse_certain=0
+          [ -n "$bad_word" ] || bad_word="$raw_tok"
+        fi
+        ;;
+    esac
+    tok=$(gate_unquote "$raw_tok")
     is_pos=0
     if [ -n "$pending" ]; then
       # `value` is a branch name; `skip` is some other flag's required argument,
@@ -591,7 +742,11 @@ verdict_for() {
         # `--` ends the options. Under CHECKOUT everything after it is a
         # pathspec; under SWITCH there is no pathspec form, so what follows is
         # still the branch. Both measured.
-        --) end_opts=1 ;;
+        # `dashdash_seen` carries the PATHSPEC half separately, because
+        # `--end-of-options` ends the options too and does NOT give what follows
+        # checkout's pathspec meaning -- measured, `git checkout
+        # --end-of-options some-feature` really switches.
+        --) end_opts=1; dashdash_seen=1 ;;
         # `-` and `@{-N}` name the PREVIOUS branch under BOTH verbs. The pattern
         # is the PREFIX `@{-`, without the closing brace, and that is measured
         # rather than sloppy: `gate_segments` TRUNCATES a segment at a `}`, so
@@ -640,6 +795,17 @@ verdict_for() {
               # judge.
               guess) no_guess=0 ;;
               no-guess) no_guess=1 ;;
+              # `--end-of-options` stops OPTION parsing without making the next
+              # token a pathspec -- gitcli(7)'s idiom for a script handling an
+              # untrusted ref. Measured against git 2.53.0: `--end-of-options
+              # main` stays on main, `--end-of-options -- f.txt` restores, and
+              # `--end-of-options some-feature` SWITCHES. So it sets `end_opts`
+              # and NOT `dashdash_seen`, and the third shape blocks through the
+              # ordinary local-branch arm rather than through a special case.
+              end-of-options) end_opts=1 ;;
+              # `--help-all` / `--git-completion-helper[-all]` are accepted and
+              # carry no effect on the positionals; they are in the tables so
+              # they resolve rather than land on the unknown-option block.
               *) : ;;
             esac
           fi
@@ -694,25 +860,38 @@ verdict_for() {
       esac
     fi
     if [ "$is_pos" -eq 1 ]; then
-      if [ "$end_opts" -eq 1 ] && [ "$verb" = checkout ]; then
+      if [ "$dashdash_seen" -eq 1 ] && [ "$verb" = checkout ]; then
         pathspec_seen=1
       else
         npos=$((npos + 1))
         if [ "$npos" -eq 1 ]; then first_pos="$tok"; else pathspec_seen=1; fi
       fi
     fi
-  done < <(gate_argv "$rest")
+  done <<EOF
+$argv
+EOF
 
-  [ "$saw_help" -eq 1 ] && return 1
-
+  # THE FENCE COMES FIRST, ahead of every arm that ALLOWS -- `--help` included.
+  # `saw_help` used to return above it, which made the help arm the one relaxing
+  # verdict that skipped the fence this whole design rests on: `git checkout
+  # --frobnicate --help` allowed. Harmless in that spelling, since git answers
+  # "unknown option" and HEAD does not move, but an exemption with no argument
+  # behind it is what the next round finds.
   if [ "$parse_certain" -eq 0 ]; then
-    # Property 3 in the header. The walk met an option it could not resolve, so
+    # Properties 3 and 4 in the header. The walk met an OPTION it could not
+    # resolve against git's grammar, or a WORD whose expansion it cannot see, so
     # it does not know where the positionals are; refusing is the only answer
     # that cannot be wrong in the dangerous direction.
     target_branch=""
-    block_reason="uses an option this gate cannot resolve against \`git $verb\`'s grammar ($bad_opt), so its target cannot be read -- block conservatively"
+    if [ -n "$bad_opt" ]; then
+      block_reason="uses an option this gate cannot resolve against \`git $verb\`'s grammar ($bad_opt), so its target cannot be read -- block conservatively"
+    else
+      block_reason="carries the word \`$bad_word\`, whose expansion this gate cannot see, so its target cannot be read -- block conservatively"
+    fi
     return 0
   fi
+
+  [ "$saw_help" -eq 1 ] && return 1
 
   if [ -n "$create_flag" ]; then
     target_branch="$create_val"

--- a/.claude/hooks/main-tree-branch-gate.sh
+++ b/.claude/hooks/main-tree-branch-gate.sh
@@ -67,20 +67,29 @@ if ! declare -F gate_matches >/dev/null 2>&1 \
   || ! declare -F gate_verb_args_dir >/dev/null 2>&1 \
   || ! declare -F gate_unquote >/dev/null 2>&1 \
   || ! declare -F gate_tokens >/dev/null 2>&1 \
-  || [ -z "${GATE_EMBEDDING_TOKEN:-}" ]; then
+  || ! declare -F gate_argv >/dev/null 2>&1 \
+  || [ -z "${GATE_EMBEDDING_TOKEN:-}" ] \
+  || [ -z "${GATE_REDIR_TOKEN:-}" ]; then
   # `gate_verb_args_dir` is named too, not only `gate_matches`: it feeds the
   # segment loop through a process substitution, so a library that predates it
   # yields NO lines, the loop body never runs, and the gate exits 0 -- a silent
   # bypass with no error anywhere. That is precisely what this fail-closed
   # check exists to stop.
   #
-  # `GATE_EMBEDDING_TOKEN` is a CONSTANT, not a function, and it is named here
-  # because the shared `gate_tokens` interpolates it into the `[[ =~ ]]` that splits
-  # the argument text. A library predating it leaves the pattern EMPTY, the match
-  # then succeeds on any input with `${BASH_REMATCH[1]}` empty, and the token
-  # walk yields nothing -- so every command would look like a bare
-  # `git checkout` and pass. `declare -F` cannot see that; only this can.
-  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches / gate_verb_args_dir / gate_unquote / gate_tokens / GATE_EMBEDDING_TOKEN is undefined (truncated or stale file?)." >&2
+  # `GATE_EMBEDDING_TOKEN` and `GATE_REDIR_TOKEN` are CONSTANTS, not functions,
+  # and they are named here because the shared `gate_tokens` / `gate_argv`
+  # interpolate them into the `[[ =~ ]]` that splits the argument text and the
+  # one that spots a redirection. A library predating either leaves that pattern
+  # EMPTY, and an empty ERE matches EVERY string at position 0 with every capture
+  # group empty -- so `gate_tokens` would print an empty first token forever and
+  # `gate_argv` would drop every word as a redirection. Either way the walk
+  # yields nothing usable and every command reads like a bare `git checkout`.
+  # (The earlier note here said the loop's `[[ =~ ]]` "does NOT match" with an
+  # empty token, which is the wrong mechanism: an empty pattern matches
+  # everything. The conclusion -- name the constants, fail closed -- is right,
+  # and the loop terminates only because `gate_tokens` breaks on an empty rest.)
+  # `declare -F` cannot see a missing constant; only this can.
+  echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches / gate_verb_args_dir / gate_unquote / gate_tokens / gate_argv / GATE_EMBEDDING_TOKEN / GATE_REDIR_TOKEN is undefined (truncated or stale file?)." >&2
   exit 2
 fi
 
@@ -136,6 +145,17 @@ canonicalize() {
 # per matched segment, since `-C` / a preceding `cd` can put two segments of one
 # command in two different trees.
 #
+# NO MEMO HERE, and cdkd's copy HAS one -- stated because the argument for this
+# gate is "one function with two homes", so a reader of either file should be
+# able to see where the two stop agreeing. cdkd caches the last <dir> and its
+# answer in a pair of globals, returning through a global rather than on stdout
+# (a command substitution would put both memo variables in a subshell that exits
+# immediately -- it did, and a 3-segment same-tree command forked
+# `git worktree list` three times under a comment claiming the saving). This
+# copy forks once per matching segment. The divergence lived only in a commit
+# message until 2026-09-02, which is to say nowhere a reader of this file could
+# find it.
+#
 # LIMIT, stated rather than hidden. `gate_segments` FLATTENS a subshell, so a
 # `cd` inside one leaks past the closing paren and steers every later segment:
 #
@@ -173,97 +193,339 @@ main_tree_of() {
 }
 
 
+# remote_dwim_names <dir>
+#
+# One candidate DWIM name per line: the names `git checkout <name>` may CREATE a
+# local branch for and switch to, because a remote carries them. Two things it
+# must get right, both measured against real git 2.53 on a fixture clone:
+#
+#   SYMREFS ARE NOT BRANCHES. `refs/remotes/<remote>/HEAD` exists in essentially
+#     every clone, and `%(refname:lstrip=3)` renders it as the bare name `HEAD`.
+#     Real git leaves HEAD exactly where it was for `git checkout HEAD`
+#     (measured: "Your branch is ahead of 'origin/main'", HEAD stayed `main`), so
+#     a list carrying it false-blocks a read-only command. `git branch HEAD` is
+#     refused by git itself, so dropping symrefs costs no real candidate.
+#
+#   A REMOTE NAME MAY CONTAIN A SLASH, so a fixed `lstrip=3` is wrong. `git
+#     remote add a/b <url>` is accepted -- measured -- and the branch `deep-only`
+#     on it lands at `refs/remotes/a/b/deep-only`, which lstrips to
+#     `b/deep-only` while git DWIMs plain `deep-only` ("Switched to a new branch
+#     'deep-only'", HEAD moved). A gate comparing against `b/deep-only` PASSES
+#     that switch -- measured against this gate before this function replaced the
+#     `lstrip=3` scan: rc=0 where 2 is wanted. The prefix is therefore stripped
+#     PER REMOTE using the remote's own name, so it is right whatever the name
+#     contains.
+#
+# ITERATING THE CONFIGURED REMOTES is also what makes the list stop at what git
+# will actually DWIM. A ref can sit under `refs/remotes/<name>/` with no remote
+# `<name>` configured -- `git update-ref` puts one there, and a removed remote
+# can leave one behind. Measured: with `refs/remotes/ghostremote/ghost` present
+# and no `ghostremote` remote, `git checkout ghost` answers "pathspec 'ghost'
+# did not match any file(s) known to git" and HEAD stays -- while a scan of
+# `refs/remotes/` alone offered `ghost` as a candidate and this gate blocked it.
+#
+# WHAT IT DOES NOT CHECK, stated because an earlier wording claimed it did: there
+# is no UNIQUENESS check. With the same name on two remotes git REFUSES ("hint:
+# If you meant to check out a remote tracking branch on, e.g. 'origin'", HEAD
+# stays -- measured) while this list still offers the name and the gate blocks.
+# That is the conservative direction, so the behaviour stays; the claim that the
+# list holds only names "exactly one remote carries" does not.
+#
+# The pattern stays the PREFIX `refs/remotes/<remote>/`, never `.../*/*`: in
+# `for-each-ref` a `*` does not cross a `/`, so the two-star form misses every
+# slashed BRANCH name (`origin/topic/nested`), which is most of them in this flow.
+remote_dwim_names() {
+  local dir="$1" remote refname symref
+  while IFS= read -r remote; do
+    [ -n "$remote" ] || continue
+    # `%(refname)` FIRST and the symref second: with `IFS=<tab>` a LEADING empty
+    # field is eaten (tab is IFS whitespace), so the symref-first spelling shifts
+    # every ordinary ref's name into the wrong variable. In this order the
+    # `IFS=$'\t' read` spelling is safe -- git refuses a ref name containing any
+    # ASCII control character, tab included, so neither field can hold a tab run
+    # for `read` to fold.
+    while IFS=$'\t' read -r refname symref; do
+      [ -n "$refname" ] || continue
+      [ -z "$symref" ] || continue
+      printf '%s\n' "${refname#refs/remotes/$remote/}"
+    done < <(git -C "$dir" for-each-ref \
+      --format=$'%(refname)\t%(symref)' "refs/remotes/$remote/" 2>/dev/null)
+  done < <(git -C "$dir" remote 2>/dev/null)
+}
+
+# The LONG-OPTION grammar of each verb, transcribed from `git checkout -h` /
+# `git switch -h` (git 2.53.0), one `<name>:<arity>` per line:
+#
+#   0   takes nothing
+#   1   REQUIRES a value, which the spaced spelling takes from the NEXT token
+#   ?   OPTIONAL value, which the spaced spelling does NOT take -- measured,
+#       `git checkout -t origin/remote-only` creates local `remote-only`, so the
+#       ref that follows is a start-point POSITIONAL and not the flag's argument
+#
+# It is COMPLETE rather than a list of the interesting flags, and that is
+# load-bearing twice over.
+#
+#   git ACCEPTS ANY UNAMBIGUOUS PREFIX of a long name, which `-h` does not show
+#     and an earlier revision of this parse took from `-h` alone. Measured:
+#     `git checkout --orph newb` prints "Switched to a new branch 'newb'",
+#     `git checkout --or newb` does the same (`orphan` is the only name starting
+#     `or`), and `git checkout --trac origin/<b>` creates local `<b>` and
+#     switches. All three scored rc=0 against this gate before the table existed.
+#     A prefix can only be resolved against the WHOLE name set, so a table
+#     holding just the flags this gate cares about would answer "unknown" for
+#     `--or` one day and "ambiguous" the next as the set changed.
+#
+#   AN UNMODELLED VALUE-TAKING FLAG MOVES EVERY POSITIONAL AFTER IT. That is the
+#     `--conflict merge <branch>` defect, and it is a defect of the TABLE, not of
+#     the walk.
+#
+# Every `--[no-]x` line in `-h` contributes BOTH `x` and `no-x`. The negated form
+# takes no value and carries no effect -- measured: `git checkout --no-orphan
+# some-feature` and `git checkout --no-conflict some-feature` both switch, so the
+# name after them is a positional.
+GATE_CHECKOUT_LONG_OPTS='help:0
+guess:0
+no-guess:0
+overlay:0
+no-overlay:0
+quiet:0
+no-quiet:0
+recurse-submodules:?
+no-recurse-submodules:0
+progress:0
+no-progress:0
+merge:0
+no-merge:0
+conflict:1
+no-conflict:0
+detach:0
+no-detach:0
+track:?
+no-track:0
+force:0
+no-force:0
+orphan:1
+no-orphan:0
+overwrite-ignore:0
+no-overwrite-ignore:0
+ignore-other-worktrees:0
+no-ignore-other-worktrees:0
+ours:0
+theirs:0
+patch:0
+no-patch:0
+unified:1
+inter-hunk-context:1
+ignore-skip-worktree-bits:0
+no-ignore-skip-worktree-bits:0
+pathspec-from-file:1
+no-pathspec-from-file:0
+pathspec-file-nul:0
+no-pathspec-file-nul:0'
+
+GATE_SWITCH_LONG_OPTS='help:0
+create:1
+no-create:0
+force-create:1
+no-force-create:0
+guess:0
+no-guess:0
+discard-changes:0
+no-discard-changes:0
+quiet:0
+no-quiet:0
+recurse-submodules:?
+no-recurse-submodules:0
+progress:0
+no-progress:0
+merge:0
+no-merge:0
+conflict:1
+no-conflict:0
+detach:0
+no-detach:0
+track:?
+no-track:0
+force:0
+no-force:0
+orphan:1
+no-orphan:0
+overwrite-ignore:0
+no-overwrite-ignore:0
+ignore-other-worktrees:0
+no-ignore-other-worktrees:0'
+
+# resolve_long_opt <verb> <name-without-dashes>
+#
+# Answers in the globals `gate_long` (the canonical name) and `gate_long_arity`.
+# Returns 0 on a resolved name, 1 on an unknown one, 2 on an AMBIGUOUS prefix --
+# and git's own answers for those two are "error: unknown option" and "error:
+# ambiguous option", both of which abort the command without touching HEAD.
+# An EXACT match wins over any prefix, as it does in git's parse-options.
+gate_long=""
+gate_long_arity=""
+resolve_long_opt() {
+  local verb="$1" name="$2" table n a hits=0
+  gate_long=""
+  gate_long_arity=""
+  if [ "$verb" = switch ]; then table="$GATE_SWITCH_LONG_OPTS"; else table="$GATE_CHECKOUT_LONG_OPTS"; fi
+  while IFS=: read -r n a; do
+    [ -n "$n" ] || continue
+    if [ "$n" = "$name" ]; then
+      gate_long="$n"
+      gate_long_arity="$a"
+      return 0
+    fi
+  done <<EOF
+$table
+EOF
+  while IFS=: read -r n a; do
+    [ -n "$n" ] || continue
+    # `$name` is QUOTED so a glob character inside it is literal; the trailing
+    # `*` is the only wildcard.
+    case "$n" in
+      "$name"*) hits=$((hits + 1)); gate_long="$n"; gate_long_arity="$a" ;;
+    esac
+  done <<EOF
+$table
+EOF
+  [ "$hits" -eq 1 ] && return 0
+  gate_long=""
+  gate_long_arity=""
+  [ "$hits" -eq 0 ] && return 1
+  return 2
+}
+
 # verdict_for <verb> <args> <dir>
 # 0 = this segment must be BLOCKED (with `target_branch` / `block_reason` set),
 # 1 = allowed. <args> is everything after the matched verb, flags included,
-# because the verb ERE already consumed the leading `git -C … ` flag run.
+# because the verb ERE already consumed the leading `git -C ... ` flag run.
 #
 #   `git switch <main|master>`             -> allow
 #   `git checkout <main|master>`           -> allow
+#   `git switch -- <main|master>`          -> allow (`--` under switch only ends
+#                                            the options; switch has no pathspec)
 #   `git switch -c|-C|--create|--force-create <branch>` -> block
 #   `git switch|checkout --orphan <branch>`             -> block
-#   `git switch <other-branch>`            -> block
+#   `git switch <other-branch>` / `git switch -- <other-branch>` -> block
 #   `git switch|checkout -` / `@{-1}`      -> block (previous branch, unknowable)
 #   `git switch --detach`                  -> block
 #   `git checkout -b|-B <branch>`          -> block
 #   `git switch|checkout -t|--track <remote-ref>` -> block (DWIM create + switch)
-#   `git checkout <other-branch>`          -> block when it is the ONLY
-#                                            positional AND names a LOCAL branch
-#                                            or a branch on some REMOTE
+#   `git checkout <other-branch>`          -> block when NO pathspec operand
+#                                            follows it AND it names a LOCAL
+#                                            branch or a branch on a CONFIGURED
+#                                            remote
+#   `git checkout <branch> --`             -> block: a `--` with nothing after it
+#                                            leaves no pathspec, so this is the
+#                                            switch (measured: HEAD moved)
 #   `git checkout [<tree-ish>] -- <paths>` -> allow (file restore)
 #   `git checkout <tree-ish> <paths>`      -> allow (file restore, no `--`)
-#   `git checkout -p|--ours|--theirs …`    -> allow (restore modes)
+#   `git checkout -p|--ours|--theirs|--pathspec-from-file ...` -> allow (restore)
+#   `git checkout --no-guess <remote-only-name>` -> allow (DWIM is off; measured,
+#                                            "pathspec did not match", HEAD stays)
 #   `git checkout <sha>` / `HEAD`          -> allow (detached HEAD / a rev)
 #   `git switch|checkout --help`           -> allow
 #
-# A REAL OPTION PARSE, not "read token 1 and token 2", and not a token walk that
-# only knows the SPACED spelling of a flag. The option grammar comes from
-# `git checkout -h` / `git switch -h` (git 2.53.0) rather than from memory:
+# A REAL OPTION PARSE over git's ARGV. Three properties carry the whole design,
+# and each replaced a class of defect rather than a spelling:
 #
-#   value-taking, BOTH verbs   --conflict <style>
-#   value-taking, checkout     -b -B <branch>, -U/--unified <n>,
-#                              --inter-hunk-context <n>,
-#                              --pathspec-from-file <file>
-#   value-taking, switch       -c -C / --create --force-create <branch>
-#   value-taking, both         --orphan <new-branch>
-#   OPTIONAL value             -t/--track[=(direct|inherit)],
-#                              --recurse-submodules[=<checkout>]
-#                              -- the SPACED form does NOT consume the next token
-#   restore modes, checkout    -p/--patch, -2/--ours, -3/--theirs
+# 1. THE INPUT IS ARGV, NOT SHELL WORDS. `gate_argv` drops the words the SHELL
+#    owns -- a redirection and its target, a trailing `&`, a `#` comment -- so
+#    they cannot be miscounted as arguments. Reading `gate_tokens` output
+#    directly made `git checkout <branch> 2>/dev/null`, `... >/dev/null 2>&1` and
+#    `... # switch lane` read as two-positional file restores and PASS; all three
+#    really move HEAD (measured, `main` -> `some-feature`).
 #
-# Every wanted verdict below was settled against real git first, printing HEAD
-# and the local branch list before and after the command. The defects this
-# replaces, in the order they were found:
+# 2. FLAGS ARE RESOLVED AGAINST A COMPLETE GRAMMAR, prefixes included (see the
+#    tables above), and a SHORT token is walked as a CLUSTER because git's
+#    parse-options accepts `-qbfeat` as `-q -b feat` and takes the remainder of
+#    the cluster as a value-taking letter's value. Every glued spelling --
+#    `-bfeat`, `-Bfeat`, `-cfeat`, `-Cfeat`, `--create=feat`, `--orphan=feat` --
+#    was measured creating the branch and switching to it.
+#
+# 3. AN INCOMPLETE PARSE MAY NOT ALLOW. When a long name resolves to no entry or
+#    to more than one, or a cluster letter is unknown, the walk does not know
+#    where the positionals are -- it cannot tell whether the flag would have
+#    eaten the next token. Every arm below that ALLOWS depends on that knowledge;
+#    the arms that BLOCK do not. So an unresolved option sets `parse_certain=0`
+#    and the verdict is a conservative block naming the option. This is the
+#    general form of the two defects that a POSITIONAL COUNT produced -- first
+#    `--conflict merge <branch>` (a value read as a positional), then
+#    `<branch> 2>/dev/null` (a shell word read as a positional). Both were the
+#    count RELAXING a verdict on a parse that was not complete. Today the arm
+#    fires only on commands git itself refuses ("error: unknown option" /
+#    "error: ambiguous option"), so it costs nothing now; it is what keeps a
+#    FUTURE git option from re-opening the same hole silently.
+#
+# The positional structure this parse still reads is the one GIT reads, and it is
+# a boolean rather than a tally: `first_pos` (the switch target) and
+# `pathspec_seen` (a pathspec operand exists). Git's own grammar is
+# `git checkout [<options>] <branch>` OR
+# `git checkout [<options>] [<branch>] -- <file>...`, so no correct gate can
+# avoid asking whether an operand follows the target -- `git checkout <branch>
+# <path>` restores a file and leaves HEAD alone while `git checkout <branch>`
+# switches, and only the extra operand tells them apart (both measured). What is
+# fixed is WHAT is examined: git's argv, fully parsed, or nothing.
+#
+# Verdicts settled against real git first, printing HEAD and the local branch
+# list before and after. The defects this parse replaced, in the order found:
 #
 #   git checkout <branch> -- <paths>   was BLOCKED, and must not be: it restores
-#     FILES and leaves HEAD alone. Measured -- HEAD stayed `main`, f.txt took the
-#     other branch's content. `git checkout <branch> <paths>` without the `--`
-#     behaves identically ("Updated 1 path from …"), which is why the rule is
-#     "two or more positionals is a restore" rather than "a `--` was seen".
-#     go-to-k/cdk-real-drift MANDATES the `--` spelling for its integration step,
-#     so the old reading refused a sibling repo's own documented flow.
+#     FILES and leaves HEAD alone. `git checkout <branch> <paths>` without the
+#     `--` behaves identically. go-to-k/cdk-real-drift MANDATES the `--` spelling
+#     for its integration step, so the old reading refused a sibling repo's own
+#     documented flow.
 #
-#   git checkout -f <branch>           was ALLOWED, and must not be: `-f` was
-#     read AS the branch name, `refs/heads/-f` does not resolve, and the gate
-#     passed. Measured -- "Switched to branch 'feat'". ANY flag before the branch
-#     did this.
+#   git checkout <branch> --           was ALLOWED once that fix shipped, and
+#     must not be: a `--` with NOTHING after it leaves no pathspec at all.
+#     Measured -- "Switched to branch 'some-feature'", HEAD moved. The rule is
+#     therefore "a pathspec operand exists", not "a `--` was seen".
+#
+#   git switch -- main                 was BLOCKED, and must not be: `git switch`
+#     has NO pathspec form (`usage: git switch [<options>] [<branch>]`), so `--`
+#     there only ends the options. Measured -- "Already on 'main'". The same
+#     token walk was applying checkout's grammar to both verbs, and the command
+#     landed on the "no resolvable target" arm. `git switch -- <feature>` DOES
+#     switch (measured), so that one still blocks.
+#
+#   git checkout -f <branch>           was ALLOWED: `-f` was read AS the branch
+#     name, `refs/heads/-f` does not resolve, and the gate passed.
 #
 #   git checkout --orphan <branch>     was ALLOWED: `--orphan` was read as the
-#     branch name. Measured -- "Switched to a new branch 'wt-new'".
+#     branch name.
 #
 #   git checkout <name> / -t origin/<name>
 #     were ALLOWED. With no LOCAL `<name>` but a remote carrying it, both CREATE
-#     the local branch and switch -- measured on a real clone, HEAD went
-#     `main` -> `feat`, git printing "Switched to a new branch". That is how a
-#     lane's branch usually FIRST appears in a checkout, so a local-only
-#     `show-ref` was blind to the commonest spelling of what this gate guards.
+#     the local branch and switch -- measured, HEAD went `main` -> `feat`. That is
+#     how a lane's branch usually FIRST appears in a checkout.
 #
 #   git checkout -  /  git checkout @{-1}   were ALLOWED while `git switch -`
 #     blocked. Measured -- both print "Switched to branch 'other'" and move HEAD.
-#     `@{-1}` was allowed under `checkout` only; `switch` blocked it by falling
-#     through its catch-all, i.e. by accident rather than by rule.
 #
-#   GLUED flag spellings were ALL invisible: `-bfeat`, `-Bfeat`, `-cfeat`,
-#     `-Cfeat`, `--create=feat`, `--force-create=feat`, `--orphan=feat`. Each was
-#     measured creating the branch and switching to it. A short flag is now
-#     parsed as a CLUSTER (`-qbfeat` = `-q -b feat`), so the glued and spaced
-#     spellings cannot diverge again, and a long flag is split on its first `=`.
+#   git checkout --conflict merge <branch>   was ALLOWED: `merge` inflated a
+#     positional count and the command read as a restore. Measured -- it switches.
 #
-#   git checkout --conflict merge <branch>   was ALLOWED: a positional COUNT is
-#     not a parse. `merge` inflated the count to 2 and the command was read as a
-#     restore. Measured -- it switches. Value-taking flags now CONSUME their
-#     argument, from the list above, so the count is a count of true positionals.
+#   git checkout --orph <branch> / --trac origin/<b> / --or <b>   were ALLOWED:
+#     git accepts unambiguous PREFIXES of a long name and the parse only knew the
+#     full spellings. Measured -- all three move HEAD.
 #
-#   git checkout HEAD                  is a FALSE BLOCK waiting to happen, and it
-#     is closed here rather than shipped: the DWIM list comes from `refs/remotes/`
-#     and every clone carries the SYMBOLIC `refs/remotes/origin/HEAD`, which
-#     `lstrip=3` renders as the bare word `HEAD`. Measured -- `git checkout HEAD`
-#     prints "Your branch is up to date" and creates nothing.
+#   git checkout deep-only             was ALLOWED where `deep-only` lives on a
+#     remote whose NAME contains a slash. Measured -- "Switched to a new branch
+#     'deep-only'". The DWIM list was built with a fixed `lstrip=3`.
 #
-#   git checkout -p <branch> / --ours / --theirs   would be FALSE BLOCKS for the
-#     same reason as the `<branch> -- <paths>` restore. Measured -- `-p` prints a
-#     diff and leaves HEAD on `main`; `--ours` / `--theirs` print "Updated 0
-#     paths from the index".
+#   git checkout ghost                 was BLOCKED where `refs/remotes/ghostremote/ghost`
+#     exists with NO `ghostremote` remote configured. Measured -- "pathspec
+#     'ghost' did not match", HEAD stays.
+#
+#   git checkout --pathspec-from-file <f> <branch>   was BLOCKED: the pathspecs
+#     come FROM THE FILE, so the trailing token is the tree-ish and the command is
+#     a RESTORE. Measured -- "Updated 1 path from ...", HEAD stayed `main`. The
+#     flag had been filed with `--conflict` as merely value-taking.
+#
+#   git checkout --no-guess <remote-only-name>   was BLOCKED: `--no-guess` turns
+#     the DWIM off, so git answers "pathspec did not match" and HEAD stays --
+#     measured, against a name that DID move HEAD without the flag.
 #
 # `--detach` stays asymmetric between the verbs: `git switch --detach` blocks
 # while `git checkout <sha>` / `git checkout --detach <sha>` passes. That is the
@@ -280,145 +542,180 @@ main_tree_of() {
 # change with its own blast radius (it would refuse a legitimate inspection
 # spelling in three repos) and belongs in its own PR, not smuggled into a parse
 # fix -- recorded here and in .claude/rules/hooks.md so the next reader inherits
-# the measurement rather than the old claim.
+# the measurement rather than the old claim. What IS fixed here is the WORDING:
+# `git checkout -d <branch>` / `--detach <branch>` really detaches (measured,
+# HEAD went to a raw sha), and the block used to announce it as "switches to
+# feature branch '<branch>'" -- a verdict that was right about an operation git
+# would not perform.
+#
+# KNOWN BOUND, in the message rather than the verdict: `gate_segments` truncates
+# a segment at a `}`, so `git switch -c 'feat/{id}'` blocks correctly but the
+# message and its `git worktree add` recipe name `feat/{id` . The cause is in the
+# shared splitter, which every gate in the library calls; it is recorded in
+# .claude/rules/hooks-main-tree-branch.md rather than worked around here.
 verdict_for() {
   local verb="$1" rest="$2" dir="$3"
-  local tok pending="" create_val="" create_flag="" detach_flag=""
-  local saw_help=0 saw_ddash=0 track_flag=0 restore_flag=0
-  local npos=0 first_pos="" lname lval lhas letters ch
+  local tok pending="" create_val="" create_flag="" detach_flag="" track_flag=""
+  local prev_ref="" bad_opt=""
+  local saw_help=0 saw_restore=0 end_opts=0 no_guess=0 detach_seen=0
+  local pathspec_seen=0 parse_certain=1 is_pos=0
+  local npos=0 first_pos="" name lval lhas letters ch rc
   target_branch=""
   block_reason=""
-  while IFS= read -r tok; do
-    tok=$(gate_unquote "$tok")
-    if [ -n "$pending" ]; then
-      # `value` is a branch name; `skip` is some other flag's argument, consumed
-      # only so it cannot be miscounted as a positional.
-      [ "$pending" = value ] && create_val="$tok"
-      pending=""
-      continue
-    fi
-    case "$tok" in
-      # Everything after `--` is a pathspec, never a branch. Under `checkout`
-      # the token BEFORE it is then a tree-ish to restore FROM, not a switch
-      # target. Remembered rather than just broken out of, because the leading
-      # positional has already been counted by the time we get here.
-      --) saw_ddash=1; break ;;
-      --*)
-        # A long flag. Split on the FIRST `=`, so the glued and spaced spellings
-        # of a value-taking flag reach the same arm. `--no-<x>` negations fall to
-        # the catch-all and are valueless, which is what git does with them.
-        case "$tok" in
-          --*=*) lname="${tok%%=*}"; lval="${tok#*=}"; lhas=1 ;;
-          *)     lname="$tok";       lval="";          lhas=0 ;;
-        esac
-        case "$lname" in
-          --help) saw_help=1 ;;
-          --create|--force-create)
-            # `switch`'s create pair. `checkout` has no long create flag.
-            if [ "$verb" = switch ]; then
-              create_flag="$lname"
-              if [ "$lhas" = 1 ]; then create_val="$lval"; else pending=value; fi
-            fi
-            ;;
-          --orphan)
-            create_flag="$lname"
-            if [ "$lhas" = 1 ]; then create_val="$lval"; else pending=value; fi
-            ;;
-          --track)
-            # OPTIONAL value (`--track=direct`), so the SPACED form must not
-            # consume the next token -- that token is the remote start-point,
-            # and the branch git creates is its last segment.
-            track_flag=1
-            ;;
-          --detach)
-            [ "$verb" = switch ] && detach_flag="$lname"
-            ;;
-          --patch|--ours|--theirs)
-            [ "$verb" = checkout ] && restore_flag=1
-            ;;
-          --conflict|--pathspec-from-file|--unified|--inter-hunk-context)
-            # Value-taking. Consume the argument when it is not glued, so it is
-            # not counted as a positional and read as a restore's pathspec.
-            [ "$lhas" = 0 ] && pending=skip
-            ;;
-          *) : ;;
-        esac
-        ;;
-      -)
-        # `git switch -` / `git checkout -` = the previous branch, which cannot
-        # be known without running git. Counted as a positional and judged below.
-        npos=$((npos + 1))
-        [ "$npos" -eq 1 ] && first_pos="-"
-        ;;
-      -?*)
-        # A SHORT flag CLUSTER: git's parse-options accepts `-qbfeat` as
-        # `-q -b feat`, so the letters are walked one at a time and a
-        # value-taking letter takes the REST of the token as its value, or the
-        # next token when nothing is left. Parsing only the whole token missed
-        # every glued spelling -- `-bfeat`, `-Bfeat`, `-cfeat`, `-Cfeat` -- each
-        # measured creating the branch and switching to it.
-        letters="${tok#-}"
-        while [ -n "$letters" ]; do
-          ch="${letters%"${letters#?}"}"
-          letters="${letters#?}"
-          case "$ch" in
-            h) saw_help=1 ;;
-            b|B)
-              if [ "$verb" = checkout ]; then
-                create_flag="-$ch"
-                if [ -n "$letters" ]; then create_val="$letters"; letters=""
-                else pending=value; fi
-              else
-                letters=""
-              fi
-              ;;
-            c|C)
-              if [ "$verb" = switch ]; then
-                create_flag="-$ch"
-                if [ -n "$letters" ]; then create_val="$letters"; letters=""
-                else pending=value; fi
-              else
-                # `-c` after `checkout` is not an option at all; the leading
-                # `git -c <k>=<v>` run was consumed by the verb ERE.
-                letters=""
-              fi
-              ;;
-            t) track_flag=1 ;;
-            d) [ "$verb" = switch ] && detach_flag="-d" ;;
-            p|2|3) [ "$verb" = checkout ] && restore_flag=1 ;;
-            U)
-              if [ "$verb" = checkout ]; then
-                if [ -n "$letters" ]; then letters=""; else pending=skip; fi
-              fi
-              ;;
-            q|l|m|f) : ;;
-            *)
-              # An unrecognised letter. Stop reading the cluster rather than
-              # guess: a wrong guess about a VALUE is what the `--conflict merge`
-              # defect was.
-              letters=""
-              ;;
-          esac
-        done
-        ;;
-      *)
-        npos=$((npos + 1))
-        [ "$npos" -eq 1 ] && first_pos="$tok"
-        ;;
-    esac
-  done < <(gate_tokens "$rest")
 
-  [ "$saw_help" -eq 1 ] && return 1
-  if [ -n "$create_flag" ]; then
-    target_branch="$create_val"
-    block_reason="creates new feature branch '$target_branch'"
+  # The argument text must be splittable into shell words at all. It is NOT when
+  # a quote is unbalanced, and `gate_argv` reports that rather than returning a
+  # truncation -- `-b agent's-branch` used to yield the single token `-b`, which
+  # read as a bare `git checkout` and PASSED. Refusing is the deliberate choice
+  # over a coarser second scan: the text is a shell syntax error in the first
+  # place (measured: "unexpected EOF while looking for matching `''"), so nothing
+  # legitimate is lost, and the message says exactly why.
+  if ! gate_argv "$rest" >/dev/null 2>&1; then
+    target_branch=""
+    block_reason="carries an argument list this gate cannot split into shell words (unbalanced quote), so its target cannot be read -- block conservatively"
     return 0
   fi
-  if [ "$track_flag" = 1 ]; then
-    # `git checkout -t origin/feat` / `git switch --track origin/feat` CREATE a
-    # local `feat` and switch to it -- measured, and the local branch appeared.
-    # The name is the start-point's LAST segment, so `origin/topic/x` yields `x`.
-    target_branch="${first_pos##*/}"
+
+  while IFS= read -r tok; do
+    tok=$(gate_unquote "$tok")
+    is_pos=0
+    if [ -n "$pending" ]; then
+      # `value` is a branch name; `skip` is some other flag's required argument,
+      # consumed only so it cannot be miscounted as a positional.
+      [ "$pending" = value ] && create_val="$tok"
+      pending=""
+    elif [ "$end_opts" -eq 1 ]; then
+      is_pos=1
+    else
+      case "$tok" in
+        # `--` ends the options. Under CHECKOUT everything after it is a
+        # pathspec; under SWITCH there is no pathspec form, so what follows is
+        # still the branch. Both measured.
+        --) end_opts=1 ;;
+        # `-` and `@{-N}` name the PREVIOUS branch under BOTH verbs. The pattern
+        # is the PREFIX `@{-`, without the closing brace, and that is measured
+        # rather than sloppy: `gate_segments` TRUNCATES a segment at a `}`, so
+        # the shared walk hands this gate `git checkout @{-1` for an input of
+        # `git checkout @{-1}`. A pattern requiring the `}` matched nothing.
+        -|@{-*) prev_ref="$tok"; is_pos=1 ;;
+        --*)
+          # A long flag. Split on the FIRST `=`, so the glued and spaced
+          # spellings of a value-taking flag reach the same arm, then resolve the
+          # NAME against the verb's grammar -- exact match, else unique prefix.
+          case "$tok" in
+            --*=*) name="${tok%%=*}"; lval="${tok#*=}"; lhas=1 ;;
+            *)     name="$tok";       lval="";          lhas=0 ;;
+          esac
+          resolve_long_opt "$verb" "${name#--}"
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            parse_certain=0
+            [ -n "$bad_opt" ] || bad_opt="$name"
+          else
+            # A REQUIRED value that is not glued comes from the next token. The
+            # effect arms below override `skip` with `value` where the argument
+            # is the branch name itself.
+            [ "$gate_long_arity" = 1 ] && [ "$lhas" -eq 0 ] && pending=skip
+            case "$gate_long" in
+              help) saw_help=1 ;;
+              create|force-create|orphan)
+                create_flag="--$gate_long"
+                if [ "$lhas" -eq 1 ]; then create_val="$lval"; else pending=value; fi
+                ;;
+              track) track_flag="--track" ;;
+              detach)
+                detach_seen=1
+                [ "$verb" = switch ] && detach_flag="--detach"
+                ;;
+              # File-restore markers. `--pathspec-from-file` belongs HERE and not
+              # with the merely value-taking flags: the pathspecs come from the
+              # FILE, so a trailing token is the tree-ish and the command is a
+              # restore (measured: "Updated 1 path", HEAD stayed). Its value is
+              # still consumed, by the arity line above.
+              patch|ours|theirs|pathspec-from-file) saw_restore=1 ;;
+              # `--pathspec-file-nul` is NOT a restore marker on its own: real git
+              # refuses it without `--pathspec-from-file` ("fatal: the option
+              # '--pathspec-file-nul' requires '--pathspec-from-file'"), so it
+              # never appears in an accepted command that this arm would need to
+              # judge.
+              guess) no_guess=0 ;;
+              no-guess) no_guess=1 ;;
+              *) : ;;
+            esac
+          fi
+          ;;
+        -?*)
+          # A SHORT flag CLUSTER: git's parse-options accepts `-qbfeat` as
+          # `-q -b feat`, so the letters are walked one at a time and a
+          # value-taking letter takes the REST of the token as its value, or the
+          # next token when nothing is left.
+          letters="${tok#-}"
+          while [ -n "$letters" ]; do
+            ch="${letters%"${letters#?}"}"
+            letters="${letters#?}"
+            case "$verb:$ch" in
+              checkout:b|checkout:B|switch:c|switch:C)
+                create_flag="-$ch"
+                if [ -n "$letters" ]; then create_val="$letters"; letters=""
+                else pending=value; fi
+                ;;
+              *:h) saw_help=1 ;;
+              *:t)
+                # OPTIONAL value: anything glued after `t` IS that value, and the
+                # SPACED form consumes nothing -- measured, `git checkout -t
+                # origin/remote-only` creates local `remote-only`, so the ref is
+                # a start-point positional.
+                track_flag="-t"
+                letters=""
+                ;;
+              *:d)
+                detach_seen=1
+                [ "$verb" = switch ] && detach_flag="-d"
+                ;;
+              checkout:p|checkout:2|checkout:3) saw_restore=1 ;;
+              checkout:U)
+                # REQUIRED value.
+                if [ -n "$letters" ]; then letters=""; else pending=skip; fi
+                ;;
+              *:q|*:m|*:f|checkout:l) : ;;
+              *)
+                # An unrecognised letter. git answers "error: unknown switch" and
+                # aborts; this walk cannot know whether the letter would have
+                # taken the rest of the cluster or the next token, so it stops
+                # reading and marks the parse incomplete.
+                parse_certain=0
+                [ -n "$bad_opt" ] || bad_opt="-$ch"
+                letters=""
+                ;;
+            esac
+          done
+          ;;
+        *) is_pos=1 ;;
+      esac
+    fi
+    if [ "$is_pos" -eq 1 ]; then
+      if [ "$end_opts" -eq 1 ] && [ "$verb" = checkout ]; then
+        pathspec_seen=1
+      else
+        npos=$((npos + 1))
+        if [ "$npos" -eq 1 ]; then first_pos="$tok"; else pathspec_seen=1; fi
+      fi
+    fi
+  done < <(gate_argv "$rest")
+
+  [ "$saw_help" -eq 1 ] && return 1
+
+  if [ "$parse_certain" -eq 0 ]; then
+    # Property 3 in the header. The walk met an option it could not resolve, so
+    # it does not know where the positionals are; refusing is the only answer
+    # that cannot be wrong in the dangerous direction.
+    target_branch=""
+    block_reason="uses an option this gate cannot resolve against \`git $verb\`'s grammar ($bad_opt), so its target cannot be read -- block conservatively"
+    return 0
+  fi
+
+  if [ -n "$create_flag" ]; then
+    target_branch="$create_val"
     block_reason="creates new feature branch '$target_branch'"
     return 0
   fi
@@ -430,21 +727,26 @@ verdict_for() {
     block_reason="detaches HEAD in the main tree (\`git switch $detach_flag\`)"
     return 0
   fi
+  if [ -n "$track_flag" ] && [ "$saw_restore" -eq 0 ] && [ "$pathspec_seen" -eq 0 ] \
+    && [ "$npos" -eq 1 ]; then
+    # `git checkout -t origin/feat` / `git switch --track origin/feat` CREATE a
+    # local `feat` and switch to it -- measured, and the local branch appeared.
+    # The name is the start-point's LAST segment, so `origin/topic/x` yields `x`.
+    target_branch="${first_pos##*/}"
+    block_reason="creates new feature branch '$target_branch'"
+    return 0
+  fi
+  if [ -n "$prev_ref" ] && [ "$saw_restore" -eq 0 ] && [ "$pathspec_seen" -eq 0 ] \
+    && [ "$npos" -eq 1 ]; then
+    target_branch="$prev_ref"
+    block_reason="switches to the previous branch (\`git $verb $prev_ref\`); resolved branch unknown -- block conservatively"
+    return 0
+  fi
 
   case "$verb" in
     switch)
       case "$first_pos" in
         main|master) return 1 ;;
-        -|@{-*)
-          # The pattern is the PREFIX `@{-`, without the closing brace, and that
-          # is measured rather than sloppy: `gate_segments` TRUNCATES a segment
-          # at a `}`, so the shared walk hands this gate `git checkout @{-1`
-          # (brace gone) for an input of `git checkout @{-1}`. A pattern
-          # requiring the `}` matched nothing and the shape stayed fail-open.
-          target_branch="$first_pos"
-          block_reason="switches to the previous branch (\`git switch $first_pos\`); resolved branch unknown -- block conservatively"
-          return 0
-          ;;
         "")
           # A bare `git switch` with no branch and no create flag. It is a git
           # error, but block conservatively rather than reason about a shape
@@ -461,66 +763,50 @@ verdict_for() {
       esac
       ;;
     checkout)
-      # `-p` / `--ours` / `--theirs` are RESTORE modes: measured, `-p <branch>`
-      # prints a diff and leaves HEAD on `main`, and `--ours` / `--theirs` print
-      # "Updated 0 paths from the index". Blocking them would be a false block of
-      # the same family as the `<branch> -- <paths>` one.
-      [ "$restore_flag" = 1 ] && return 1
-      # A `--` makes everything after it a pathspec and the leading positional a
-      # tree-ish to restore FROM: a file restore, whatever it names.
-      [ "$saw_ddash" -eq 1 ] && return 1
-      # No positional: a bare `git checkout` is a NOP or a restore depending on
-      # the git version. TWO OR MORE: `<tree-ish> <paths...>`, the same restore
-      # without the `--`. The count is of TRUE positionals -- every value-taking
-      # flag above consumed its own argument first.
-      [ "$npos" -ne 1 ] && return 1
+      # `-p` / `--ours` / `--theirs` / `--pathspec-from-file` are RESTORE modes
+      # whatever the operands look like: measured, `-p <branch>` prints a diff and
+      # leaves HEAD on `main`, `--ours` / `--theirs` refuse to run without paths,
+      # and `--pathspec-from-file <f> <branch>` updates paths from `<branch>`.
+      [ "$saw_restore" -eq 1 ] && return 1
+      # A PATHSPEC OPERAND exists -- either after a `--` or as a second
+      # positional. That is `git checkout [<branch>] -- <file>...`, a file
+      # restore, whatever it names. Note this is the operand's EXISTENCE, not a
+      # count: `git checkout <branch> --` has a `--` and no operand, and it
+      # switches.
+      [ "$pathspec_seen" -eq 1 ] && return 1
+      # No positional at all: a bare `git checkout` or `git checkout --`, both of
+      # which leave HEAD alone (measured).
+      [ "$npos" -eq 0 ] && return 1
       case "$first_pos" in
         main|master) return 1 ;;
-        -|@{-*)
-          # Measured: both print "Switched to branch 'other'" and move HEAD. They
-          # were ALLOWED here while the identical `git switch -` blocked.
-          target_branch="$first_pos"
-          block_reason="switches to the previous branch (\`git checkout $first_pos\`); resolved branch unknown -- block conservatively"
-          return 0
-          ;;
         *)
           # A branch name or a sha. A name resolving to a LOCAL branch is a
-          # branch switch; so is one that resolves only on a REMOTE (the DWIM
-          # arm below). A sha or a pathspec passes. Both questions are asked of
-          # the SEGMENT's own tree, since that is where the command would run.
+          # branch switch; so is one that resolves on a CONFIGURED REMOTE (the
+          # DWIM arm below). A sha or a pathspec passes. Both questions are asked
+          # of the SEGMENT's own tree, since that is where the command would run.
           if git -C "$dir" show-ref --verify --quiet "refs/heads/$first_pos" 2>/dev/null; then
             target_branch="$first_pos"
-            block_reason="switches to feature branch '$first_pos'"
+            if [ "$detach_seen" -eq 1 ]; then
+              block_reason="detaches HEAD in the main tree at '$first_pos'"
+            else
+              block_reason="switches to feature branch '$first_pos'"
+            fi
             return 0
           fi
-          # DWIM. With no LOCAL `<name>` but a remote carrying it,
+          # DWIM. With no LOCAL `<name>` but a configured remote carrying it,
           # `git checkout <name>` CREATES the local branch and switches to it.
-          #
-          # The pattern is the PREFIX `refs/remotes/`, NOT `refs/remotes/*/*`. A
-          # `*` does not cross a `/` in for-each-ref, so the two-star form lists
-          # `origin/feat` and MISSES `origin/topic/nested` -- measured on a real
-          # clone, where `--format='%(refname:lstrip=3)' 'refs/remotes/*/*'`
-          # printed `HEAD feat main` while the prefix form printed
-          # `HEAD feat main topic/nested`, and git DWIMs the nested name just the
-          # same ("Switched to a new branch 'topic/nested'"). Slashed names are
-          # most of them in this flow, so the two-star form is fail-open here.
-          #
-          # `HEAD` is EXCLUDED, and that is measured rather than defensive: the
-          # list comes from `refs/remotes/`, which holds the SYMBOLIC
-          # `refs/remotes/origin/HEAD` in essentially every clone -- `lstrip=3`
-          # renders it as the bare word `HEAD`, and both cdkd and cdk-local carry
-          # it. But `git checkout HEAD` resolves HEAD as a rev and creates
-          # nothing -- measured, "Your branch is up to date", HEAD stayed `main`
-          # -- so matching it would refuse a read-only command in the main tree.
-          # A branch cannot be NAMED `HEAD` (`git branch HEAD` is fatal), so
-          # nothing real is lost. `grep -qxF` is an exact whole-LINE match, so a
-          # name that is merely a SUBSTRING of a remote branch does not
-          # false-block either.
-          if [ "$first_pos" != HEAD ] \
-            && git -C "$dir" for-each-ref --format='%(refname:lstrip=3)' 'refs/remotes/' 2>/dev/null \
-              | grep -qxF -- "$first_pos"; then
+          # `--no-guess` turns that off, and then git answers "pathspec did not
+          # match" and HEAD stays -- measured, so the arm is skipped for it.
+          # `grep -qxF` is an exact whole-LINE match, so a name that is merely a
+          # SUBSTRING of a remote branch does not false-block either.
+          if [ "$no_guess" -eq 0 ] \
+            && remote_dwim_names "$dir" | grep -qxF -- "$first_pos"; then
             target_branch="$first_pos"
-            block_reason="creates a local branch tracking remote '$first_pos' and switches to it"
+            if [ "$detach_seen" -eq 1 ]; then
+              block_reason="detaches HEAD in the main tree at remote branch '$first_pos'"
+            else
+              block_reason="creates a local branch tracking remote '$first_pos' and switches to it"
+            fi
             return 0
           fi
           return 1

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -667,18 +667,96 @@ The hooks split into four classes:
 
 - **`main-tree-branch-gate.sh`** blocks branch-switching commands in
   the MAIN worktree so concurrent agents don't race on the shared
-  `/Users/.../cdk-local` slot. Allowed in the main tree:
-  `git switch main` / `git switch master`,
-  `git checkout main|master`, `git checkout -- <pathspec>` (file
-  restore), `git checkout <sha>` (detached HEAD), `git worktree add
-  ...` (sanctioned escape). Blocked: `git switch -c <feat>`,
-  `git switch <existing-feat>`, `git checkout -b <feat>`,
-  `git checkout <local-branch-name>`, `git switch -`. Inside any
-  `.claude/worktrees/<x>/` subtree everything passes through —
-  feature-branch work is meant to live there. The error message
-  names the resolved target dir + the operation + the corrective
+  `/Users/.../cdk-local` slot. Inside any `.claude/worktrees/<x>/`
+  subtree everything passes through — feature-branch work is meant to
+  live there. The error message names the resolved target dir + the
+  operation + the corrective
   `git worktree add .claude/worktrees/<branch> -b <branch> origin/main`
   recipe.
+
+  **Allowed** in the main tree: `git switch main|master`,
+  `git checkout main|master`, `git checkout [<tree-ish>] -- <pathspec>`
+  AND `git checkout <tree-ish> <pathspec>` (both are file restores that
+  leave HEAD alone), `git checkout -p|--patch|--ours|--theirs …`
+  (restore modes), `git checkout <sha>` (detached HEAD — see the
+  correction below), `git checkout HEAD`, `--help` under either verb,
+  and `git worktree add ...` (sanctioned escape).
+
+  **Blocked**: `git switch <not-main>`, the create pair under both
+  verbs in every spelling — `-c|-C|--create|--force-create <b>` for
+  switch, `-b|-B <b>` for checkout, `--orphan <b>` for both, plus the
+  GLUED forms `-c<b>` / `-C<b>` / `-b<b>` / `-B<b>` / `--create=<b>` /
+  `--force-create=<b>` / `--orphan=<b>` and short-flag BUNDLES like
+  `-qb<b>` — `-t|--track|--track=<mode> <remote-ref>` (git DWIMs it into
+  a create + switch), `git checkout <name>` when `<name>` is the only
+  positional and names either a LOCAL branch or a branch on some REMOTE,
+  `git switch --detach`, and `-` / `@{-1}` under BOTH verbs.
+
+  **The arguments are read by a real option parse**, not by "token 1 and
+  token 2", since 2026-09-01, over tokens from the shared `gate_tokens` in
+  `_command-match.sh`. The splitter lives in the LIBRARY rather than in the gate
+  because matching `GATE_EMBEDDING_TOKEN` inside a hook and then reading a
+  positional `${BASH_REMATCH[N]}` out of it couples the gate to a shared
+  constant's group count: widening the constant shifts the index and silently
+  re-opens the gate. (cdkd's `unresolved-target-class.test.sh` fence 4 refuses
+  that shape by name and caught the first draft of this parse; this repo has no
+  such fence, so the same shape is adopted here deliberately rather than under
+  compulsion.) Every wanted verdict was settled against
+  real git (2.53.0) with HEAD and the local branch list printed before
+  and after, and the option grammar comes from `git checkout -h` /
+  `git switch -h` rather than from memory. Nine defects, all live in the
+  main checkout before the change and all measured there:
+
+  ```text
+  git checkout <branch> -- <paths>            rc=2  want 0  <- false block (restore)
+  git checkout <branch> <paths>               rc=2  want 0  <- false block (restore)
+  git switch --help                           rc=2  want 0  <- false block
+  git checkout -f <branch>                    rc=0  want 2  <- bypass
+  git checkout --orphan <branch>              rc=0  want 2  <- bypass
+  git checkout -bfeat / -Bfeat / -qbfeat      rc=0  want 2  <- bypass (glued)
+  git checkout --orphan=feat                  rc=0  want 2  <- bypass (glued)
+  git checkout --conflict merge <branch>      rc=0  want 2  <- bypass (count != parse)
+  git checkout --pathspec-from-file <f> <b>   rc=0  want 2  <- bypass (count != parse)
+  git checkout --recurse-submodules <branch>  rc=0  want 2  <- bypass
+  git checkout <remote-only branch>           rc=0  want 2  <- bypass (DWIM)
+  git checkout -t origin/<b> / --track=direct rc=0  want 2  <- bypass (DWIM)
+  git checkout - / git checkout @{-1}         rc=0  want 2  <- bypass (previous branch)
+  ```
+
+  Three of those are load-bearing rather than tidiness. `git checkout -f
+  <branch>` is a LIVE BYPASS of the protection the whole worktree
+  discipline rests on — `-f` was read AS the branch name, `refs/heads/-f`
+  does not resolve, and the gate passed a switch that really happens.
+  `git checkout <branch> -- <paths>` is a documented integration step in
+  a sibling repo, so the false block refused a mandated flow. And
+  `git checkout <name>` for a branch that exists only on a remote is how
+  a lane's branch usually FIRST appears in a checkout, so a local-only
+  `show-ref` was blind to the commonest spelling of what the gate guards.
+
+  Two shapes are ALLOWED for measured reasons that look like gaps and are
+  not. `git checkout HEAD` creates nothing ("Your branch is up to date",
+  HEAD stays), yet the DWIM lookup reads `refs/remotes/` and every clone
+  carries the SYMBOLIC `refs/remotes/origin/HEAD`, which `lstrip=3`
+  renders as the bare word `HEAD` — so the literal `HEAD` is excluded, or
+  the gate would refuse a read-only command. The pattern is the PREFIX
+  `refs/remotes/` and NOT `refs/remotes/*/*`: a `*` does not cross a `/`
+  there, so the two-star form lists `origin/feat` and misses
+  `origin/topic/nested` while git DWIMs the nested name identically —
+  fail-open for most branch names in this flow. And `-p` / `--ours` /
+  `--theirs` leave HEAD alone (`-p` prints a diff; the other two print
+  "Updated 0 paths from the index"), so blocking them would be the same
+  false block as the `<branch> -- <paths>` one.
+
+  **Correction to an older rationale.** `git checkout <sha>` was
+  justified here as "read-only inspection". That is false: it rewrites
+  the shared working tree and leaves a detached HEAD, and the detached
+  HEAD then disarms `branch-gate.sh`, which reads
+  `git -C <dir> symbolic-ref --short HEAD` — EMPTY while detached — and
+  falls through to `exit 0`. Measured in a throwaway repo carrying a
+  `.markgate.yml`, driving branch-gate with `git commit -m x`: rc=2 on
+  `main`, rc=0 once detached. The verdict is unchanged (blocking it would
+  refuse a legitimate inspection spelling across three repos and belongs
+  in its own PR), but the claim is retired.
 
   The VERDICT is read per SEGMENT, from `gate_verb_args` — the same
   constant that armed the gate — not from the whole command. It used to
@@ -728,9 +806,22 @@ The hooks split into four classes:
   gate that calls it.
   Covered by `.claude/hooks/gate-command-recognition.test.sh`, whose
   main-tree block pins the chained blocks, the per-segment allowances,
-  the linked-worktree pass and the quoted-mention pair (167 cases in
-  that file overall, alongside the `post-merge-orphan-push-gate` block
-  added for the same defect). The interpreter those cases run the hooks
+  the linked-worktree pass, the quoted-mention pair, and — since
+  2026-09-01 — every argument shape in the table above with its
+  false-block control beside it (213 cases in that file overall,
+  alongside the `post-merge-orphan-push-gate` block added for the same
+  defect). This gate has no suite of its own; its cases live here
+  because the per-segment tree-resolution cases they must be read
+  against are already here, and a second file would give one gate two
+  suites with no rule for which gets the next case. Where the exit code
+  cannot discriminate — a dropped create-flag still names the branch
+  correctly, it merely calls the creation a switch — the case asserts
+  the whole message PHRASE rather than the name. Every added assertion
+  was mutation-proven; the three that turned out to fence nothing when
+  first written were a `-C`-carrying CHECKOUT (dropping `${GATE_FLAGS}`
+  from `GATE_RE_GIT_CHECKOUT` left the suite green), the quoted branch
+  name (dropping `gate_unquote` left it green), and the
+  previous-branch MESSAGE under `switch`. The interpreter those cases run the hooks
   under is now explicit: a `bash` symlink at the front of the pinned
   PATH, defaulting to `/bin/bash` (3.2 on macOS) and overridable with
   `HOOK_BASH=<path> bash .claude/hooks/gate-command-recognition.test.sh`

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -704,8 +704,12 @@ The hooks split into four classes:
   compulsion.) Every wanted verdict was settled against
   real git (2.53.0) with HEAD and the local branch list printed before
   and after, and the option grammar comes from `git checkout -h` /
-  `git switch -h` rather than from memory. Nine defects, all live in the
-  main checkout before the change and all measured there:
+  `git switch -h` rather than from memory. Thirteen defects, all live in
+  the main checkout before the change and all measured there. Thirteen is
+  the ROW COUNT below: this paragraph read "nine" over the same table
+  while the commit shipping it said "five bypasses and three false
+  blocks" in its title and "nineteen command shapes" in its body — four
+  spellings of one set. Count the rows; do not recall the number.
 
   ```text
   git checkout <branch> -- <paths>            rc=2  want 0  <- false block (restore)
@@ -716,7 +720,7 @@ The hooks split into four classes:
   git checkout -bfeat / -Bfeat / -qbfeat      rc=0  want 2  <- bypass (glued)
   git checkout --orphan=feat                  rc=0  want 2  <- bypass (glued)
   git checkout --conflict merge <branch>      rc=0  want 2  <- bypass (count != parse)
-  git checkout --pathspec-from-file <f> <b>   rc=0  want 2  <- bypass (count != parse)
+  git checkout --pathspec-from-file <f> <b>   rc=2  want 0  <- false block (restore)
   git checkout --recurse-submodules <branch>  rc=0  want 2  <- bypass
   git checkout <remote-only branch>           rc=0  want 2  <- bypass (DWIM)
   git checkout -t origin/<b> / --track=direct rc=0  want 2  <- bypass (DWIM)
@@ -733,19 +737,114 @@ The hooks split into four classes:
   a lane's branch usually FIRST appears in a checkout, so a local-only
   `show-ref` was blind to the commonest spelling of what the gate guards.
 
+  The `--pathspec-from-file` row is a CORRECTION rather than a find: the
+  first pass filed that flag with `--conflict` as merely value-taking,
+  wrote `want 2` here, and pinned rc=2 in a test. Backwards — the
+  pathspecs come FROM THE FILE, so the trailing token is the tree-ish and
+  the command is a RESTORE (measured: "Updated 1 path from <sha>", HEAD
+  stayed on `main`, for the spaced and the `=` spelling alike). A wrong
+  `want` in a table is worse than a missing row, because the test written
+  from it defends the defect.
+
+  **That parse then shipped a REGRESSION and five more holes, closed
+  2026-09-02.** Measured against a fixture main checkout with a
+  CONFIGURED `origin`, a SLASH-named remote, a ref under an unconfigured
+  remote and a real local branch; `OLD` is cdkd's `origin/main` copy of
+  the gate, so the first four rows read as regressions rather than as
+  plain failures:
+
+  ```text
+  command                                     OLD  NEW  now  want
+  git checkout <branch> 2>/dev/null             2    0    2     2
+  git checkout <branch> >/dev/null 2>&1         2    0    2     2
+  git checkout <branch> # switch lane           2    0    2     2
+  git checkout <branch> --                      2    0    2     2
+  git checkout -q <branch> 2>&1                 0    0    2     2
+  git checkout - 2>/dev/null                    0    0    2     2
+  git checkout --orph <b> / --or <b>            0    0    2     2
+  git checkout --trac origin/<b>                0    0    2     2
+  git checkout <b on a SLASH-named remote>      0    0    2     2
+  git switch -- main                            2    2    0     0
+  git checkout <ref under an UNCONFIGURED rem>  0    2    0     0
+  git checkout --no-guess <remote-only>         0    2    0     0
+  git checkout --pathspec-from-file <f> <b>     0    2    0     0
+  control: git checkout <branch>                2    2    2     2
+  ```
+
+  Four causes. (1) **The input is ARGV, not shell WORDS** — a
+  redirection, its spaced target, a trailing `&` and a `#` comment are
+  the SHELL's, and git never sees them; a new `gate_argv` in
+  `_command-match.sh` drops them, leaving `gate_tokens` for callers that
+  want the raw words. (2) **A positional COUNT relaxed a verdict on an
+  incomplete parse, twice** — first a flag's VALUE read as a positional,
+  then a shell WORD. The count cannot simply be removed: git's own
+  grammar makes `git checkout <b> <path>` a restore and `git checkout
+  <b>` a switch, so only the extra OPERAND tells them apart. The rule is
+  now that an INCOMPLETE parse may not ALLOW — an unresolvable or
+  ambiguous option sets `parse_certain=0` and the verdict is a
+  conservative block naming it. (3) **git accepts any unambiguous PREFIX
+  of a long name** (measured: `--orph newb`, `--or newb`, `--trac
+  origin/<b>` all move HEAD), which `-h` does not show — so each verb now
+  carries its COMPLETE long-option table with per-name arity, since a
+  prefix can only be resolved against the whole name set. (4) **`--` is
+  checkout's pathspec separator and switch's end-of-options** — `git
+  checkout <b> --` switches (no operand follows), and `git switch -- main`
+  prints "Already on 'main'" while `git switch -- <feature>` switches.
+
+  **The DWIM list is the CONFIGURED remotes, stripped per remote**, which
+  is what git does and what cdk-real-drift's copy already did. A remote
+  NAME may contain a slash (`git remote add a/b <url>` is accepted), so a
+  fixed `lstrip=3` renders its `deep-only` as `b/deep-only` while git
+  DWIMs the bare name — a fail-open; and a ref under an UNCONFIGURED
+  remote is not DWIMed at all ("pathspec did not match", HEAD stays) — a
+  false block. Dropping SYMREFS replaces the old literal `HEAD`
+  exclusion and is the same rule stated properly. `--no-guess` turns the
+  DWIM off entirely and the arm is skipped for it. The list does NOT
+  check uniqueness: with one name on two remotes git refuses while the
+  gate blocks — the conservative direction, so the behaviour stays, but
+  no comment may claim the list holds only names one remote carries.
+
+  **A truncated argument list is refused, not parsed.** An unbalanced
+  quote cannot be split into words, and `gate_tokens` returned the prefix
+  it managed silently — `-b agent's-branch` yielded just `-b`, read as a
+  bare `git checkout`, and PASSED. It now REPORTS the truncation and the
+  gate blocks naming the cause.
+
   Two shapes are ALLOWED for measured reasons that look like gaps and are
   not. `git checkout HEAD` creates nothing ("Your branch is up to date",
-  HEAD stays), yet the DWIM lookup reads `refs/remotes/` and every clone
-  carries the SYMBOLIC `refs/remotes/origin/HEAD`, which `lstrip=3`
-  renders as the bare word `HEAD` — so the literal `HEAD` is excluded, or
-  the gate would refuse a read-only command. The pattern is the PREFIX
-  `refs/remotes/` and NOT `refs/remotes/*/*`: a `*` does not cross a `/`
-  there, so the two-star form lists `origin/feat` and misses
-  `origin/topic/nested` while git DWIMs the nested name identically —
-  fail-open for most branch names in this flow. And `-p` / `--ours` /
-  `--theirs` leave HEAD alone (`-p` prints a diff; the other two print
-  "Updated 0 paths from the index"), so blocking them would be the same
-  false block as the `<branch> -- <paths>` one.
+  HEAD stays), and it is excluded by the SYMREF rule rather than by a
+  literal — a branch cannot be NAMED `HEAD` anyway. And `-p` / `--ours` /
+  `--theirs` / `--pathspec-from-file` leave HEAD alone, so blocking them
+  would be the same false block as the `<branch> -- <paths>` one.
+  `--pathspec-file-nul` is deliberately NOT in that restore set: git
+  refuses it without `--pathspec-from-file`, so it never appears in an
+  accepted command this arm would judge.
+
+  **A block must not name an operation git will not perform.**
+  `git checkout -d <branch>` / `--detach <branch>` really DETACHES
+  (measured: HEAD went to a raw sha) and the block announced it as
+  "switches to feature branch '<b>'". The verdict is unchanged; the
+  wording now matches.
+
+  **Known bound, in the message rather than the verdict**: `gate_segments`
+  truncates a segment at a `}`, so `git switch -c 'feat/{id}'` blocks
+  correctly while the message and its `git worktree add … -b feat/{id`
+  recipe name a TRUNCATED branch. The cause is in the shared splitter
+  every gate calls, so it is recorded rather than worked around here.
+
+  **This repo's `main_tree_of` has NO memo** and forks `git worktree
+  list` once per matching segment, while cdkd's carries a one-entry memo
+  plus an out-variable (a command substitution would put both memo
+  variables in a subshell). The divergence used to live only in a commit
+  message, so neither repo's reader could see it; the argument for this
+  gate is "one function with two homes", which makes the difference worth
+  stating in both.
+
+  **This repo keeps the gate's cases in `gate-command-recognition.test.sh`**
+  while cdkd and cdk-real-drift each keep a per-gate
+  `main-tree-branch-gate.test.sh`. The choice is deliberate, and the
+  consequence for a porter is that a case added in one repo has no
+  same-named home in the other — a port has to be told where to land.
 
   **Correction to an older rationale.** `git checkout <sha>` was
   justified here as "read-only inspection". That is false: it rewrites

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -790,6 +790,35 @@ The hooks split into four classes:
   checkout's pathspec separator and switch's end-of-options** — `git
   checkout <b> --` switches (no operand follows), and `git switch -- main`
   prints "Already on 'main'" while `git switch -- <feature>` switches.
+  (5) **A WORD THE SHELL OWNS MAY NOT RELAX EITHER** — cause 2 is stated
+  for git's OPTIONS, and `gate_argv` did the opposite for the shell's
+  WORDS: it ENUMERATED the forms it recognised and passed everything else
+  through as an argument, so three rounds of fixes each added a spelling
+  and the next round found the one still missing (`$EMPTY` and
+  `${EMPTY}`, whose expansion VANISHES, and `{fd}>/dev/null`, bash's
+  fd-variable redirection — all four measured rc=0 where 2 is wanted, on
+  commands that move HEAD). The default is now INVERTED rather than the
+  list extended: `gate_word_is_literal` admits a word only when every one
+  of its characters is on a closed list of characters the shell does not
+  act on, and a word that fails sets `parse_certain=0`. A shape nobody
+  has thought of lands on BLOCK because every shell construct is SPELLED,
+  and one outside the list necessarily carries a character the list does
+  not hold — the audit surface is the LIST, with a reason per member, not
+  a catalogue of shell forms. The cost is over-strictness (`git checkout
+  main -- "$f"` is a restore and now blocks); measured over all three
+  repos' committed invocations, 32 of 206 texts newly block and 30 of
+  those are documentation metasyntax rather than commands, while the
+  count on lines that actually EXECUTE is zero.
+
+  **Three options git ACCEPTS were blocked by cause 2's arm**, which had
+  been documented as firing "only on commands git itself refuses":
+  `--end-of-options main`, `--end-of-options -- <path>` and
+  `--git-completion-helper` all run with rc=0 (measured, git 2.53.0).
+  They and `--git-completion-helper-all` / `--help-all` are
+  `parse-options` built-ins, absent from `-h` where the tables came from,
+  and are in the tables now at arity 0. `--end-of-options` sets
+  `end_opts` but NOT the pathspec flag, because `git checkout
+  --end-of-options <branch>` really SWITCHES.
 
   **The DWIM list is the CONFIGURED remotes, stripped per remote**, which
   is what git does and what cdk-real-drift's copy already did. A remote
@@ -808,7 +837,18 @@ The hooks split into four classes:
   quote cannot be split into words, and `gate_tokens` returned the prefix
   it managed silently — `-b agent's-branch` yielded just `-b`, read as a
   bare `git checkout`, and PASSED. It now REPORTS the truncation and the
-  gate blocks naming the cause.
+  gate blocks naming the cause. **The justification recorded for that
+  ordering was false and is retired**: it read "the text is a shell
+  syntax error in the first place, so nothing legitimate is lost", but
+  the splittability rc came from tokenizing the WHOLE text while the `#`
+  comment was dropped later inside the walk, so an apostrophe INSIDE a
+  comment was weighed as a quote. `bash -n "git checkout main # don't
+  switch lanes"` reports VALID syntax and git answers "Already on 'main'"
+  with HEAD unmoved — and the gate blocked it. `gate_argv` now cuts the
+  comment BEFORE splitting (`gate_strip_comment`, with
+  `gate_segments_raw`'s `ignore_q` second pass for a quote that never
+  closes), so the refusal covers only text bash itself will not run;
+  `-b agent's-branch` still refuses, having no comment to cut.
 
   Two shapes are ALLOWED for measured reasons that look like gaps and are
   not. `git checkout HEAD` creates nothing ("Your branch is up to date",


### PR DESCRIPTION
Closes go-to-k/cdk-real-drift#1845.

## Summary

This repo had nothing blocking a feature branch being created IN the main
checkout — the shared resource every parallel lane depends on staying on `main`.
`branch-gate.sh` fires on `git commit` / `git push` when the target tree is on
`main`, i.e. on the SYMPTOM; `worktree-guard.sh` fires on Edit/Write into the
main checkout's `src/**` / `tests/**`. Neither sees a branch SWITCH, and
`.claude/settings.json` wired no hook to `git switch` / `git checkout`.

Three commits: the port, then two rounds of review that between them rewrote how
the gate reads a command.

## Why the port waited for the siblings

The shape to copy was wrong until the same day. Both sibling repos resolved the
target tree ONCE per command, outside the segment walk, so a chain spanning two
trees was judged against whichever tree the first matching segment named.
Reproduced here before porting, by changing one line back to that shape:

```
                                                   before  after  want
git -C <wt> switch -c a && git switch -c b              0      2     2
git -C <wt> checkout -b a && git checkout -b b          0      2     2
git switch main && git -C <wt> switch -c a              2      0     0
controls: bare create 2, switch main 0, lone -C create 0 — unchanged
payload cwd = the worktree: bare create 0, cd <main> && create 2
```

## The gate reads git's ARGV, and refuses to ALLOW on an incomplete parse

Two review rounds each found the same class of defect one layer down, and the
second one made the diagnosis clear.

Round 2 replaced a two-token read (`-bfeat`, `--orphan=feat`,
`--conflict merge <branch>`, `-`, `@{-1}` all waved through) with an option
parse. Round 3 found that parse had introduced four regressions of its own,
because it counted SHELL words: a redirection or a trailing `# comment`
inflated the positional count and the command read as a restore.

The obvious fix — "remove the count, read the first positional the way the
switch arm does" — measured false in both halves:

- `git checkout <branch> <paths>` RESTORES files and leaves HEAD alone
  (`Updated 1 path from 1687364`, HEAD `main` → `main`). Reading only the first
  positional blocks it — and that spelling is what **this repo's CLAUDE.md
  mandates** for the orchestrator's integration step.
- The switch arm is not immune either. Its apparent immunity is an artefact of
  switch's command shapes: with `--conflict` unmodelled,
  `git checkout --conflict merge <branch>` yields `first_pos=merge`, resolves to
  no branch, and fails open exactly like the count.

So the count was never the cause. The cause is that **a relaxing verdict was
computed from an incomplete parse, twice** — once with a flag's VALUE left in
the stream, once with a shell WORD left in it. git's own grammar
(`git checkout [<opts>] <branch>` against `[<opts>] [<branch>] -- <file>...`)
forces the question of whether an operand follows the target, so no correct gate
can avoid asking it.

The general fence that replaced the special cases: **an incomplete parse may not
ALLOW.** An unresolvable or ambiguous long name, or an unknown cluster letter,
sets `parse_certain=0` and the gate blocks conservatively, naming the option.
Today it fires only on commands git itself refuses; its job is to stop a future
git option re-opening the hole silently.

## Verdicts, all three repos

`OLD` is this repo's `origin/main`. Fixture: real git 2.53.0, a `.markgate.yml`,
a configured `origin`, a **slash-named remote** `a/b`, a ref under an
**unconfigured** remote, real local branches, a linked worktree. Every `want` was
settled against real git first, with HEAD printed before and after.

```
COMMAND                                     want  OLD  BEFORE   AFTER
git checkout <branch> 2>/dev/null              2    2   0 0 0   2 2 2
git checkout <branch> # switch lane            2    2   0 0 0   2 2 2
git checkout -q <branch> 2>&1                  2    0   0 0 0   2 2 2
git checkout - 2>/dev/null                     2    0   0 0 0   2 2 2
git checkout <branch> --                       2    2   0 0 0   2 2 2
git checkout <branch> -- f.txt                 0    2   0 0 0   0 0 0
git checkout <branch> f.txt                    0    2   0 0 0   0 0 0
git checkout --orph newb                       2    0   0 0 0   2 2 2
git checkout --or newb                         2    0   0 0 0   2 2 2
git checkout deep-only (slash-named remote)    2    0   0 0 2   2 2 2
git checkout ghost  (unconfigured remote)      0    0   2 2 0   0 0 0
git checkout --pathspec-from-file PF <b>       0    0   2 2 0   0 0 0
git switch -- main                             0    2   2 2 2   0 0 0
git checkout --no-guess remote-only            0    0   2 2 2   0 0 0
git checkout -U 3 <branch>                     2    -     -     2 2 2
... plus 24 control rows, unchanged
```

39 rows, **39/39 correct in all three repos**. Columns are cdkd / cdk-local /
this repo.

## This repo was AHEAD of its siblings, and the direction was checked

`remote_dwim_names` here iterates the CONFIGURED remotes, strips per remote and
drops symrefs — what git's DWIM actually does — while the siblings globbed the
ref namespace with `lstrip=3`. `deep-only` going 0 → 2 and `ghost` /
`--pathspec-from-file` going 2 → 0 are the rows that settle it. The siblings
converged onto this shape in their own PRs rather than the reverse.

`--pathspec-from-file` belongs on the restore side; its neighbour
`--pathspec-file-nul` does NOT — measured,
`git checkout --pathspec-file-nul <branch>` is `fatal: the option
'--pathspec-file-nul' requires '--pathspec-from-file'`, so it never appears in
an accepted command this arm judges.

## Also in this PR: main contradicted itself

`CLAUDE.md` still printed `git worktree add .worktrees/<name> -b wt-<name> main`
after go-to-k/cdk-real-drift#1847 corrected `/work-issues` to `origin/main`.
Three copies carried local `main` — `CLAUDE.md`,
`.claude/skills/hunt-bugs/references/plan.md` and
`.claude/skills/check/SKILL.md`, whose throwaway repro worktree wants
`origin/main` even more, since the question it answers is whether CI's main is
red. All agree now, with the measured reason recorded:
`stale-base-gate.sh` opens with `git merge-base --is-ancestor "$base" HEAD ||
exit 0`, so it is INERT for a lane cut from a stale local `main` — basing on
`origin/main` is what turns that gate ON.

Three skill files asserted "there is no `main-tree-branch-gate` here at all",
false the moment this lands. Each keeps its `-C <LANE_TREE>` routing with the
honest reason: the gate now REFUSES the stray spelling instead of letting it
clobber, and a refusal is not a redirect.

## A bash 3.2 parser defect, recorded rather than worked around

Under 3.2.57 a `'` inside a double-quoted word inside `$(...)` opens a quote span
that the NEXT single-quoted argument closes: the `jq` filter splits, jq fails,
and the remaining arguments shift by one (`argc=4 a2=[] a3=[]` under 3.2 against
`argc=3 a3=[unbalanced quote]` under 5.3.9). The unbalanced-quote cases build
their apostrophe with `printf '\047'`; written directly they report a hook defect
that does not exist.

## Verification

- **39/39** verdicts, and the two-tree table re-run and unchanged.
- **23 mutations, every one caught** (control 144/0), including 4 for
  `parse_certain` and 6 for prefix resolution. One case is labelled a CONTROL
  rather than a fence — the heredoc-delimiter token — because nothing reddens it
  today.
- **bash 3.2 shim proven live** with `;;&` (a PARSE error under 3.2, a no-op
  under 5.x — unlike `declare -A`, which is a RUNTIME error there and reports a
  false all-clear): 144/0 → 38/106 under `/bin/bash` 3.2.57, 0 fail under 5.3.9
  throughout.
- Gate suite **144/0** and library **200/0** under both shells; 16 hook
  harnesses rc=0; `vp run verify` rc=0 with **349 files / 6,622 tests**.
- `symlinked_main` fixture added for `canonicalize`, which had no case and could
  not grow one by accident: the fixture root is `pwd -P`'d, so every path the
  hook saw was already canonical. Deleting canonicalisation left the suite green
  while the same repo reached through a symlink went 2 → 0.

Registration is two separate `if:` entries, never one joined with `or` — the
go-to-k/cdk-real-drift#1801 shape where a single `if` holding `A or B` matches
nothing and every gate silently goes inert — and
`tests/gate-if-matchers-1801.test.ts` now requires them.

## Known bounds, stated rather than left implicit

- `git switch --detach` blocks while `git checkout <sha>` passes. Not
  principled: the sha form rewrites the shared working tree and detaches HEAD,
  and `branch-gate.sh` reads `symbolic-ref --short HEAD`, which is empty when
  detached — a `git commit` there scores rc=2 on `main` and **rc=0 detached**.
  Filed as go-to-k/cdkd#2402; the sha form stays allowed for inspection until
  that is decided.
- `gate_segments` truncates a segment at `}`, so `git switch -c 'feat/{id}'`
  blocks correctly but the message names a truncated branch. Shared by every
  gate in the library; recorded in-code.
- A missing `jq` fails open silently, matching every other gate in this repo.
