### PR TITLE
fix(integ): remove the Docker images eight fixtures build, instead of leaking a tag per run

### DIFF
--- a/tests/integration/_lib/image-cleanup.sh
+++ b/tests/integration/_lib/image-cleanup.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# Built-image cleanup for integration fixtures (issue #603).
+#
+# A fixture that builds a Docker image -- directly, or by running a cdk-local
+# command that builds one -- used to leave the tag behind on every run. Eight
+# fixtures did, across four tag namespaces:
+#
+#   cdkl-run-task-<assetHash16>        src/local/ecs-task-runner.ts
+#   cdkl-override-<svc>-<hash>:local   src/local/image-override-engine.ts
+#   cdkl-invoke-<hash16>               src/local/docker-image-builder.ts
+#   cdkl-agentcore-code-<hash>         src/local/agentcore-code-build.ts
+#
+# ## Why snapshot-and-delta rather than a blanket `docker rmi`
+#
+# Parallel integ lanes share ONE Docker daemon on a dev host. A blanket sweep
+# over a namespace deletes an image a peer lane is mid-run on -- the reasoning
+# issue #587 landed in local-studio. So the set present at the start is
+# recorded, and only tags that appeared SINCE are removed.
+#
+# ## Why this is shared rather than copied per fixture
+#
+# Fixtures are deliberately self-contained for their ASSERTIONS, and this
+# followed that habit at first -- eight near-identical copies. Review rejected it,
+# correctly: this is a DESTRUCTIVE primitive on shared host state whose
+# invariants (both `comm` operands sorted, the baseline captured before any
+# build, the baseline never trusted when empty-by-accident) are not obvious from
+# reading a call site. Copies had live fail-opens in them; eight copies meant
+# fixing each one eight times and getting it right eight times.
+#
+# ## The fail-open that made this a library
+#
+# The first version published the temp path and wrote the snapshot into it as
+# two separate steps:
+#
+#     IMAGES_BEFORE="$(mktemp)"          # path is live from here
+#     snapshot_images > "${IMAGES_BEFORE}"
+#
+# If that write failed or truncated -- a docker hiccup after the daemon probe,
+# or `pipefail` catching a partial `docker images` -- `set -e` aborted, the EXIT
+# trap fired, and the cleanup read an EMPTY baseline. An empty baseline makes
+# the delta the ENTIRE namespace, so the run deletes every peer lane's tags.
+# Measured with a deliberately empty baseline and two peer images present, it
+# selected both. `integ_image_cleanup_init` therefore assigns the module's
+# baseline variable ONLY after a successful write; until then it stays empty and
+# `integ_image_cleanup_run` is a no-op.
+#
+# Know what that costs, because it is not "the run continues without cleanup":
+# `init` is called at TOP LEVEL, and every consumer runs `set -euo pipefail`, so
+# a non-zero return ABORTS THE FIXTURE right there -- measured, the line after
+# `init` never runs. That is deliberate. A fixture that cannot establish a
+# baseline cannot safely clean up what it is about to build, and the honest
+# response to "docker just failed" is to stop rather than to build images whose
+# removal is now unbounded. A caller that would rather continue must opt in
+# explicitly with `integ_image_cleanup_init ... || true` and accept leaking its
+# own tags.
+#
+# ## Usage
+#
+#   source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+#   ...
+#   docker version ... >/dev/null            # daemon probe first
+#   integ_image_cleanup_init 'cdkl-run-task-*'
+#   ...
+#   cleanup() { ...; integ_image_cleanup_run; }   # LAST in the trap
+#
+# Call `init` AFTER the daemon probe and BEFORE anything builds into the
+# namespace. A `docker pull` of a base image outside the namespace may sit
+# either side of it; a pull INTO the namespace must come after.
+
+# Space-free glob patterns passed to `docker images --filter reference=`.
+# Held as a plain string rather than an array: bash 3.2 (macOS system bash,
+# which `vp run test:hooks` exercises) errors on `"${arr[@]}"` for an empty
+# array under `set -u`, and every consumer here is a whitespace-free glob.
+INTEG_IMAGE_FILTERS=""
+
+# Path to the baseline snapshot. Empty until a snapshot has been written
+# SUCCESSFULLY -- see the fail-open note above. Never assign this directly.
+INTEG_IMAGES_BEFORE=""
+
+# Print the current tag set for every registered filter, sorted.
+# Sorting is not cosmetic: `comm` requires both operands sorted, and
+# `docker images` does not promise an order.
+integ_image_snapshot() {
+  # `${INTEG_IMAGE_FILTERS}` is UNQUOTED on purpose, to split on whitespace --
+  # but an unquoted expansion also PATHNAME-EXPANDS, and these values are globs.
+  # Measured: with a file named `cdkl-run-task-deadbeef` in the cwd, the loop
+  # sees `cdkl-run-task-deadbeef` instead of `cdkl-run-task-*`, so the snapshot
+  # covers one tag instead of the namespace. An incomplete BASELINE is the same
+  # fail-open as an empty one: every pre-existing tag it missed lands in this
+  # run's delta and gets deleted. `set -f` splits without globbing.
+  local f had_f=0 rc=0 acc
+  case "$-" in *f*) had_f=1 ;; esac
+  set -f
+
+  # Each filter is checked INDIVIDUALLY, and the results accumulate in a file
+  # that is sorted at the end. The obvious spelling -- `for ...; done | sort` --
+  # is a fail-open: a `for` loop's exit status is its LAST iteration's, so a
+  # `docker images` failure on any filter but the last is lost inside the loop
+  # before `pipefail` can see it. `init` would then return 0 having armed a
+  # PARTIAL baseline, and everything under the failed filter looks new and gets
+  # deleted. Measured: with a stub failing only the first of two filters, the
+  # pipeline form returned 0. `local-invoke-agentcore` is the only two-filter
+  # caller and it puts the shared `cdkl-invoke-*` namespace first, i.e. exactly
+  # in the swallowed position.
+  acc="$(mktemp)" || { [ "${had_f}" -eq 1 ] || set +f; return 1; }
+  for f in ${INTEG_IMAGE_FILTERS}; do
+    if ! docker images --filter "reference=${f}" --format '{{.Repository}}:{{.Tag}}' >> "${acc}"; then
+      rc=1
+      break
+    fi
+  done
+  [ "${had_f}" -eq 1 ] || set +f
+  if [ "${rc}" -ne 0 ]; then
+    rm -f "${acc}"
+    return 1
+  fi
+  sort "${acc}"
+  rc=$?
+  rm -f "${acc}"
+  return "${rc}"
+}
+
+# integ_image_cleanup_init <glob> [<glob>...]
+# Record the baseline. Returns non-zero without arming anything if the
+# snapshot cannot be written.
+integ_image_cleanup_init() {
+  if [ "$#" -eq 0 ]; then
+    echo "integ_image_cleanup_init: at least one reference glob is required" >&2
+    return 1
+  fi
+  INTEG_IMAGE_FILTERS="$*"
+  local snap
+  snap="$(mktemp)" || return 1
+  # Write FIRST, publish SECOND. A failed or partial write leaves
+  # INTEG_IMAGES_BEFORE empty, so the cleanup declines to delete anything
+  # rather than treating an empty baseline as "the namespace was empty".
+  if ! integ_image_snapshot > "${snap}"; then
+    rm -f "${snap}"
+    return 1
+  fi
+  INTEG_IMAGES_BEFORE="${snap}"
+}
+
+# Remove only the tags that appeared since `init`. Safe to call more than
+# once: fixtures trap `EXIT INT TERM`, so cleanup can fire twice.
+integ_image_cleanup_run() {
+  if [ -z "${INTEG_IMAGES_BEFORE:-}" ] || [ ! -f "${INTEG_IMAGES_BEFORE}" ]; then
+    return 0
+  fi
+  local new
+  new="$(integ_image_snapshot | comm -13 "${INTEG_IMAGES_BEFORE}" - || true)"
+  if [ -n "${new}" ]; then
+    echo "==> Removing image(s) built by this run:"
+    echo "${new}" | sed 's/^/      /'
+    # Unforced ON PURPOSE, but do NOT read it as peer protection: a fixture's
+    # own cleanup typically force-removes every `cdkl-*` container first, so by
+    # the time this runs nothing is holding the image and the unforced remove
+    # succeeds anyway. What actually bounds the blast radius is the delta.
+    echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
+  fi
+  rm -f "${INTEG_IMAGES_BEFORE}"
+  INTEG_IMAGES_BEFORE=""
+}
+
+# KNOWN RESIDUAL WINDOW, stated rather than papered over: a peer lane that
+# builds into the namespace AFTER this run's snapshot lands in this run's delta
+# and is removed. Two same-fixture lanes produce the SAME asset hash, hence the
+# same tag, so this is reachable rather than theoretical. Do NOT reach for the
+# comforting version of this -- "the peer's own container already holds the
+# image, so the unforced remove fails harmlessly" is FALSE for a peer sitting
+# between `docker build` and `docker run`, which is precisely the window a
+# `--watch` rebuild roll spends most of its time in. Closing it properly needs
+# per-lane tag names (the `cdkl-*` prefix is not lane-scoped) and is tracked
+# separately from this cleanup.

