### PR TITLE
chore(work-issues): when an issue offers two fixes, say which one the four fields cost

### DIFF
--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -293,6 +293,18 @@ the rc table were all in hand, and a later session would have re-derived all
 three. Re-classified `now` in the same session on the maintainer's challenge,
 and shipped; the port then found four more defects in the shape it was copying,
 none of which a fresh session would have known to look for.)
+**And when the issue body offers more than one fix, say which one the four
+fields cost.** Cost the CHEAPEST one you would actually accept. A deferral
+justified by the expensive option is not a measurement, it is a choice of
+comparand -- and the fields are supposed to be the measurement.
+
+(2026-09-02, an hour after the paragraph above went in: an issue was filed
+listing two fixes -- block the spelling in the gate that let the tree detach, a
+behaviour change across three repos, or teach the OTHER gate to recognise a
+detached HEAD, about six lines and no behaviour change. The `Session-fit: next`
+reason read "a behaviour change across three repos with its own review surface",
+which costs only the first. Nobody had decided which fix to take; the first one
+described became the one measured.)
 
 **The converse is the honest use of `next`, and it costs one line.** When you CAN
 name the verification and a fresh session plainly has it (an existing `local-*`


### PR DESCRIPTION
chore(work-issues): when an issue offers two fixes, say which one the four fields cost

The paragraph added an hour earlier -- "it needs its own PR" is not a `next`
reason -- did not catch the next miss, and the next miss was a different
question.

An issue filed this session listed TWO fixes for one defect: block the spelling
in the gate that lets the shared tree detach (a behaviour change across three
repos, refusing a legitimate inspection spelling), or teach the OTHER gate to
recognise a detached HEAD (about six lines, no behaviour change). The
`Session-fit: next` reason read "a behaviour change across three repos with its
own review surface" -- which costs only the first. `Effort` and `Estimate` were
written against it too.

Nobody had decided which fix to take. The first option DESCRIBED became the one
MEASURED, and the deferral was justified by a fix that would not have been
chosen.

That is a different error from the one above it. That one was about the BAR --
reading "needs its own PR" as "needs its own session". This one is about the
COMPARAND: the four fields are supposed to be a measurement, and a measurement
of the wrong thing is not made honest by being accurate. So the rule is to name
the option, and to cost the cheapest one you would actually accept.

One sentence plus its dated example, 798 B, inside section 3-b immediately after
the paragraph whose gap it closes -- so the two failures read as what they are, a
pair. No new section, and nothing added to any `SKILL.md`.

Suites: cdkd 850 files / 17,598 tests with no type errors, cdk-local 242 /
4,359, cdk-real-drift 349 / 6,620, all rc=0.

