### PR TITLE
fix(test): require the own-throw branch in the STS relay fence; hoist in-body dynamic imports (#613, #615)

### DIFF
--- a/tests/unit/cli/sts-error-relay-source-fence.test.ts
+++ b/tests/unit/cli/sts-error-relay-source-fence.test.ts
@@ -28,6 +28,35 @@ import { dirname, join } from 'node:path';
  *   - Detection was per-line, so a template wrapping across a `+` — the house
  *     style at four of the nine sites — was invisible.
  *
+ * Issue #613 added the half the first draft could not express. The four
+ * `--assume-role` relays catch a class cdk-local THROWS ITSELF
+ * (`AssumeRoleFailure`, whose `detail` was pre-rendered by the policy at
+ * throw time), so the correct shape at those sites is a ternary:
+ *
+ *   err instanceof AssumeRoleFailure ? err.detail : describeAwsFailureForWarn(err, op)
+ *
+ * Drop the `instanceof` half and what remains is exactly what `HELPER_CALL`
+ * requires -- so the fence BLESSED the defective form, which WITHHOLDS text
+ * the policy had already sanitized (`ExpiredTokenException: ...` became
+ * `Error; 138-character message withheld`). That happened twice in one PR
+ * (go-to-k/cdk-local#611), caught both times by per-occurrence literal
+ * assertions, never here. Now a site whose announcement names `STS
+ * AssumeRole` must ALSO carry the own-throw branch, read from a slightly
+ * wider window (see `OWN_THROW_LINES_BEFORE`).
+ *
+ * The same issue widened what may vouch for a site: a NAMED RENDERER defined
+ * in the scanned tree, so the four duplicated ternaries CAN be factored into
+ * one function without defeating the tenth-site property (PR #611 tried, and
+ * the fence failed all three factored sites; the ternaries were inlined to
+ * satisfy it). Recognition is deliberately strict so an arbitrary
+ * neighbouring call cannot vouch: the callee must be DEFINED in
+ * `src/cli/commands/*.ts`, its body must carry the FULL policy shape (the
+ * helper call AND the own-throw branch), it must not `warn` itself (a
+ * renderer renders; a site warns), and the body must close within
+ * `RENDERER_BODY_MAX_LINES`. Anything the collector cannot model is NOT a
+ * renderer -- fail-closed: the site using it is reported and the author
+ * reacts, rather than an unmodelled shape vouching silently.
+ *
  * WHAT IT STILL DOES NOT CATCH, stated so nobody reads more into a green run:
  *
  *   - It does not match the error VALUE. A `describeAwsFailureForWarn(other, …)`
@@ -35,7 +64,7 @@ import { dirname, join } from 'node:path';
  *     fixes that, which needs an AST.
  *   - It is wording-bound. A tenth site spelled `STS ${op} failure` or with no
  *     `STS` token at all produces no finding — though a copy-paste-shaped one
- *     trips the exact-9 count loudly.
+ *     trips the pinned count loudly.
  *   - Its directory scope is `src/cli/commands/*.ts`, non-recursively. FOUR
  *     relays of the same shape live outside it, and issue #579 added two of
  *     them: `src/utils/role-arn.ts`'s `assumeRoleCredentials` and
@@ -65,6 +94,17 @@ import { dirname, join } from 'node:path';
  *   - The announcing check needs `STS <Op>` on ONE physical line, so a template
  *     that wraps between `STS ` and the operation is undetected. The `+`-wrap
  *     fix covered the `failed` half of the split, not this one.
+ *   - The own-throw classifier is wording-bound like the rest of the file: a
+ *     relay announcing `STS AssumeRole` under any other spelling is not asked
+ *     for the branch. And it derives "throws AssumeRoleFailure" from the
+ *     OPERATION NAME, not from the call graph -- true today because every
+ *     AssumeRole in this repo goes through a helper that throws it
+ *     (`assumeRoleCredentials` / `applyRoleArnIfSet` in
+ *     `src/utils/role-arn.ts`, `assumeAgentCoreExecutionRole` in
+ *     `local-invoke-agentcore.ts`); a future direct SDK send would inherit a
+ *     requirement it does not need, which errs STRICT and loud, never silent.
+ *   - A renderer defined OUTSIDE `src/cli/commands/*.ts` is not recognized,
+ *     same fail-closed direction as the rest of the scan scope.
  *   - `RAW_RELAY` is identifier-bound to `err` / `error` / `e`, so
  *     `caught.message`, a destructured `{ message }`, `err.toString()` and
  *     `JSON.stringify(err)` all miss. That only bites inside the adjacency
@@ -110,6 +150,26 @@ const RAW_RELAY =
 const HELPER_CALL = /describeAwsFailureForWarn\s*\(/;
 
 /**
+ * Issue #613 -- classifies a finding as a relay of a class cdk-local throws
+ * itself. Every `STS AssumeRole` in this repo goes through a helper that
+ * throws `AssumeRoleFailure` with a pre-rendered `detail`, so the operation
+ * name in the announcement IS the discriminator -- no call graph needed.
+ * Matched against the same joined DETECTION text `STS_FAILURE_LINE` matched,
+ * so a helper-call string above or below the warn cannot reclassify a site.
+ */
+const OWN_THROW_ANNOUNCE = /\bSTS\s+AssumeRole\b/;
+
+/**
+ * The two halves of the own-throw branch, required SEPARATELY rather than as
+ * one exact ternary spelling (the raw-relay lesson above: one-spelling
+ * patterns rot). `.detail` is what makes the branch USE the pre-rendered
+ * text; `instanceof` alone would also match the inverted defect
+ * (re-rendering the own throw and printing the helper's withhold line).
+ */
+const OWN_THROW_GUARD = /\binstanceof\s+AssumeRoleFailure\b/;
+const OWN_THROW_DETAIL = /\.detail\b/;
+
+/**
  * How many source lines around the announcing line count as part of the site.
  *
  * Measured, not guessed: seven sites render inline on the announcing line or
@@ -122,6 +182,29 @@ const HELPER_CALL = /describeAwsFailureForWarn\s*\(/;
 const LINES_BEFORE = 2;
 const LINES_AFTER = 1;
 
+/**
+ * The own-throw check reads a WIDER window. Measured like the numbers above:
+ * at all four sites the layout is `const <name> =` / `err instanceof
+ * AssumeRoleFailure` / `? err.detail` / `: describeAwsFailureForWarn(...)` /
+ * `logger.warn(` / the announcing line -- the `instanceof` sits exactly four
+ * lines above the announcement, two above the helper-call window's reach.
+ * The vouching concern that keeps `LINES_BEFORE` at 2 applies here too, but
+ * asymmetrically: this check is a REQUIREMENT on the site, not permission to
+ * relay, so a neighbour's branch leaking into the window can only excuse a
+ * missing `instanceof` marker -- and only when two AssumeRole relays sit
+ * within four lines of each other, which the per-file counts below would
+ * surface as a new finding first.
+ */
+const OWN_THROW_LINES_BEFORE = 4;
+
+/**
+ * Issue #613 -- a named renderer's body must CLOSE within this many lines of
+ * its definition or it is not a renderer. The canonical shape is a
+ * one-expression function; a workflow function that happens to contain the
+ * policy shape somewhere in a long body must not become a name that vouches.
+ */
+const RENDERER_BODY_MAX_LINES = 12;
+
 interface Finding {
   file: string;
   line: number;
@@ -129,6 +212,19 @@ interface Finding {
   code: string;
   /** The window verbatim — what `RAW_RELAY` is matched against. See below. */
   raw: string;
+  /**
+   * The `OWN_THROW_LINES_BEFORE` window, comments stripped — what the
+   * own-throw branch check reads. Stripped like `code`, because for a
+   * PRESENCE check stripping can only remove a mark, never invent one.
+   */
+  wideCode: string;
+  /** Whether the DETECTION text announced `STS AssumeRole` (issue #613). */
+  ownThrow: boolean;
+}
+
+/** A function name the helper check accepts as vouching for a site. */
+interface NamedRenderer {
+  name: string;
 }
 
 /**
@@ -171,8 +267,8 @@ function commandFiles(): string[] {
     .sort();
 }
 
-function stsFailureRelays(file: string): Finding[] {
-  const lines = readFileSync(join(COMMANDS, file), 'utf8').split('\n');
+function scanSource(text: string, file: string): Finding[] {
+  const lines = text.split('\n');
   const found: Finding[] = [];
   for (const [i, line] of lines.entries()) {
     const bare = line.trimStart();
@@ -185,13 +281,120 @@ function stsFailureRelays(file: string): Finding[] {
     const ahead = lines.slice(i, i + LINES_AFTER + 1).join('\n');
     if (!/\bSTS\s+[A-Za-z$]/.test(line) || !STS_FAILURE_LINE.test(ahead)) continue;
     const window = lines.slice(Math.max(0, i - LINES_BEFORE), i + LINES_AFTER + 1).join('\n');
-    found.push({ file, line: i + 1, code: stripComments(window), raw: window });
+    const wide = lines
+      .slice(Math.max(0, i - OWN_THROW_LINES_BEFORE), i + LINES_AFTER + 1)
+      .join('\n');
+    found.push({
+      file,
+      line: i + 1,
+      code: stripComments(window),
+      raw: window,
+      wideCode: stripComments(wide),
+      // Classified from the DETECTION text, not the guard window: the guard
+      // window at a GetCallerIdentity site can legitimately contain the
+      // string 'STS AssumeRole' inside a neighbouring helper-call argument.
+      ownThrow: OWN_THROW_ANNOUNCE.test(ahead),
+    });
   }
   return found;
 }
 
+function stsFailureRelays(file: string): Finding[] {
+  return scanSource(readFileSync(join(COMMANDS, file), 'utf8'), file);
+}
+
+/**
+ * A definition that CAN open a renderer: `function name(` or
+ * `const name = (`-style arrow. `const name =` with the initializer on the
+ * next line never matches (the `\(` must sit on the definition line), which
+ * is what keeps the four sites' own `const reason =` hoists out of here.
+ */
+const RENDERER_DEF =
+  /^\s*(?:export\s+)?(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(|^\s*(?:export\s+)?const\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(/;
+
+/**
+ * Body = the definition line through the line where its braces re-balance,
+ * or — for an expression-arrow that never opens a brace — through the line
+ * ending in `;`. `undefined` when `RENDERER_BODY_MAX_LINES` is hit first: an
+ * unmodelled or long shape is NOT a renderer (fail-closed). Brace counting is
+ * naive about braces inside string literals, and that is fine for the same
+ * reason: imbalance means no capture means no name to vouch with.
+ */
+function captureBody(lines: string[], start: number): string | undefined {
+  let depth = 0;
+  let opened = false;
+  const taken: string[] = [];
+  for (let i = start; i < Math.min(lines.length, start + RENDERER_BODY_MAX_LINES); i++) {
+    const l = lines[i]!;
+    taken.push(l);
+    for (const ch of l) {
+      if (ch === '{') {
+        depth++;
+        opened = true;
+      } else if (ch === '}') {
+        depth--;
+      }
+    }
+    if (opened && depth <= 0) return taken.join('\n');
+    if (!opened && /;\s*$/.test(l)) return taken.join('\n');
+  }
+  return undefined;
+}
+
+/**
+ * The names allowed to vouch for a site (issue #613). Qualification is the
+ * FULL policy shape, every condition load-bearing:
+ *
+ *   - a `describeAwsFailureForWarn` CALL — the body routes through the policy;
+ *   - the own-throw branch (`instanceof AssumeRoleFailure` + `.detail`) — a
+ *     bare-helper wrapper is the defective shape one indirection away, and
+ *     recognizing it would re-open exactly the hole this issue closes;
+ *   - no `.warn(` — a renderer RENDERS and returns; a function that warns is
+ *     a SITE, and letting a site's name vouch elsewhere is the adjacency
+ *     evasion in function form;
+ *   - a body the bounded capture can model at all.
+ */
+function collectRenderersFromText(text: string): NamedRenderer[] {
+  const lines = stripComments(text).split('\n');
+  const out: NamedRenderer[] = [];
+  for (const [i, line] of lines.entries()) {
+    const m = RENDERER_DEF.exec(line);
+    if (!m) continue;
+    const name = m[1] ?? m[2]!;
+    const body = captureBody(lines, i);
+    if (body === undefined) continue;
+    if (!HELPER_CALL.test(body)) continue;
+    if (!OWN_THROW_GUARD.test(body) || !OWN_THROW_DETAIL.test(body)) continue;
+    if (/\.warn\s*\(/.test(body)) continue;
+    out.push({ name });
+  }
+  return out;
+}
+
+function callsRenderer(code: string, renderers: NamedRenderer[]): boolean {
+  return renderers.some((r) =>
+    new RegExp(`\\b${r.name.replace(/\$/g, '\\$')}\\s*\\(`).test(code)
+  );
+}
+
+/** The issue #613 helper check: a direct call, or a named renderer's. */
+function isHelperGuarded(f: Finding, renderers: NamedRenderer[]): boolean {
+  return HELPER_CALL.test(f.code) || callsRenderer(f.code, renderers);
+}
+
+/** The issue #613 own-throw check, read from the wider window. */
+function isOwnThrowGuarded(f: Finding, renderers: NamedRenderer[]): boolean {
+  return (
+    (OWN_THROW_GUARD.test(f.wideCode) && OWN_THROW_DETAIL.test(f.wideCode)) ||
+    callsRenderer(f.wideCode, renderers)
+  );
+}
+
 describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
   const all = commandFiles().flatMap(stsFailureRelays);
+  const renderers = commandFiles().flatMap((f) =>
+    collectRenderersFromText(readFileSync(join(COMMANDS, f), 'utf8'))
+  );
 
   it('finds the STS failure lines it is supposed to be guarding', () => {
     // Non-vacuity: if the regex ever stops matching (a reworded message, a
@@ -221,11 +424,51 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
     ]);
   });
 
-  it('routes every one of them through a describeAwsFailureForWarn CALL', () => {
-    const unguarded = all.filter((f) => !HELPER_CALL.test(f.code));
+  it('classifies exactly the four --assume-role relays as own-throw sites (issue #613)', () => {
+    // The classifier's own non-vacuity, both ways: the `STS AssumeRole`
+    // announcements are exactly the four ternary sites, and the seven
+    // GetCallerIdentity relays are NOT asked for a branch they do not need
+    // (nothing on their catch path throws AssumeRoleFailure).
+    expect(
+      all
+        .filter((f) => f.ownThrow)
+        .map((f) => f.file)
+        .sort()
+    ).toEqual([
+      'local-invoke-agentcore.ts',
+      'local-invoke-agentcore.ts',
+      'local-invoke-agentcore.ts',
+      'local-invoke.ts',
+    ]);
+  });
+
+  it('recognizes no named renderer in the tree today', () => {
+    // Pins the collector against silent over-collection: a name in this list
+    // is a name `isHelperGuarded` accepts as vouching for a site, so an entry
+    // must arrive DELIBERATELY (the issue #613 refactor would land an
+    // `assumeRoleDetail` here by name), never as a side effect of an
+    // unrelated function happening to match the shape.
+    expect(renderers).toEqual([]);
+  });
+
+  it('routes every one of them through a describeAwsFailureForWarn CALL or a named renderer', () => {
+    const unguarded = all.filter((f) => !isHelperGuarded(f, renderers));
     expect(
       unguarded.map((f) => `${f.file}:${f.line}`),
       'an STS failure warn that does not render its error through the shared policy'
+    ).toEqual([]);
+  });
+
+  it('requires the own-throw branch at every site relaying a class cdk-local throws itself (issue #613)', () => {
+    // At the four --assume-role sites the helper call ALONE is the DEFECTIVE
+    // shape: re-rendering an `AssumeRoleFailure` through the policy WITHHOLDS
+    // text the policy had already sanitized at throw time. Until this check
+    // the fence blessed exactly that form — twice shipped in PR #611's review
+    // rounds, both caught by per-occurrence literal assertions, never here.
+    const missing = all.filter((f) => f.ownThrow && !isOwnThrowGuarded(f, renderers));
+    expect(
+      missing.map((f) => `${f.file}:${f.line}`),
+      'an --assume-role relay missing the `err instanceof AssumeRoleFailure ? err.detail` branch'
     ).toEqual([]);
   });
 
@@ -305,5 +548,167 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
     expect(STS_FAILURE_LINE.test(guarded)).toBe(true);
     expect(HELPER_CALL.test(stripComments(guarded))).toBe(true);
     expect(RAW_RELAY.test(stripComments(guarded))).toBe(false);
+  });
+
+  it('proves the issue #613 additions discriminate, in both directions', () => {
+    // (g) the DEFECTIVE shape — the helper call WITHOUT the own-throw branch
+    // at an AssumeRole announcement. This is the form the fence used to
+    // bless, and the red-today assertion the issue names: `isHelperGuarded`
+    // is satisfied (that is the old fence passing it) while
+    // `isOwnThrowGuarded` rejects it.
+    const defective = scanSource(
+      [
+        '      } catch (err) {',
+        "        const reason = describeAwsFailureForWarn(err, 'STS AssumeRole');",
+        '        logger.warn(',
+        '          `--assume-role: STS AssumeRole(${arn}) failed: ${reason}. ` +',
+        "            'Falling back.'",
+        '        );',
+        '      }',
+      ].join('\n'),
+      'x.ts'
+    );
+    expect(defective).toHaveLength(1);
+    expect(defective[0]!.ownThrow).toBe(true);
+    expect(isHelperGuarded(defective[0]!, [])).toBe(true);
+    expect(isOwnThrowGuarded(defective[0]!, [])).toBe(false);
+
+    // (h) the genuine inline ternary — the shape at all four real sites —
+    // is accepted by BOTH halves.
+    const genuine = scanSource(
+      [
+        '      } catch (err) {',
+        '        const reason =',
+        '          err instanceof AssumeRoleFailure',
+        '            ? err.detail',
+        "            : describeAwsFailureForWarn(err, 'STS AssumeRole');",
+        '        logger.warn(',
+        '          `--assume-role: STS AssumeRole(${arn}) failed: ${reason}. ` +',
+        "            'Falling back.'",
+        '        );',
+        '      }',
+      ].join('\n'),
+      'x.ts'
+    );
+    expect(genuine).toHaveLength(1);
+    expect(genuine[0]!.ownThrow).toBe(true);
+    expect(isHelperGuarded(genuine[0]!, [])).toBe(true);
+    expect(isOwnThrowGuarded(genuine[0]!, [])).toBe(true);
+
+    // (i) a GetCallerIdentity relay is NOT classified own-throw — the branch
+    // is required only where cdk-local's own class can arrive.
+    const gci = scanSource(
+      [
+        "        const detail = describeAwsFailureForWarn(err, 'STS GetCallerIdentity');",
+        '        logger.warn(',
+        '          `STS GetCallerIdentity failed: ${detail}. Falling back.`',
+        '        );',
+      ].join('\n'),
+      'x.ts'
+    );
+    expect(gci).toHaveLength(1);
+    expect(gci[0]!.ownThrow).toBe(false);
+    expect(isHelperGuarded(gci[0]!, [])).toBe(true);
+
+    // (j) a NAMED RENDERER — the refactor the fence used to forbid — is
+    // collected, and a site delegating to it passes both halves...
+    const rendererSource = [
+      'function assumeRoleDetail(err: unknown, op: string): string {',
+      '  return err instanceof AssumeRoleFailure ? err.detail : describeAwsFailureForWarn(err, op);',
+      '}',
+    ].join('\n');
+    const collected = collectRenderersFromText(rendererSource);
+    expect(collected.map((r) => r.name)).toEqual(['assumeRoleDetail']);
+    const delegating = scanSource(
+      [
+        "        const reason = assumeRoleDetail(err, 'STS AssumeRole');",
+        '        logger.warn(',
+        '          `--assume-role: STS AssumeRole(${arn}) failed: ${reason}. ` +',
+        "            'Falling back.'",
+        '        );',
+      ].join('\n'),
+      'x.ts'
+    );
+    expect(delegating).toHaveLength(1);
+    expect(isHelperGuarded(delegating[0]!, collected)).toBe(true);
+    expect(isOwnThrowGuarded(delegating[0]!, collected)).toBe(true);
+    // ...and WITHOUT the definition in the tree the SAME site fails both —
+    // an arbitrary neighbouring call cannot vouch (the tenth-site property).
+    expect(isHelperGuarded(delegating[0]!, [])).toBe(false);
+    expect(isOwnThrowGuarded(delegating[0]!, [])).toBe(false);
+
+    // (k) deleting what the collector REQUIRES de-recognizes the renderer.
+    // The body no longer routes through the policy:
+    expect(
+      collectRenderersFromText(
+        [
+          'function assumeRoleDetail(err: unknown, op: string): string {',
+          '  return err instanceof AssumeRoleFailure ? err.detail : String(err);',
+          '}',
+        ].join('\n')
+      )
+    ).toEqual([]);
+    // The own-throw branch is gone (the defective shape one indirection away):
+    expect(
+      collectRenderersFromText(
+        [
+          'function assumeRoleDetail(err: unknown, op: string): string {',
+          '  return describeAwsFailureForWarn(err, op);',
+          '}',
+        ].join('\n')
+      )
+    ).toEqual([]);
+    // A body that WARNS is a site, not a renderer:
+    expect(
+      collectRenderersFromText(
+        [
+          'function warnAssumeRoleFailure(err: unknown): void {',
+          '  const d =',
+          '    err instanceof AssumeRoleFailure ? err.detail : describeAwsFailureForWarn(err, "op");',
+          '  logger.warn(`bad: ${d}`);',
+          '}',
+        ].join('\n')
+      )
+    ).toEqual([]);
+
+    // (l) an expression-arrow renderer is modelled too.
+    expect(
+      collectRenderersFromText(
+        [
+          'const assumeRoleDetail = (err: unknown, op: string): string =>',
+          '  err instanceof AssumeRoleFailure ? err.detail : describeAwsFailureForWarn(err, op);',
+        ].join('\n')
+      ).map((r) => r.name)
+    ).toEqual(['assumeRoleDetail']);
+
+    // (m) a body that does not close within the bound is NOT a renderer —
+    // a long workflow function containing the shape somewhere must not
+    // become a name that vouches; the unmodelled shape fails closed.
+    expect(
+      collectRenderersFromText(
+        [
+          'function bigWorkflow(err: unknown): string {',
+          ...Array.from({ length: 12 }, () => '  something();'),
+          '  return err instanceof AssumeRoleFailure ? err.detail : describeAwsFailureForWarn(err, "op");',
+          '}',
+        ].join('\n')
+      )
+    ).toEqual([]);
+
+    // (n) a comment mentioning a renderer name does not vouch — the check
+    // reads the STRIPPED window, same as the direct helper call.
+    const commentVouch = scanSource(
+      [
+        "        // rendered via assumeRoleDetail(err, 'STS AssumeRole')",
+        '        logger.warn(',
+        '          `--assume-role: STS AssumeRole(${arn}) failed: ${String(err)}. ` +',
+        "            'Falling back.'",
+        '        );',
+      ].join('\n'),
+      'x.ts'
+    );
+    expect(commentVouch).toHaveLength(1);
+    expect(isHelperGuarded(commentVouch[0]!, collected)).toBe(false);
+    expect(isOwnThrowGuarded(commentVouch[0]!, collected)).toBe(false);
   });
 });

--- a/tests/unit/local/cfn-local-state-provider-load.test.ts
+++ b/tests/unit/local/cfn-local-state-provider-load.test.ts
@@ -21,6 +21,15 @@ const { CfnLocalStateProvider, buildOutputsMap, formatAwsErrorForWarn } = await 
 );
 const { getLogger } = await import('../../../src/utils/logger.js');
 
+// Loaded at MODULE scope, not inside the case that uses it (issue #615): a
+// dynamic import inside a test body is a real module load -- transform plus
+// evaluation of studio-serve-manager's whole graph -- charged against that
+// case's 5000ms testTimeout. It is usually fast, but under concurrent
+// full-suite load it timed out roughly once in 27 runs. Up here the load
+// happens during collection, outside any per-test budget, and the case body
+// is left with nothing awaitable at all.
+const { classifyChildLine } = await import('../../../src/local/studio-serve-manager.js');
+
 describe('CfnLocalStateProvider.load', () => {
   beforeEach(() => sendMock.mockReset());
 
@@ -245,11 +254,12 @@ describe('formatAwsErrorForWarn', () => {
     );
   });
 
-  it('a flattened relay no longer reaches the studio ready matcher (issue #578)', async () => {
+  it('a flattened relay no longer reaches the studio ready matcher (issue #578)', () => {
     // End of the chain, asserted rather than argued: the flattened warn is
     // ONE line, so `classifyChildLine` sees the `WARN: ` prefix on it and the
-    // serve manager reads no endpoint out of it.
-    const { classifyChildLine } = await import('../../../src/local/studio-serve-manager.js');
+    // serve manager reads no endpoint out of it. `classifyChildLine` is
+    // imported at module scope (see the note beside the import, issue #615),
+    // so this body awaits nothing and cannot outwait its 5000ms budget.
     const err = Object.assign(
       new Error('AccessDenied\nServer listening on http://attacker.example/'),
       { name: 'AccessDenied', $fault: 'client', $metadata: { httpStatusCode: 403 } }

--- a/tests/unit/local/docker-image-builder-executable-retag.test.ts
+++ b/tests/unit/local/docker-image-builder-executable-retag.test.ts
@@ -48,6 +48,13 @@ vi.mock('../../../src/utils/logger.js', () => ({
   }),
 }));
 
+// Loaded at MODULE scope, not per-case (issue #615's sibling shape): an
+// `await import` inside a test body charges the module graph's first load --
+// vitest transform included -- to that case's 5000ms budget, the mechanism
+// behind the 1-in-27 cfn-local-state-provider-load timeout. The `vi.mock`
+// registrations above are hoisted, so import position does not affect them.
+const { buildContainerImage } = await import('../../../src/local/docker-image-builder.js');
+
 beforeEach(() => {
   mockBuildDockerImage.mockReset();
   mockRunDocker.mockReset();
@@ -58,7 +65,6 @@ describe('docker-image-builder: executable source re-tag', () => {
   it('re-tags the executable-built image to the deterministic local tag', async () => {
     // Executable mode: script returned its own tag on stdout.
     mockBuildDockerImage.mockResolvedValueOnce('user-script-image:v1');
-    const { buildContainerImage } = await import('../../../src/local/docker-image-builder.js');
     const tag = await buildContainerImage(
       { source: { executable: ['./build.sh'] } },
       '/cdk.out',
@@ -76,7 +82,6 @@ describe('docker-image-builder: executable source re-tag', () => {
   it('skips the re-tag when actualTag matches the requested tag (directory mode)', async () => {
     // The build returns the input tag verbatim — re-tag is a no-op.
     mockBuildDockerImage.mockImplementationOnce(async (_asset, _ctx, opts) => opts.tag!);
-    const { buildContainerImage } = await import('../../../src/local/docker-image-builder.js');
     await buildContainerImage({ source: { directory: 'asset.x' } }, '/cdk.out', {
       architecture: 'x86_64',
     });
@@ -95,7 +100,6 @@ describe('docker-image-builder: executable source re-tag', () => {
       }
       return { stdout: '', stderr: '' };
     });
-    const { buildContainerImage } = await import('../../../src/local/docker-image-builder.js');
     await expect(
       buildContainerImage({ source: { executable: ['./build.sh'] } }, '/cdk.out', {
         architecture: 'x86_64',


### PR DESCRIPTION
Closes #613
Closes #615

Two test-only fixes in one bundle; no `src/**` or `tests/integration/**` change, so the integ gate short-circuits and the cdkd-parity gate is out of scope by construction.

## Relay source fence: the own-throw branch is now required (#613)

`tests/unit/cli/sts-error-relay-source-fence.test.ts` accepted a bare `describeAwsFailureForWarn(err, ...)` call — exactly the shape whose omission shipped twice in PR (#611)'s review rounds, where re-rendering an `AssumeRoleFailure` withheld text the policy had already sanitized (`ExpiredTokenException: ...` became `Error; 138-character message withheld`). Two additions, both from the issue's fix direction:

- **Own-throw half**: a finding whose DETECTION text announces `STS AssumeRole` is classified `ownThrow` (every AssumeRole in this repo goes through a helper throwing `AssumeRoleFailure` with pre-rendered `detail`, so the operation name is the discriminator — no call graph needed). Such a site must now carry `instanceof AssumeRoleFailure` AND `.detail` in a wider stripped window (`OWN_THROW_LINES_BEFORE = 4` — measured: the `instanceof` line sits exactly four above the announcing line at all four real sites). A new vacuity test pins the classification to exactly the four ternary sites (`local-invoke.ts` x1, `local-invoke-agentcore.ts` x3); the seven GetCallerIdentity relays are not asked for a branch they do not need.
- **Named-renderer half**: a site may now delegate to a renderer DEFINED in the scanned tree, so the four duplicated ternaries can be factored without defeating the tenth-site property (the refactor PR (#611) declined). Recognition is strict and fail-closed: the callee's body must carry the FULL policy shape (helper call AND own-throw branch), must not `.warn(` itself (a renderer renders; a site warns), and must close within a bounded capture (`RENDERER_BODY_MAX_LINES = 12`); an unmodelled shape is not a renderer. Today's tree is pinned to recognize NO renderer, so a name can only start vouching deliberately.

Discriminance cases (g)-(n) pin both directions on synthetic sources: the defective shape rejected, the genuine ternary accepted, GetCallerIdentity unclassified, a qualifying renderer collected and vouching, each collector requirement deleted one at a time de-recognizing it, the arrow form modelled, the bound failing closed, and a comment mentioning a renderer not vouching.

### Mutation-probe evidence (the live test for a fence change)

Run against the REAL tree, then restored (`git status` clean):

| probe | mutation | origin/main fence | this fence |
| --- | --- | --- | --- |
| A | `local-invoke.ts` ternary degraded to the bare helper call — the exact PR (#611) defective shape | 4/4 green (the defect is blessed) | RED: `an --assume-role relay missing the instanceof AssumeRoleFailure ? err.detail branch: [ 'local-invoke.ts:1090' ]` |
| C | helper call deleted at a GetCallerIdentity site (`local-run-task.ts`) | — | RED on the widened helper test AND the raw-relay test, naming `local-run-task.ts:567` — the pre-existing property survives the widening |

Also fixed in passing: the header's stale `exact-9 count` wording (the pinned count has been 11 since issue (#579); the assertion was right, the prose was not).

## Flake fix: dynamic import hoisted out of the timed body (#615)

The issue-(#578) case in `tests/unit/local/cfn-local-state-provider-load.test.ts` did `await import('../../../src/local/studio-serve-manager.js')` INSIDE its body: a real first load of that module graph — vitest transform plus evaluation — charged against the case's 5000ms `testTimeout`, which timed out roughly once in 27 full-suite runs under concurrent load. The import is hoisted to module scope beside the file's existing top-level `await import`s, where it runs at collection time; the case body is now synchronous and awaits nothing at all, so it structurally cannot outwait its budget (the issue's "establish whether the case can wait on anything unbounded" answered by construction).

Mechanism evidence, since a 1-in-27 flake cannot be reproduced on demand: this tree's full run reports `import 130.93s` cumulative against `tests 38.15s` — module-graph loading dominates suite wall-time and is exactly the cost that must not sit inside a 5s per-case window. A 15x loop of the file after the fix: 0 failures (a stability check, not proof).

## Sibling-site sweeps (deriving commands inline, re-derived at this HEAD)

- **(#613) class — other own-throw relays**: `grep -rn "class \w*Failure extends Error" src/` and `grep -rn "instanceof AssumeRoleFailure" src/` show `AssumeRoleFailure` is the only error class carrying pre-rendered `detail` relayed through the policy, and its four command-layer relays are exactly the four `STS AssumeRole` fence findings (now pinned by the classification test). The two `src/utils/role-arn.ts` relays remain outside the fence's scan per the issue's own scope note — widening the scan is recorded there as a separate decision, not re-derived here.
- **(#615) class — other in-body dynamic imports**: a scanner over `tests/unit/**` for `await import(` inside `it()` / hook bodies found 34 syntactic hits. Eligibility for the root cause is narrower: the FIRST load of a `src/**` module graph (which pays vitest transform) with no module-scope import of the same module and no `vi.resetModules` semantics. Exactly two files qualify: the issue's own, and `tests/unit/local/docker-image-builder-executable-retag.test.ts` (three occurrences of the same import — hoisted here the same way). The other hits are module-cache re-imports (the SUT is already module-scope imported, directly or transitively — e.g. `cli-consistency-249.test.ts` reaches `ecs-service-emulator.js` through `local-start-alb.ts` line 31) or Node built-ins / small externalized deps (`node:stream`, `node:fs`, `ws`, `commander`) that pay no transform in the timed window.

## Follow-up + Won't-do (decided + recorded)

- TODO (#645): factor the four ternaries into the named renderer the fence now accepts, refreshing the four in-code comments that still say one level of indirection defeats the fence — true when written, superseded here. Left untouched in THIS PR deliberately: a comment-only `src/**` edit stales the `integ` marker and drags a Docker cycle into a test-only bundle; the follow-up issue carries the classification and the verification command.
- A mechanical scanner banning in-body `await import` in tests was considered and rejected: the legitimate population (cache-hit re-imports, built-ins, post-`vi.resetModules` reloads) is textually indistinguishable from the defect without a module graph, and a fence with a standing false-positive population is a fence nobody keeps.

## Test plan

- `vp run verify` green (check + full unit suite + `test:hooks` + build); full suite 242 files / 4363 tests.
- `vp test run tests/unit/cli/sts-error-relay-source-fence.test.ts` — 8 tests green on the real tree.
- Mutation probes A and C above (fence red exactly where it must be, src restored).
- 15x loop of `tests/unit/local/cfn-local-state-provider-load.test.ts` — 0 failures.

https://claude.ai/code/session_013nzcfREnS27fGicTe4qAfT