--- a/tests/integration/_lib/image-cleanup.test.sh
+++ b/tests/integration/_lib/image-cleanup.test.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# Smoke test for tests/integration/_lib/image-cleanup.sh (issue #603).
+#
+# The subject DELETES Docker images on a daemon every parallel integ lane
+# shares, so the failure it can produce is another lane losing an image
+# mid-run. That is why it is fenced here rather than left to the six fixtures
+# that call it.
+#
+# What it pins, in the order the failure would hurt:
+#
+#   1. A snapshot that could not be written NEVER arms the cleanup. This was a
+#      live fail-open in the first version: the temp path was published to the
+#      baseline variable BEFORE the snapshot was written into it, so a failed
+#      or truncated write left an EMPTY baseline, which makes the delta the
+#      ENTIRE namespace. Section 1 drives the old shape and the new one over
+#      the same input and requires them to disagree -- if they ever agree
+#      again, the regression is back.
+#   2. Only tags that appeared AFTER the baseline are removed; anything present
+#      before it survives. That is the whole peer-lane guarantee.
+#   3. Re-entrancy: fixtures trap `EXIT INT TERM`, so cleanup can fire twice.
+#      The second firing must remove nothing and exit 0.
+#   4. Multiple filters are honoured (local-invoke-agentcore needs two, and a
+#      one-filter snapshot silently leaves the other namespace behind).
+#   5. Every fixture that builds an image sources the library and calls BOTH
+#      halves -- with a population floor, because the list is derived and a
+#      predicate that stops matching would silently empty the suite while
+#      still printing `fail: 0`.
+#   6. local-invoke-agentcore COMPOSES the call into its existing progressive
+#      `trap ... EXIT` chain instead of adding one. A second `trap ... EXIT`
+#      REPLACES the first, so a new trap would silently drop the temp-file
+#      cleanup that chain carries.
+#
+# `docker` is STUBBED on PATH throughout: the logic under test is set algebra
+# over `docker images` output, so a real daemon would make this slower, flaky
+# and unavailable in CI without buying a single additional assertion.
+#
+# Must stay green under macOS system bash 3.2 as well as modern bash: no
+# `${var,,}`, no associative arrays, no `mapfile`.
+#
+# Run: bash tests/integration/_lib/image-cleanup.test.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd -P)"
+LIB="${ROOT}/tests/integration/_lib/image-cleanup.sh"
+pass=0
+fail=0
+
+ok()   { pass=$((pass+1)); echo "ok   $1"; }
+bad()  { fail=$((fail+1)); echo "FAIL $1"; }
+check(){ # check <desc> <actual> <expected>
+  if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 -- got [$2] want [$3]"; fi
+}
+
+[ -f "${LIB}" ] || { echo "FAIL library not found at ${LIB}"; exit 1; }
+
+# --- docker stub -------------------------------------------------------------
+# STUB_IMAGES is a newline-separated "<filterglob> <tag>" table. `docker images
+# --filter reference=<glob>` prints the tags whose glob matches. `docker image
+# rm` appends to STUB_RM_LOG. Deliberately NOT sorted on output, so a caller
+# that forgets to sort before `comm` fails here rather than in production.
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+cat > "${STUB_DIR}/docker" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  images)
+    glob=""
+    for a in "$@"; do
+      case "$a" in reference=*) glob="${a#reference=}" ;; esac
+    done
+    # A chosen filter can FAIL. Without this the stub always exits 0, so a
+    # per-filter `docker images` failure is unreachable and the swallowed-status
+    # fail-open (a `for ... done | sort` pipeline reports only its LAST
+    # iteration) cannot be fenced at all.
+    if [ -n "${STUB_FAIL_FILTER:-}" ] && [ "${glob}" = "${STUB_FAIL_FILTER}" ]; then
+      echo "stub: simulated docker failure for ${glob}" >&2
+      exit 1
+    fi
+    while IFS=' ' read -r g t; do
+      [ -n "${g:-}" ] || continue
+      [ "$g" = "$glob" ] || continue
+      printf '%s\n' "$t"
+    done < "${STUB_IMAGES_FILE}"
+    ;;
+  image)
+    shift
+    if [ "${1:-}" = "rm" ]; then
+      shift
+      for t in "$@"; do printf '%s\n' "$t" >> "${STUB_RM_LOG}"; done
+    fi
+    ;;
+esac
+exit 0
+STUB
+chmod +x "${STUB_DIR}/docker"
+PATH="${STUB_DIR}:${PATH}"
+export PATH
+STUB_IMAGES_FILE="${STUB_DIR}/images.txt"
+STUB_RM_LOG="${STUB_DIR}/rm.log"
+STUB_FAIL_FILTER=""
+export STUB_IMAGES_FILE STUB_RM_LOG STUB_FAIL_FILTER
+
+set_images() { printf '%s\n' "$@" > "${STUB_IMAGES_FILE}"; }
+removed()    { [ -f "${STUB_RM_LOG}" ] && sort "${STUB_RM_LOG}" | tr '\n' ' ' | sed 's/ $//' || true; }
+reset_rm()   { : > "${STUB_RM_LOG}"; }
+
+# shellcheck source=/dev/null
+. "${LIB}"
+
+echo "== 1. a snapshot that cannot be written never arms the cleanup"
+# The OLD shape, transcribed, driven over the same input. It must DIFFER from
+# the new one; an assertion that both "do the right thing" would pass even if
+# the fix were reverted, so the disagreement itself is the assertion.
+set_images 'cdkl-x-* cdkl-x-peer1:local' 'cdkl-x-* cdkl-x-peer2:local'
+old_delta="$(
+  OLD_BEFORE="$(mktemp)"                 # path published FIRST
+  false > "${OLD_BEFORE}" || true        # ...and the write then fails
+  docker images --filter 'reference=cdkl-x-*' --format '{{.Repository}}:{{.Tag}}' \
+    | sort | comm -13 "${OLD_BEFORE}" - | tr '\n' ' ' | sed 's/ $//'
+)"
+check "old shape would delete every peer tag" \
+  "${old_delta}" "cdkl-x-peer1:local cdkl-x-peer2:local"
+
+INTEG_IMAGES_BEFORE=""
+reset_rm
+(
+  # Force the snapshot write to fail.
+  integ_image_snapshot() { return 1; }
+  integ_image_cleanup_init 'cdkl-x-*'
+  rc=$?
+  printf '%s|%s\n' "${rc}" "${INTEG_IMAGES_BEFORE}" > "${STUB_DIR}/initres"
+)
+initres="$(cat "${STUB_DIR}/initres")"
+check "new shape: init reports failure and arms nothing" "${initres}" "1|"
+
+# And with nothing armed, the cleanup must be inert.
+INTEG_IMAGES_BEFORE=""
+reset_rm
+integ_image_cleanup_run
+check "new shape: unarmed cleanup removes nothing" "$(removed)" ""
+
+echo "== 2. only tags that appeared after the baseline are removed"
+INTEG_IMAGES_BEFORE=""
+reset_rm
+set_images 'cdkl-x-* cdkl-x-peer1:local' 'cdkl-x-* cdkl-x-peer2:local'
+integ_image_cleanup_init 'cdkl-x-*'
+check "init armed a baseline" "$([ -n "${INTEG_IMAGES_BEFORE}" ] && echo yes || echo no)" "yes"
+set_images 'cdkl-x-* cdkl-x-peer1:local' 'cdkl-x-* cdkl-x-peer2:local' 'cdkl-x-* cdkl-x-mine:local'
+integ_image_cleanup_run
+check "removes only this run's tag" "$(removed)" "cdkl-x-mine:local"
+
+echo "== 3. a second firing is a silent no-op"
+reset_rm
+integ_image_cleanup_run
+rc=$?
+check "second firing removes nothing" "$(removed)" ""
+check "second firing exits 0" "${rc}" "0"
+
+echo "== 4. every registered filter is snapshotted"
+INTEG_IMAGES_BEFORE=""
+reset_rm
+set_images 'cdkl-a-* cdkl-a-old:latest' 'cdkl-b-* cdkl-b-old:latest'
+integ_image_cleanup_init 'cdkl-a-*' 'cdkl-b-*'
+set_images 'cdkl-a-* cdkl-a-old:latest' 'cdkl-a-* cdkl-a-new:latest' \
+           'cdkl-b-* cdkl-b-old:latest' 'cdkl-b-* cdkl-b-new:latest'
+integ_image_cleanup_run
+check "both namespaces are cleaned" "$(removed)" "cdkl-a-new:latest cdkl-b-new:latest"
+
+# A one-filter arm must NOT reach the second namespace -- this is the
+# local-invoke-agentcore mistake, and it is invisible without this case.
+INTEG_IMAGES_BEFORE=""
+reset_rm
+set_images 'cdkl-a-* cdkl-a-old:latest' 'cdkl-b-* cdkl-b-old:latest'
+integ_image_cleanup_init 'cdkl-a-*'
+set_images 'cdkl-a-* cdkl-a-old:latest' 'cdkl-a-* cdkl-a-new:latest' \
+           'cdkl-b-* cdkl-b-old:latest' 'cdkl-b-* cdkl-b-new:latest'
+integ_image_cleanup_run
+check "a one-filter arm leaves the other namespace alone" "$(removed)" "cdkl-a-new:latest"
+
+echo "== 4b. the snapshot is SORTED, which comm requires"
+# Deliberately REVERSE-ordered stub data. `docker images` promises no order, and
+# `comm` silently produces a wrong answer on unsorted input, so dropping the
+# `| sort` must be visible here. It was not until this case existed: a mutation
+# that removed the sort left the suite fully green because every other case
+# happened to feed already-ordered data.
+INTEG_IMAGES_BEFORE=""
+reset_rm
+set_images 'cdkl-s-* cdkl-s-zzz:latest' 'cdkl-s-* cdkl-s-mmm:latest' 'cdkl-s-* cdkl-s-aaa:latest'
+integ_image_cleanup_init 'cdkl-s-*'
+set_images 'cdkl-s-* cdkl-s-zzz:latest' 'cdkl-s-* cdkl-s-mmm:latest' \
+           'cdkl-s-* cdkl-s-nnn:latest' 'cdkl-s-* cdkl-s-aaa:latest'
+integ_image_cleanup_run
+check "unordered daemon output still yields exactly the new tag" \
+  "$(removed)" "cdkl-s-nnn:latest"
+
+echo "== 4c. a cwd file matching a filter glob must not replace it"
+# `${INTEG_IMAGE_FILTERS}` is expanded unquoted to split on whitespace, which
+# also pathname-expands. With a matching FILE in the cwd the loop would see that
+# FILENAME instead of the glob, so the snapshot would cover one tag instead of
+# the namespace -- and an incomplete baseline puts every tag it missed into this
+# run's delta. Measured before the `set -f` fix: the loop saw
+# `cdkl-run-task-deadbeef` in place of `cdkl-run-task-*`.
+INTEG_IMAGES_BEFORE=""
+reset_rm
+glob_cwd="$(mktemp -d)"
+touch "${glob_cwd}/cdkl-g-decoy"
+set_images 'cdkl-g-* cdkl-g-old:latest'
+cd "${glob_cwd}" || exit 1
+integ_image_cleanup_init 'cdkl-g-*'
+set_images 'cdkl-g-* cdkl-g-old:latest' 'cdkl-g-* cdkl-g-mine:latest'
+integ_image_cleanup_run
+cd "${ROOT}" || exit 1
+# Without `set -f` the baseline is narrowed to the decoy filename, so it misses
+# `cdkl-g-old` and the pre-existing tag is deleted alongside this run's.
+check "a decoy file in cwd does not narrow the snapshot" "$(removed)" "cdkl-g-mine:latest"
+rm -rf "${glob_cwd}"
+
+echo "== 4d. a tag REMOVED during the run is not resurrected into the delta"
+# Every other case has an after-set that is a SUPERSET of the baseline, which
+# makes `comm -13` and `comm -3` indistinguishable. Here the baseline holds a tag
+# that is GONE afterwards: `-13` (lines only in the after-set) still yields just
+# the new tag, while `-3` would also emit the vanished one and try to delete a
+# tag that no longer exists.
+INTEG_IMAGES_BEFORE=""
+reset_rm
+set_images 'cdkl-d-* cdkl-d-old:latest' 'cdkl-d-* cdkl-d-vanishes:latest'
+integ_image_cleanup_init 'cdkl-d-*'
+set_images 'cdkl-d-* cdkl-d-old:latest' 'cdkl-d-* cdkl-d-mine:latest'
+integ_image_cleanup_run
+check "a vanished baseline tag stays out of the delta" "$(removed)" "cdkl-d-mine:latest"
+
+echo "== 4e. an armed-but-missing baseline file is a no-op, not a crash"
+# `run` guards on `[ ! -f ]`. Without it `comm` is handed a nonexistent operand:
+# it errors, `|| true` swallows that, `new` is empty, and the cleanup silently
+# does nothing -- which LOOKS the same from outside. Assert the guard by way of
+# the exit status and the absence of any removal.
+INTEG_IMAGES_BEFORE=""
+reset_rm
+set_images 'cdkl-e-* cdkl-e-old:latest'
+integ_image_cleanup_init 'cdkl-e-*'
+rm -f "${INTEG_IMAGES_BEFORE}"          # the baseline file disappears
+set_images 'cdkl-e-* cdkl-e-old:latest' 'cdkl-e-* cdkl-e-new:latest'
+# stderr is the discriminator. Removing the guard leaves `comm` reading a
+# nonexistent operand: it errors, `|| true` swallows the status, `new` comes out
+# empty and NOTHING is removed -- identical from the outside. Only the error
+# message distinguishes the two, so assert on it.
+err4e="$(integ_image_cleanup_run 2>&1 >/dev/null)"; rc=$?
+check "a missing baseline file removes nothing" "$(removed)" ""
+check "a missing baseline file still exits 0" "${rc}" "0"
+check "a missing baseline file produces no error output" "${err4e}" ""
+
+echo "== 4f. a failure on a NON-LAST filter fails the whole snapshot"
+# A `for ... done | sort` pipeline reports only the LAST iteration's status, so a
+# `docker images` failure on any earlier filter is swallowed: `init` returns 0
+# having armed a PARTIAL baseline, and every tag under the failed filter then
+# looks new and is deleted. local-invoke-agentcore is the only two-filter caller
+# and it puts the shared `cdkl-invoke-*` namespace FIRST -- the swallowed slot.
+INTEG_IMAGES_BEFORE=""
+reset_rm
+set_images 'cdkl-p-* cdkl-p-peer:latest' 'cdkl-q-* cdkl-q-peer:latest'
+STUB_FAIL_FILTER='cdkl-p-*'
+integ_image_cleanup_init 'cdkl-p-*' 'cdkl-q-*'
+rc=$?
+STUB_FAIL_FILTER=''
+check "init fails when the FIRST of two filters fails" "${rc}" "1"
+check "init arms nothing when a filter failed" "${INTEG_IMAGES_BEFORE}" ""
+integ_image_cleanup_run
+check "nothing is deleted after a failed multi-filter snapshot" "$(removed)" ""
+
+echo "== 5. init refuses with no filters"
+INTEG_IMAGES_BEFORE=""
+err="$(integ_image_cleanup_init 2>&1 >/dev/null)"; rc=$?
+check "no-filter init exits non-zero" "$([ "${rc}" -ne 0 ] && echo yes || echo no)" "yes"
+check "no-filter init explains itself" \
+  "$(printf '%s' "${err}" | grep -c 'reference glob is required')" "1"
+check "no-filter init arms nothing" "${INTEG_IMAGES_BEFORE}" ""
+
+echo "== 6. every image-building fixture wires BOTH halves"
+# Derived, not hand-listed. The floor below is what stops a predicate that
+# stopped matching from silently emptying this section.
+builders=""
+for v in "${ROOT}"/tests/integration/*/verify.sh; do
+  grep -q '_lib/image-cleanup.sh' "$v" || continue
+  builders="${builders} $(basename "$(dirname "$v")")"
+done
+n=0
+for b in ${builders}; do n=$((n+1)); done
+check "population floor: at least 8 fixtures source the library" \
+  "$([ "${n}" -ge 8 ] && echo yes || echo no)" "yes"
+for b in ${builders}; do
+  v="${ROOT}/tests/integration/${b}/verify.sh"
+  check "${b}: calls integ_image_cleanup_init" \
+    "$(grep -c 'integ_image_cleanup_init' "$v")" "1"
+  check "${b}: calls integ_image_cleanup_run" \
+    "$([ "$(grep -c 'integ_image_cleanup_run' "$v")" -ge 1 ] && echo yes || echo no)" "yes"
+  # The `source` must come BEFORE the fixture's `cd "$(dirname "$0")"`.
+  # `${BASH_SOURCE[0]}` holds the path the script was INVOKED with, so once the
+  # cwd changes it no longer resolves and the source dies with "No such file or
+  # directory" before a single assertion runs. Costs a whole integ round to find
+  # by running, and nothing else in the repo would notice.
+  src_ln="$(grep -n 'source .*_lib/image-cleanup.sh' "$v" | head -1 | cut -d: -f1)"
+  cd_ln="$(grep -n '^cd "\$(dirname' "$v" | head -1 | cut -d: -f1)"
+  check "${b}: sources the library before the cd" \
+    "$([ -n "${cd_ln}" ] && [ "${src_ln}" -lt "${cd_ln}" ] && echo yes || echo no)" "yes"
+
+  # The init must come BEFORE the first thing that could build into the
+  # namespace; the daemon probe is the agreed anchor.
+  init_ln="$(grep -n 'integ_image_cleanup_init' "$v" | head -1 | cut -d: -f1)"
+  dv_ln="$(grep -n 'docker version' "$v" | head -1 | cut -d: -f1)"
+  check "${b}: init runs after the docker daemon probe" \
+    "$([ -n "${dv_ln}" ] && [ "${init_ln}" -gt "${dv_ln}" ] && echo yes || echo no)" "yes"
+done
+
+echo "== 7. local-invoke-agentcore composes into its trap chain, never adds one"
+AC="${ROOT}/tests/integration/local-invoke-agentcore/verify.sh"
+traps="$(grep -c '^trap ' "$AC")"
+composed="$(grep -c "; integ_image_cleanup_run' EXIT" "$AC")"
+check "every EXIT trap carries the cleanup" "${composed}" "${traps}"
+check "the chain still has its 8 progressive handlers" "${traps}" "8"
+# The last handler must still list every temp file the chain accumulated: a
+# replacement trap would have dropped them. Count the `${VAR}` references rather
+# than matching the call -- the previous spelling ORed in a bare
+# `integ_image_cleanup_run` alternative, so it matched any line containing the
+# call and stayed green when the final handler was reduced to one temp file.
+last_trap="$(grep '^trap ' "$AC" | tail -1)"
+first_trap="$(grep '^trap ' "$AC" | head -1)"
+nlast="$(printf '%s' "${last_trap}" | grep -o '\${[A-Z0-9_]*}' | sort -u | wc -l | tr -d ' ')"
+nfirst="$(printf '%s' "${first_trap}" | grep -o '\${[A-Z0-9_]*}' | sort -u | wc -l | tr -d ' ')"
+check "the final trap lists the full accumulated temp-file set (8)" "${nlast}" "8"
+check "the chain GREW: the first handler lists fewer files than the last" \
+  "$([ "${nfirst}" -lt "${nlast}" ] && echo yes || echo no)" "yes"
+
+echo
+echo "pass: ${pass}  fail: ${fail}"
+[ "${fail}" -eq 0 ]

--- a/tests/integration/local-invoke-agentcore/verify.sh
+++ b/tests/integration/local-invoke-agentcore/verify.sh
@@ -29,6 +29,19 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# BOTH namespaces: the container-artifact agents build `cdkl-invoke-*`, the two
+# `fromCodeAsset` runtimes build `cdkl-agentcore-code-*`. One filter would leave
+# the code images behind -- which is also why the issue's own "5 -> 8" count,
+# taken over `cdkl-invoke-*` alone, under-reports this fixture.
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -86,14 +99,26 @@ capture_all() {
   fi
   printf '%s\n' "${out}"
 }
+
 # Registered immediately: the first capture happens before the fixture's own
 # first `trap 'rm -f ...' EXIT`, which would otherwise leave this file behind
 # when a run fails on the very first step. Later traps replace this handler
 # and already list "${CDKL_STDERR}" themselves.
-trap 'rm -f "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
+
+# Snapshot AFTER the daemon check, so a docker-down run fails at the friendly
+# step above and the `[ -f ]` guard makes the cleanup a no-op.
+#
+# The `docker pull`s below run AFTER this snapshot, which looks unsafe and is
+# not: they pull `amazon/...` and `public.ecr.aws/...` base images, none of
+# which can match this fixture's `cdkl-*` reference filter, so they cannot
+# enter the delta. If you ever widen the filter or add a pull INTO the
+# namespace, move it above this line -- otherwise the cleanup would delete a
+# shared base image that other fixtures and other lanes depend on.
+integ_image_cleanup_init 'cdkl-invoke-*' 'cdkl-agentcore-code-*'
 
 echo "==> Pulling base images (one-time)"
 docker pull --platform linux/arm64 "${BASE_IMAGE}" >/dev/null
@@ -121,7 +146,7 @@ echo "${RESULT_1}" | grep -Eq '"sessionId":"[0-9a-fA-F-]{8,}' || {
 # Test 2 — event payload via --event echoes through /invocations.
 echo "==> [2/20] Invoking EchoAgent with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"prompt":"hello agent","n":7}' > "${EVENT_FILE}"
 RESULT_2=$(capture ${CDKL} invoke-agentcore "${TARGET}" --event "${EVENT_FILE}")
 echo "    response: ${RESULT_2}"
@@ -133,7 +158,7 @@ echo "${RESULT_2}" | grep -q '"prompt":"hello agent"' || {
 # Test 3 — --env-vars override wins over the template env.
 echo "==> [3/20] Invoking EchoAgent with --env-vars override"
 ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
 RESULT_3=$(capture ${CDKL} invoke-agentcore "${TARGET}" --env-vars "${ENV_FILE}")
 echo "    response: ${RESULT_3}"
@@ -200,7 +225,7 @@ echo "${RESULT_7}" | grep -q "\"authorization\":\"Bearer ${TOKEN}\"" || {
 # line — so we capture all output, not just tail -1).
 echo "==> [8/20] EchoAgent streams a text/event-stream response to stdout"
 STREAM_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"stream":true}' > "${STREAM_EVENT}"
 RESULT_8=$(capture_all ${CDKL} invoke-agentcore "${TARGET}" --event "${STREAM_EVENT}")
 echo "    response: ${RESULT_8}"
@@ -229,7 +254,7 @@ echo "${RESULT_9}" | grep -q '"name": "add_numbers"' || {
 # Test 10 — an MCP tools/call via --event returns the tool result.
 echo "==> [10/20] McpAgent with --event runs tools/call"
 CALL_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"method":"tools/call","params":{"name":"add_numbers","arguments":{"a":2,"b":3}}}' > "${CALL_EVENT}"
 RESULT_10=$(capture_all ${CDKL} invoke-agentcore "${MCP}" --event "${CALL_EVENT}")
 echo "    response: ${RESULT_10}"
@@ -256,7 +281,7 @@ echo "${RESULT_11}" | grep -q '"greeting":"hello-from-code"' || {
 # Test 12 — a --event payload echoes through the from-source agent.
 echo "==> [12/20] CodeAgent with --event echoes the payload"
 CODE_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"prompt":"hello code"}' > "${CODE_EVENT}"
 RESULT_12=$(capture ${CDKL} invoke-agentcore "${CODE}" --event "${CODE_EVENT}")
 echo "    response: ${RESULT_12}"
@@ -271,7 +296,7 @@ echo "${RESULT_12}" | grep -q '"prompt":"hello code"' || {
 # Authorization + GREETING) then a second text frame, then closes.
 echo "==> [13/20] EchoAgent over the /ws WebSocket (--ws)"
 WS_EVENT=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"prompt":"hello ws"}' > "${WS_EVENT}"
 RESULT_13=$(capture_all ${CDKL} invoke-agentcore "${TARGET}" --ws --event "${WS_EVENT}")
 echo "    response: ${RESULT_13}"
@@ -412,7 +437,7 @@ echo "${RESULT_19}" | grep -q '"name": "fixture-a2a-agent"' || {
 # Test 19 — A2A with --event runs the tasks/send method.
 echo "==> [18/20] A2aAgent with --event runs tasks/send"
 A2A_EVENT=$(mktemp -t cdkl-a2a-event-XXXX.json)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${A2A_EVENT}" "${CDKL_STDERR}"' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${STREAM_EVENT}" "${CALL_EVENT}" "${CODE_EVENT}" "${WS_EVENT}" "${A2A_EVENT}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"method":"tasks/send","params":{"id":"task-1","message":{"text":"hello a2a"}}}' > "${A2A_EVENT}"
 RESULT_19B=$(capture_all ${CDKL} invoke-agentcore "${A2A}" --event "${A2A_EVENT}")
 echo "    response: ${RESULT_19B}"

--- a/tests/integration/local-invoke-container/verify.sh
+++ b/tests/integration/local-invoke-container/verify.sh
@@ -15,6 +15,16 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Namespace: this fixture `docker build`s a `cdkl-invoke-<hash>` image.
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -49,48 +59,16 @@ capture() {
   fi
   printf '%s\n' "${out}" | tail -1
 }
-
-# --- built-image cleanup (issue #587) --------------------------------------
-# This fixture's DockerImageFunction makes cdkl `docker build` a
-# `cdkl-invoke-<hash>:latest` image of ~421 MB. Nothing removed it, so every
-# run leaked one -- and because the tag is a fingerprint of the asset (the
-# platform included), a change to the Dockerfile, the handler or the
-# architecture mints a NEW tag that no later run will ever reuse or reclaim.
-#
-# Only the tag(s) THIS run creates are removed: the set of `cdkl-invoke-*`
-# tags present now is snapshotted, and cleanup deletes only what appeared
-# since. A blanket `docker rmi` of every `cdkl-invoke-*` tag is deliberately
-# NOT used -- parallel integ lanes share one Docker daemon on a dev host, so
-# a blanket sweep deletes images other lanes are mid-run on, and it would
-# also destroy the local cache other container fixtures rely on.
-IMAGES_BEFORE="$(mktemp)"
-docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
-  | sort > "${IMAGES_BEFORE}"
-
-remove_run_images() {
-  [ -f "${IMAGES_BEFORE:-}" ] || return 0
-  local new
-  new="$(docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
-    | sort | comm -13 "${IMAGES_BEFORE}" -)"
-  if [ -n "${new}" ]; then
-    echo "==> Removing image(s) built by this run:"
-    echo "${new}" | sed 's/^/      /'
-    # Unforced: `docker image rm` refuses an image while a container still holds
-    # it, so a lane whose container is UP survives. It does NOT cover a lane
-    # between `docker build` and `docker run` -- the delta scoping is what keeps
-    # this run away from another lane's tag in that window.
-    echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
-  fi
-  rm -f "${IMAGES_BEFORE}"
-}
 # Installed BEFORE test 1, because test 1 is what triggers the `docker build`.
 # The later `trap 'rm -f ...' EXIT` lines REPLACE this handler rather than
-# adding to it, so each of them re-appends `remove_run_images`; without this
+# adding to it, so each of them re-appends `integ_image_cleanup_run`; without this
 # first registration a failure during test 1 would still leak the image.
-trap 'rm -f "${CDKL_STDERR}"; remove_run_images' EXIT
+trap 'rm -f "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
+
+integ_image_cleanup_init 'cdkl-invoke-*'
 
 echo "==> Pulling ${BASE_IMAGE} (one-time, ~600MB)"
 docker pull "${BASE_IMAGE}"
@@ -121,7 +99,7 @@ echo "${RESULT_1}" | grep -q '"fromContainer":true' || {
 # Test 2 — event payload via --event
 echo "==> [2/4] Invoking EchoHandler with --event payload"
 EVENT_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"; remove_run_images' EXIT
+trap 'rm -f "${EVENT_FILE}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"key":"value","n":42}' > "${EVENT_FILE}"
 RESULT_2=$(capture ${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --event "${EVENT_FILE}" --no-pull)
 echo "    response: ${RESULT_2}"
@@ -133,7 +111,7 @@ echo "${RESULT_2}" | grep -q '"key":"value"' || {
 # Test 3 — --env-vars override
 echo "==> [3/4] Invoking EchoHandler with --env-vars override"
 ENV_FILE=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"; remove_run_images' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 echo '{"Parameters":{"GREETING":"overridden"}}' > "${ENV_FILE}"
 RESULT_3=$(capture ${CDKL} invoke CdkLocalInvokeContainerFixture/EchoHandler --env-vars "${ENV_FILE}" --no-pull)
 echo "    response: ${RESULT_3}"
@@ -151,7 +129,7 @@ echo "${RESULT_3}" | grep -q '"greeting":"overridden"' || {
 # greeting check.
 echo "==> [4/4] Invoking EchoHandler with --no-build (image must already be cached from steps 1-3)"
 COMBINED_4=$(mktemp)
-trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${COMBINED_4}" "${CDKL_STDERR}"; remove_run_images' EXIT
+trap 'rm -f "${EVENT_FILE}" "${ENV_FILE}" "${COMBINED_4}" "${CDKL_STDERR}"; integ_image_cleanup_run' EXIT
 # A non-zero exit here used to abort the script (issue #577) BEFORE any of the
 # three FAIL branches below that `cat "${COMBINED_4}"` -- so the one test whose
 # whole point is inspecting the log lost the log. Capture the status instead.
@@ -179,7 +157,7 @@ if grep -q "Building container image" "${COMBINED_4}"; then
   exit 1
 fi
 
-remove_run_images
+integ_image_cleanup_run
 
 echo ""
 echo "==> All 4 local-invoke container-Lambda tests passed"

--- a/tests/integration/local-start-alb-watch/verify.sh
+++ b/tests/integration/local-start-alb-watch/verify.sh
@@ -39,6 +39,16 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# Namespace(s) for this fixture: the replicas run a `ContainerImage.fromAsset` image (one at boot, one per watcher rebuild).
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -93,6 +103,9 @@ cleanup() {
   docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
     | xargs -r docker network rm >/dev/null 2>&1 || true
   rm -f "${LOG_FILE}" "${PROBE_LOG}"
+  # LAST: `docker image rm` is unforced, so it must run after the container
+  # sweep above has released the tags.
+  integ_image_cleanup_run
 }
 trap cleanup EXIT INT TERM
 
@@ -105,6 +118,17 @@ docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
+
+# Snapshot AFTER the daemon check, so a docker-down run fails at the friendly
+# step above and the `[ -f ]` guard makes the cleanup a no-op.
+#
+# The `docker pull`s below run AFTER this snapshot, which looks unsafe and is
+# not: they pull `amazon/...` and `public.ecr.aws/...` base images, none of
+# which can match this fixture's `cdkl-*` reference filter, so they cannot
+# enter the delta. If you ever widen the filter or add a pull INTO the
+# namespace, move it above this line -- otherwise the cleanup would delete a
+# shared base image that other fixtures and other lanes depend on.
+integ_image_cleanup_init 'cdkl-run-task-*'
 
 echo "==> Pulling fixture images"
 docker pull "${SIDECAR_IMAGE}"

--- a/tests/integration/local-start-api-container/verify.sh
+++ b/tests/integration/local-start-api-container/verify.sh
@@ -21,6 +21,16 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Namespace: this fixture `docker build`s a `cdkl-invoke-<hash>` image.
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -31,6 +41,8 @@ CONTAINER_HOST="127.0.0.1"
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
 
+integ_image_cleanup_init 'cdkl-invoke-*'
+
 echo "==> Pulling ${BASE_IMAGE} (one-time, ~600MB)"
 docker pull "${BASE_IMAGE}"
 
@@ -38,42 +50,6 @@ echo "==> Installing fixture deps"
 if [[ ! -d node_modules ]]; then
   vp install --prefer-offline
 fi
-
-
-
-# --- built-image cleanup (issue #587) --------------------------------------
-# This fixture's DockerImageFunction makes cdkl `docker build` a
-# `cdkl-invoke-<hash>:latest` image of ~421 MB. Nothing removed it, so every
-# run leaked one -- and because the tag is a fingerprint of the asset (the
-# platform included), a change to the Dockerfile, the handler or the
-# architecture mints a NEW tag that no later run will ever reuse or reclaim.
-#
-# Only the tag(s) THIS run creates are removed: the set of `cdkl-invoke-*`
-# tags present now is snapshotted, and cleanup deletes only what appeared
-# since. A blanket `docker rmi` of every `cdkl-invoke-*` tag is deliberately
-# NOT used -- parallel integ lanes share one Docker daemon on a dev host, so
-# a blanket sweep deletes images other lanes are mid-run on, and it would
-# also destroy the local cache other container fixtures rely on.
-IMAGES_BEFORE="$(mktemp)"
-docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
-  | sort > "${IMAGES_BEFORE}"
-
-remove_run_images() {
-  [ -f "${IMAGES_BEFORE:-}" ] || return 0
-  local new
-  new="$(docker images --filter 'reference=cdkl-invoke-*' --format '{{.Repository}}:{{.Tag}}' \
-    | sort | comm -13 "${IMAGES_BEFORE}" -)"
-  if [ -n "${new}" ]; then
-    echo "==> Removing image(s) built by this run:"
-    echo "${new}" | sed 's/^/      /'
-    # Unforced: `docker image rm` refuses an image while a container still holds
-    # it, so a lane whose container is UP survives. It does NOT cover a lane
-    # between `docker build` and `docker run` -- the delta scoping is what keeps
-    # this run away from another lane's tag in that window.
-    echo "${new}" | xargs -r docker image rm >/dev/null 2>&1 || true
-  fi
-  rm -f "${IMAGES_BEFORE}"
-}
 
 LOG_FILE="$(mktemp)"
 SERVER_PID=""
@@ -100,7 +76,7 @@ cleanup() {
     echo "${ORPHANS}" | xargs -r docker rm -f >/dev/null 2>&1 || true
   fi
   rm -f "${LOG_FILE}"
-  remove_run_images
+  integ_image_cleanup_run
 }
 trap cleanup EXIT INT TERM
 

--- a/tests/integration/local-start-service-image-override/verify.sh
+++ b/tests/integration/local-start-service-image-override/verify.sh
@@ -38,6 +38,16 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# Namespace(s) for this fixture: `--image-override` builds a local-only tag; the service's own image is a placeholder ECR URI rather than a CDK asset, so `cdkl-run-task-*` is never built here.
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -71,6 +81,9 @@ cleanup() {
   docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
     | xargs -r docker network rm >/dev/null 2>&1 || true
   rm -f "${LOG_FILE}"
+  # LAST: `docker image rm` is unforced, so it must run after the container
+  # sweep above has released the tags.
+  integ_image_cleanup_run
 }
 trap cleanup EXIT INT TERM
 
@@ -82,6 +95,17 @@ docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
+
+# Snapshot AFTER the daemon check, so a docker-down run fails at the friendly
+# step above and the `[ -f ]` guard makes the cleanup a no-op.
+#
+# The `docker pull`s below run AFTER this snapshot, which looks unsafe and is
+# not: they pull `amazon/...` and `public.ecr.aws/...` base images, none of
+# which can match this fixture's `cdkl-*` reference filter, so they cannot
+# enter the delta. If you ever widen the filter or add a pull INTO the
+# namespace, move it above this line -- otherwise the cleanup would delete a
+# shared base image that other fixtures and other lanes depend on.
+integ_image_cleanup_init 'cdkl-override-*'
 
 echo "==> Pulling fixture images"
 docker pull "${SIDECAR_IMAGE}"

--- a/tests/integration/local-start-service-watch-fast/verify.sh
+++ b/tests/integration/local-start-service-watch-fast/verify.sh
@@ -30,6 +30,16 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# Namespace(s) for this fixture: the replicas run a `ContainerImage.fromAsset` image; only the Dockerfile-edit phase rebuilds (the source edit is the soft-reload path, which builds nothing).
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -83,6 +93,9 @@ cleanup() {
   docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
     | xargs -r docker network rm >/dev/null 2>&1 || true
   rm -f "${LOG_FILE}"
+  # LAST: `docker image rm` is unforced, so it must run after the container
+  # sweep above has released the tags.
+  integ_image_cleanup_run
 }
 trap cleanup EXIT INT TERM
 
@@ -95,6 +108,17 @@ docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
+
+# Snapshot AFTER the daemon check, so a docker-down run fails at the friendly
+# step above and the `[ -f ]` guard makes the cleanup a no-op.
+#
+# The `docker pull`s below run AFTER this snapshot, which looks unsafe and is
+# not: they pull `amazon/...` and `public.ecr.aws/...` base images, none of
+# which can match this fixture's `cdkl-*` reference filter, so they cannot
+# enter the delta. If you ever widen the filter or add a pull INTO the
+# namespace, move it above this line -- otherwise the cleanup would delete a
+# shared base image that other fixtures and other lanes depend on.
+integ_image_cleanup_init 'cdkl-run-task-*'
 
 echo "==> Pulling fixture images"
 docker pull "${SIDECAR_IMAGE}"

--- a/tests/integration/local-start-service-watch-multi/verify.sh
+++ b/tests/integration/local-start-service-watch-multi/verify.sh
@@ -32,6 +32,16 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# Namespace(s) for this fixture: the replicas run a `ContainerImage.fromAsset` image (one at boot, one per watcher rebuild).
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -84,6 +94,9 @@ cleanup() {
   docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
     | xargs -r docker network rm >/dev/null 2>&1 || true
   rm -f "${LOG_FILE}" "${PROBE_LOG}"
+  # LAST: `docker image rm` is unforced, so it must run after the container
+  # sweep above has released the tags.
+  integ_image_cleanup_run
 }
 trap cleanup EXIT INT TERM
 
@@ -96,6 +109,17 @@ docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
+
+# Snapshot AFTER the daemon check, so a docker-down run fails at the friendly
+# step above and the `[ -f ]` guard makes the cleanup a no-op.
+#
+# The `docker pull`s below run AFTER this snapshot, which looks unsafe and is
+# not: they pull `amazon/...` and `public.ecr.aws/...` base images, none of
+# which can match this fixture's `cdkl-*` reference filter, so they cannot
+# enter the delta. If you ever widen the filter or add a pull INTO the
+# namespace, move it above this line -- otherwise the cleanup would delete a
+# shared base image that other fixtures and other lanes depend on.
+integ_image_cleanup_init 'cdkl-run-task-*'
 
 echo "==> Pulling fixture images"
 docker pull "${SIDECAR_IMAGE}"

--- a/tests/integration/local-start-service-watch/verify.sh
+++ b/tests/integration/local-start-service-watch/verify.sh
@@ -26,6 +26,16 @@
 
 set -euo pipefail
 
+# --- built-image cleanup (issue #603) ---------------------------------------
+# Sourced BEFORE the `cd` below, matching the idiom the other _lib consumers
+# use: `${BASH_SOURCE[0]}` holds the path this script was INVOKED with, so it
+# stops resolving the moment the cwd changes.
+# Namespace(s) for this fixture: the replicas run a `ContainerImage.fromAsset` image (one at boot, one per watcher rebuild).
+# The snapshot/delta primitive is shared because it DELETES images on a daemon
+# other lanes share; see tests/integration/_lib/image-cleanup.sh for why it is
+# not copied per fixture and what it deliberately fails closed on.
+source "$(dirname "${BASH_SOURCE[0]}")/../_lib/image-cleanup.sh"
+
 cd "$(dirname "$0")"
 
 CDKL="node ../../../dist/cli.js"
@@ -74,6 +84,9 @@ cleanup() {
   docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
     | xargs -r docker network rm >/dev/null 2>&1 || true
   rm -f "${LOG_FILE}"
+  # LAST: `docker image rm` is unforced, so it must run after the container
+  # sweep above has released the tags.
+  integ_image_cleanup_run
 }
 trap cleanup EXIT INT TERM
 
@@ -86,6 +99,17 @@ docker network ls --filter "name=cdkl-" --format '{{.ID}}' \
 
 echo "==> Verifying Docker is available"
 docker version --format '{{.Server.Version}}' >/dev/null
+
+# Snapshot AFTER the daemon check, so a docker-down run fails at the friendly
+# step above and the `[ -f ]` guard makes the cleanup a no-op.
+#
+# The `docker pull`s below run AFTER this snapshot, which looks unsafe and is
+# not: they pull `amazon/...` and `public.ecr.aws/...` base images, none of
+# which can match this fixture's `cdkl-*` reference filter, so they cannot
+# enter the delta. If you ever widen the filter or add a pull INTO the
+# namespace, move it above this line -- otherwise the cleanup would delete a
+# shared base image that other fixtures and other lanes depend on.
+integ_image_cleanup_init 'cdkl-run-task-*'
 
 echo "==> Pulling fixture images"
 docker pull "${SIDECAR_IMAGE}"


### PR DESCRIPTION
## Summary

Eight integ fixtures ran `docker build` (directly or via cdk-local) and never removed the result, so every run left a tag behind. Each now snapshots its own tag namespace(s) before the run and removes only what appeared since.

Closes #603

## Scope correction: eight fixtures, not seven

`local-studio-from-cfn-stack` **builds no image at all** and is dropped from the set. Its only Docker call is `docker version`; it never starts a serve, never invokes, and never passes `--image-override`. Its stack is `ContainerImage.fromEcrRepository(repo)` with `desiredCount: 0`, so there is no `DockerImageAsset`, and the fixture dir has no Dockerfile for `discoverDockerfiles` to find. The issue's derivation query matched it on **prose** only — `image-override` appears in its stack JSDoc and in two `verify.sh` comments as English, not as a flag.

That is not just tidiness: it was the **only fixture in the set needing real AWS** (`cdk deploy`) and its orphan sweep, so dropping it removes the entire AWS cost of this lane.

## Namespaces, derived from `src` rather than assumed

| namespace | source | fixtures |
|---|---|---|
| `cdkl-run-task-<assetHash16>` | `src/local/ecs-task-runner.ts:901` | the four `*-watch` |
| `cdkl-override-<svc>-<hash>:local` | `src/local/image-override-engine.ts:938` | `local-start-service-image-override` |
| `cdkl-invoke-<hash16>` | `src/local/docker-image-builder.ts:208` | `local-invoke-agentcore` |
| `cdkl-agentcore-code-<hash>` | `src/local/agentcore-code-build.ts:248` | `local-invoke-agentcore` |

Two consequences worth calling out:

- **The issue's own verification recipe would have gone vacuously green.** It watches `reference=cdkl-invoke-*`, but the four `*-watch` fixtures build `cdkl-run-task-*`. Someone following it literally would watch an always-equal count and declare the fix good while the cleanup did nothing. No fixture in the suite cleaned that namespace before — `grep -rl 'reference=cdkl-run-task' tests/` returned nothing — so this is its first cleanup.
- **`local-invoke-agentcore` needs TWO filters.** Its container-artifact agents build `cdkl-invoke-*`, its two `fromCodeAsset` runtimes build `cdkl-agentcore-code-*`. A single-filter snapshot leaves the latter behind, which is also why the issue's "5 -> 8" measurement, taken over `cdkl-invoke-*` alone, under-reports this fixture's leak.

## Why snapshot/delta rather than a blanket `docker rmi`

Parallel integ lanes share one Docker daemon, so a blanket sweep over the namespace deletes an image a peer lane is mid-run on — the reasoning https://github.com/go-to-k/cdk-local/issues/587 landed in `local-studio`. The set present at the start is recorded, and only tags that appeared since are removed.

## Review caught a fail-open in the first version, and it changed the design

The first cut published the temp path and wrote the snapshot into it as two steps:

```bash
IMAGES_BEFORE="$(mktemp)"            # baseline is live from here
snapshot_images > "${IMAGES_BEFORE}"
```

If that write failed or truncated — a docker hiccup after the daemon probe, or `pipefail` catching a partial `docker images` — `set -e` aborted, the EXIT trap fired, and the cleanup read an **empty baseline**. An empty baseline makes the delta the **entire namespace**, so the run deletes every peer lane's tags. Driven directly over the same input:

```
--- OLD shape (publish path, THEN write; write fails) ---
   would delete: cdkl-probe603-peer1:local cdkl-probe603-peer2:local
--- NEW shape (write, THEN publish; write fails) ---
   init rc=1  armed=''
   peers surviving: 2 (want 2)
```

`integ_image_cleanup_init` now assigns the baseline **only after a successful write**, and fails closed: until then nothing is armed and the cleanup is inert. Failing closed leaks this run's own tag, which is the bug this PR fixes — still the right trade against deleting someone else's image.

**That finding is also why the helper is now shared** rather than six near-identical copies. Fixtures are self-contained for their *assertions*, but this is a destructive primitive on shared host state whose invariants are not obvious from a call site — and one fail-open in it meant fixing the same bug six times and getting it right six times. It lives in `tests/integration/_lib/image-cleanup.sh`, beside the existing shared shell (`stack-name.sh`, `aws-orphan-sweep.sh`).

Two further review findings, both fixed: the delete comment claimed the unforced `docker image rm` protects a peer whose container is up (false — `cleanup()` force-removes every `cdkl-*` container four lines earlier, so nothing holds the image by then), and that delta scoping keeps this run away from a peer's tag in general (true only for a peer that built *before* this run's snapshot). The library states the one real bound and names the residual window explicitly instead.

## A new test suite, because this deletes things

`tests/integration/_lib/image-cleanup.test.sh` — **58 cases**, picked up automatically by `vp run test:hooks` (its glob already covers `tests/integration/_lib/*.test.sh`), so it runs in CI. `docker` is stubbed on PATH, so it is deterministic and needs no daemon. Green under modern bash **and** macOS system bash 3.2.

Mutation-probed rather than assumed — each of these turns it red:

| mutation | result |
|---|---|
| revert the blocker fix (publish-then-write) | **red** |
| swallow a non-last filter failure (restore the pipeline form) | **red** |
| drop the `sort` from the snapshot | **red** |
| remove `set -f` (let the filter glob be pathname-expanded) | **red** |
| replace the armed-guard with an empty-baseline fallback | **red** |
| drop the `[ ! -f ]` guard | **red** |
| `comm -13` -> `comm -3` | **red** |
| reduce the last agentcore trap to one temp file | **red** |
| move a fixture's `source` below its `cd` | **red** |

**Six of those turned red only after the suite was fixed**, and each gap is worth naming because they are the same failure in different clothes: the stub always exited 0, so a filter failure was *unreachable*; the missing-baseline case could not discriminate (both paths remove nothing — only stderr separates them); the last-trap check ORed in an alternative matching any line containing the call; every after-set was a superset of its baseline, making `comm -13` and `comm -3` indistinguishable; and the `sort` mutation stayed green until the stub fed deliberately **reverse-ordered** data. A suite that is green over a present defect is not evidence, so each of these now has a case built to fail.

## Round 2 found two more fail-opens of the same class, and two missed fixtures

**A swallowed exit status.** `for f in ...; done | sort` reports only the **last** iteration's status, so a `docker images` failure on any earlier filter was lost inside the loop before `pipefail` could see it. `init` then returned 0 having armed a **partial** baseline — and every tag under the failed filter looks new and gets deleted. `local-invoke-agentcore` is the only two-filter caller and it puts the shared `cdkl-invoke-*` namespace **first**, i.e. exactly in the swallowed slot. Reproduced independently, then fixed by checking each filter individually into an accumulator sorted at the end.

**Glob expansion.** `${INTEG_IMAGE_FILTERS}` is expanded unquoted to split on whitespace, and an unquoted expansion also pathname-expands. Measured: with a file named `cdkl-run-task-deadbeef` in the cwd, the loop saw that **filename** instead of `cdkl-run-task-*`, narrowing the snapshot to one tag. An incomplete baseline deletes every pre-existing tag it missed — the empty-baseline blast radius again. `set -f` now splits without globbing.

**Two more copies.** `local-invoke-container` and `local-start-api-container` carried the *original* publish-before-write blocker in their own copies, so the sweep is **eight** fixtures, not six. Both converted; the test suite's derived population picked them up without being told, which is the point of deriving it.

**Two comments were overclaiming**, both corrected: a failed `init` does *not* leave the run going without cleanup — under `set -euo pipefail` it **aborts the fixture**, which is deliberate and now stated; and "a peer's own container holds the image, so the unforced remove fails harmlessly" is false for a peer sitting between `docker build` and `docker run`, which is where a `--watch` rebuild roll spends most of its time.

## The eight-trap fixture

`local-invoke-agentcore` has **eight** progressive `trap '...' EXIT` handlers, each re-listing every temp file created so far — a second `trap ... EXIT` REPLACES the first, so the chain grows rather than accumulating. The call is composed **inside** all eight handler strings; adding a ninth trap would have silently dropped the file cleanup the chain exists to carry. Verified after the change: still exactly 8 traps, all 8 end with the call, and the last still lists every temp file.

## Results: zero leaked tags, every fixture

Each run with a before/after snapshot of its own namespace(s). The four re-run after the final refactor are marked; the rest were measured on the same code path before it.

| fixture | verify.sh | cleanup fired | leaked tags |
|---|---|---|---|
| `local-invoke-container` (new to the sweep) | pass (20s) | yes | **0** |
| `local-start-api-container` (new to the sweep) | pass (8s) | yes | **0** |
| `local-invoke-agentcore` | pass (133s) | yes | **0** |
| `local-start-service-watch` | pass (123s) | yes | **0** |
| `local-start-service-watch-fast` | pass (175s) | yes | **0** |
| `local-start-alb-watch` | pass (177s) | yes | **0** |
| `local-start-service-watch-multi` | **fail (pre-existing)** | yes | **0** |
| `local-start-service-image-override` | **fail (pre-existing)** | n/a — dies at boot | **0** |

## Two fixtures were already red on `main` — filed, not folded in

Both were confirmed by running them on a **stashed, clean `origin/main` tree** and getting the identical FAIL line, so neither is caused by this change:

| fixture | on `origin/main` | with this patch |
|---|---|---|
| `local-start-service-image-override` | `rc=1` (7s), `FAIL: cdk-local exited before reaching the boot banner` | `rc=1` (25s), same line |
| `local-start-service-watch-multi` | `rc=1`, `total=3003 v1=963 v2=2039 FAIL=1` | `rc=1`, `total=2949 v1=972 v2=1976 FAIL=1` |

They are different root causes from the image leak, so per the sweep boundary they are filed with their evidence rather than bundled here:

- https://github.com/go-to-k/cdk-local/issues/659 — `--image-override` is ignored because the placeholder ECR image is not detected as pinned, so `start-service` tries to pull an image the fixture documents as never-pullable. Severity high: the flag is silently ignored for the exact case it exists for.
- https://github.com/go-to-k/cdk-local/issues/660 — the multi-replica soft reload drops one request in ~3000; the TCP-ready probe times out at the full 60s for **every** replica in **every** run and re-publishes anyway, then logs "TCP-ready probe complete".

Both are worked instances of https://github.com/go-to-k/cdk-local/issues/594 (nothing runs the integ fixtures, so a fixture can be red on `main` indefinitely) — two of six in one sweep were already red, and only a lane that ran all six found out.

Because `image-override` dies before building anything, its helper could not be exercised by its own run, so it was proven **directly** instead: driving its extracted functions removed both newly-built tags and left the namespace empty.

## Test plan

- `vp run check` / `build` / `test` (246 files, 4401 tests) / `test:hooks` — green, including the new 41-case suite. `bash -n` clean on all six fixtures.
- The refactor initially broke **all six** fixtures: the `source` landed after each fixture's `cd "$(dirname "$0")"`, and `${BASH_SOURCE[0]}` holds the path the script was *invoked* with, so it stops resolving once the cwd changes — every run died before its first assertion. Found by running them, fixed by sourcing before the `cd` (the idiom the other `_lib` consumers already use), and now fenced by a test case.
- `/run-integ local-start-service-watch`: `verify.sh` rc=0, cleanup removed the tag it built, `docker: 0 orphans, network: 0 orphans`, `AWS sweep: rc=0` (`VERDICT: clean (nothing to sweep, no AWS call made)`).
- All six run with before/after namespace snapshots — table above.
- Peer-lane safety and no-op re-entrancy proven directly — output above.

One note for reviewers: every fixture's `docker pull` of its base images runs **after** the snapshot. That is safe because those are `amazon/...` and `public.ecr.aws/...` images which cannot match a `cdkl-*` reference filter — but since the ordering reads as unsafe, each fixture now carries a comment saying so and telling a future editor to move any in-namespace pull above the snapshot line.
