### PR TITLE
refactor(cli): factor the four AssumeRoleFailure ternaries into a named renderer

### DIFF
--- a/src/cli/commands/local-invoke-agentcore.ts
+++ b/src/cli/commands/local-invoke-agentcore.ts
@@ -112,6 +112,7 @@ import { resolveProfileCredentials } from './local-start-api.js';
 import { buildStsClientConfig } from '../../utils/profile-resolver.js';
 import {
   applyProfileCredentialsOverlay,
+  assumeRoleDetail,
   resolveExecutionRoleArnFromState,
 } from './local-invoke.js';
 import {
@@ -897,14 +898,14 @@ export async function resolveHostCredentialsForSigV4(
       // Issue #579: `assumeAgentCoreExecutionRole` renders its own
       // no-usable-credentials sentence, so re-rendering it here would WITHHOLD
       // cdk-local's own text (a non-service error is the withheld branch by
-      // design). Inlined rather than factored into a helper: the source fence
-      // in `tests/unit/cli/sts-error-relay-source-fence.test.ts` requires a
-      // visible `describeAwsFailureForWarn` CALL in the window around the
-      // announcing line, and one level of indirection defeats that check.
-      const sigv4Detail =
-        err instanceof AssumeRoleFailure
-          ? err.detail
-          : describeAwsFailureForWarn(err, 'STS AssumeRole (--sigv4 signing)');
+      // design). That split now lives once in `assumeRoleDetail`.
+      //
+      // This used to say the site was inlined BECAUSE one level of indirection
+      // defeated the source fence. True when written, and no longer: issue
+      // #644 taught `sts-error-relay-source-fence.test.ts` to collect a named
+      // renderer defined in `src/cli/commands/*.ts` and accept a site that
+      // delegates to it, which is what made this refactor possible.
+      const sigv4Detail = assumeRoleDetail(err, 'STS AssumeRole (--sigv4 signing)');
       logger.warn(
         `--assume-role: STS AssumeRole(${flattenToOneLine(assumeRoleArn)}) failed for --sigv4 signing: ` +
           `${sigv4Detail}. ` +
@@ -1144,11 +1145,8 @@ export async function resolveAgentCoreCodeImageFromS3(
       // see `describeAwsFailureForWarn` in `src/local/credential-error.ts`.
       // `assumeRoleArn` keeps printing for the reason recorded at the
       // `applyAgentCoreCredentialEnv` site below.
-      // Same inline shape and the same reason as the `--sigv4` site above.
-      const bundleDetail =
-        err instanceof AssumeRoleFailure
-          ? err.detail
-          : describeAwsFailureForWarn(err, 'STS AssumeRole (fromS3 bundle download)');
+      // Same shape and the same reason as the `--sigv4` site above.
+      const bundleDetail = assumeRoleDetail(err, 'STS AssumeRole (fromS3 bundle download)');
       logger.warn(
         `--assume-role: STS AssumeRole(${flattenToOneLine(assumeRoleArn)}) failed for the fromS3 bundle download: ` +
           `${bundleDetail}. ` +
@@ -1475,11 +1473,8 @@ export async function applyAgentCoreCredentialEnv(
       // the ARN from a live `GetAgentRuntime` response, so it is wire-derived
       // text on the line the helper beside it just made forge-proof. On a real
       // ARN the call is a no-op, so the integ grep is unaffected.
-      // Same inline shape and the same reason as the two sites above.
-      const assumeDetail =
-        err instanceof AssumeRoleFailure
-          ? err.detail
-          : describeAwsFailureForWarn(err, 'STS AssumeRole');
+      // Same shape and the same reason as the two sites above.
+      const assumeDetail = assumeRoleDetail(err, 'STS AssumeRole');
       logger.warn(
         `--assume-role: STS AssumeRole(${flattenToOneLine(args.assumeRoleArn)}) failed: ${assumeDetail}. ` +
           "Falling back to the developer's shell credentials."
@@ -1736,8 +1731,9 @@ async function assumeAgentCoreExecutionRole(
   // `utils/role-arn.ts` so all three word the refusal identically. Refuses
   // BEFORE the SDK is even imported, so nothing is loaded, built or logged.
   //
-  // Throws `AssumeRoleFailure`, NOT a bare error: all three callers re-render
-  // with `describeAwsFailureForWarn` unless the error is an
+  // Throws `AssumeRoleFailure`, NOT a bare error: all three callers render
+  // through `assumeRoleDetail`, which falls back to
+  // `describeAwsFailureForWarn` unless the error is an
   // `AssumeRoleFailure`, and a non-service error is that policy's WITHHELD
   // branch — so a `CdkLocalError` here would come out as
   // `CdkLocalError; 213-character message withheld`, the exact double-withhold

--- a/src/cli/commands/local-invoke.ts
+++ b/src/cli/commands/local-invoke.ts
@@ -543,6 +543,45 @@ async function resolveZipImagePlan(
   };
 }
 
+/**
+ * Render an STS AssumeRole failure into the one line a warn may print.
+ *
+ * The single home for the policy that used to be copy-pasted as a ternary at
+ * four relay sites (one here, three in `local-invoke-agentcore.ts`). Both
+ * branches matter and neither is the obvious one:
+ *
+ * - `AssumeRoleFailure` carries a detail `assumeRoleCredentials` ALREADY
+ *   rendered through the policy, so it is taken verbatim. Re-rendering it here
+ *   would hand `describeAwsFailureForWarn` a plain `Error` -- cdk-local's own,
+ *   so no `$fault` -- and WITHHOLD text that was already sanitized, which is
+ *   how `ExpiredTokenException: ...` briefly became
+ *   `Error; 138-character message withheld` (issue #579 review round 4).
+ * - Anything else is a raw SDK error and goes through
+ *   `describeAwsFailureForWarn`, which keeps a modeled service exception's
+ *   message and withholds everything else -- credential-chain failures above
+ *   all, which can carry a `credential_process` command line.
+ *
+ * `op` is the label `describeAwsFailureForWarn` puts on the `debug` line it
+ * emits when it withholds a message -- NOT on the returned string, which is the
+ * clamped class plus a character count and carries no operation. Callers pass
+ * `'STS AssumeRole'` or a qualified variant such as
+ * `'STS AssumeRole (--sigv4 signing)'`, and that qualification is the whole
+ * reason the label is a parameter rather than a constant in here.
+ *
+ * This is deliberately a ONE-EXPRESSION function, and that is a hard
+ * constraint rather than a style preference:
+ * `tests/unit/cli/sts-error-relay-source-fence.test.ts` only accepts a NAMED
+ * RENDERER whose body carries the full policy shape, does not `warn` itself,
+ * and closes within `RENDERER_BODY_MAX_LINES`. A longer body, or one that
+ * warned, would stop being collected and every site delegating to it would be
+ * reported as an unguarded relay. Before issue #644 the fence could not model
+ * indirection at all, so these four sites had to stay inline; it can now, and
+ * this is the refactor that was waiting on it.
+ */
+export function assumeRoleDetail(err: unknown, op: string): string {
+  return err instanceof AssumeRoleFailure ? err.detail : describeAwsFailureForWarn(err, op);
+}
+
 export async function materializeLambdaLayersIncludingArns(
   layers: ResolvedLambdaLayer[],
   options: LocalInvokeOptions
@@ -1076,19 +1115,9 @@ export async function resolveLambdaContainerEnv(
       // the very line the helper beside it just made forge-proof. On a real
       // ARN the call is a no-op, so the integ grep is unaffected.
       //
-      // Issue #579 review round 4: `assumeRoleCredentials` now renders the
-      // failure ITSELF, because three of its four call paths are unguarded all
-      // the way to `formatError`. Re-rendering its output here would hand
-      // `describeAwsFailureForWarn` a plain `Error` -- cdk-local's own, so no
-      // `$fault` -- and WITHHOLD text the policy had already sanitized, which
-      // is how `ExpiredTokenException: ...` briefly became
-      // `Error; 138-character message withheld`. Take the pre-rendered
-      // `detail` when it is there; the `debug` line was emitted at render
-      // time, so the withheld/at-debug pairing still holds exactly once.
-      const reason =
-        err instanceof AssumeRoleFailure
-          ? err.detail
-          : describeAwsFailureForWarn(err, 'STS AssumeRole');
+      // The pre-rendered / raw split, and why re-rendering a pre-rendered
+      // detail is wrong, now live once in `assumeRoleDetail` above.
+      const reason = assumeRoleDetail(err, 'STS AssumeRole');
       logger.warn(
         `--assume-role: STS AssumeRole(${flattenToOneLine(resolvedAssumeRoleArn)}) failed: ${reason}. ` +
           "Falling back to the developer's shell credentials."

--- a/tests/unit/cli/sts-error-relay-sites.test.ts
+++ b/tests/unit/cli/sts-error-relay-sites.test.ts
@@ -655,3 +655,60 @@ describe("#579 — cdk-local's own no-credentials sentence survives every relay"
   });
 });
 
+/**
+ * Issue #645 — the RENDERER the four sites above now delegate to.
+ *
+ * The site-level cases in this file prove each `catch` still emits its own
+ * literal; these prove the shared policy those sites hand their error to. Both
+ * are needed and neither implies the other: a renderer with the branches
+ * swapped would keep every site's WORDING intact while inverting which errors
+ * get withheld, and the site tests would stay green.
+ */
+describe('#645 — assumeRoleDetail renders both branches of the relay policy', () => {
+  it('takes a pre-rendered AssumeRoleFailure detail VERBATIM, without re-withholding it', async () => {
+    const { assumeRoleDetail } = await import('../../../src/cli/commands/local-invoke.js');
+    const { AssumeRoleFailure } = await import('../../../src/utils/role-arn.js');
+    // `assumeRoleCredentials` has already rendered this through the policy.
+    // Re-rendering would hand `describeAwsFailureForWarn` a plain Error --
+    // cdk-local's own, so no `$fault` -- and WITHHOLD text that was already
+    // sanitized: the `ExpiredTokenException: ... -> Error; N-character message
+    // withheld` double-withhold of issue #579 review round 4.
+    const detail = 'ExpiredTokenException: The security token included in the request is expired';
+    const rendered = assumeRoleDetail(new AssumeRoleFailure('outer message', detail), 'STS AssumeRole');
+    expect(rendered).toBe(detail);
+    expect(rendered).not.toContain('withheld');
+  });
+
+  it('routes any OTHER error through describeAwsFailureForWarn, so a raw message is withheld', async () => {
+    const { assumeRoleDetail } = await import('../../../src/cli/commands/local-invoke.js');
+    // A credential-chain failure is the population the policy exists for: its
+    // message can carry a `credential_process` command line, so the class name
+    // survives and the text does not.
+    const secret = 'could not run credential_process: /usr/local/bin/get-creds --secret hunter2';
+    const rendered = assumeRoleDetail(new Error(secret), 'STS AssumeRole');
+    expect(rendered).not.toContain('hunter2');
+    expect(rendered).not.toContain('credential_process');
+    expect(rendered).toContain('withheld');
+  });
+
+  it('threads the caller op label through to the debug line, not a hard-coded one', async () => {
+    const { assumeRoleDetail } = await import('../../../src/cli/commands/local-invoke.js');
+    // The three agentcore sites QUALIFY the label ('STS AssumeRole (--sigv4
+    // signing)' and so on), so the label has to reach the helper rather than be
+    // hard-coded inside the renderer. Asserting on the RETURN value cannot show
+    // that -- `describeAwsFailureForWarn` puts the operation in the DEBUG line
+    // and returns only the clamped class + character count -- so assert on the
+    // debug line, which is the one place the label is observable.
+    const debugSpy = vi.spyOn(getLogger(), 'debug').mockImplementation(() => {});
+    try {
+      assumeRoleDetail(new Error('boom'), 'STS AssumeRole (--sigv4 signing)');
+      const logged = debugSpy.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(logged).toContain('STS AssumeRole (--sigv4 signing)');
+      // ...and it is the CALLER's label, not the bare default the other two
+      // sites pass -- otherwise a renderer ignoring `op` would pass too.
+      expect(logged).not.toMatch(/STS AssumeRole:/);
+    } finally {
+      debugSpy.mockRestore();
+    }
+  });
+});

--- a/tests/unit/cli/sts-error-relay-source-fence.test.ts
+++ b/tests/unit/cli/sts-error-relay-source-fence.test.ts
@@ -173,21 +173,33 @@ const OWN_THROW_DETAIL = /\.detail\b/;
  * How many source lines around the announcing line count as part of the site.
  *
  * Measured, not guessed: seven sites render inline on the announcing line or
- * the one after it, and one (`local-invoke.ts`'s `--assume-role` site) hoists
- * the render into a `const reason = ...` two lines above. A one-sided window
- * reported that one as unguarded. The numbers are the measured need and no
- * more — a wider window lets one site's helper call vouch for an unguarded
- * neighbour.
+ * the one after it, and the sites that hoist the render into a
+ * `const <name> = ...` put it two lines above. A one-sided window reported
+ * those as unguarded. The numbers are the measured need and no more — a wider
+ * window lets one site's helper call vouch for an unguarded neighbour.
+ *
+ * Since issue #645 ALL FOUR AssumeRole sites hoist, because they delegate to
+ * the one-line `assumeRoleDetail(err, op)` call; the "one site" this used to
+ * name was the pre-refactor shape.
  */
 const LINES_BEFORE = 2;
 const LINES_AFTER = 1;
 
 /**
- * The own-throw check reads a WIDER window. Measured like the numbers above:
- * at all four sites the layout is `const <name> =` / `err instanceof
- * AssumeRoleFailure` / `? err.detail` / `: describeAwsFailureForWarn(...)` /
- * `logger.warn(` / the announcing line -- the `instanceof` sits exactly four
- * lines above the announcement, two above the helper-call window's reach.
+ * The own-throw check reads a WIDER window, and since issue #645 it is wider
+ * than the TREE needs -- deliberately. It was measured against the INLINE
+ * layout: `const <name> =` / `err instanceof AssumeRoleFailure` /
+ * `? err.detail` / `: describeAwsFailureForWarn(...)` / `logger.warn(` / the
+ * announcing line, putting the `instanceof` exactly four lines above the
+ * announcement. All four sites now DELEGATE to `assumeRoleDetail` on one line,
+ * so measured on today's tree the distance is 2 at every one of them, and the
+ * extra two lines vouch for nothing that exists.
+ *
+ * The window stays at 4 anyway, because the inline shape is still a LEGAL way
+ * to write a new site -- the renderer is an option, not a mandate -- and
+ * synthetic case (h) below pins exactly that shape. Narrowing to 2 would
+ * reject a site written the way every site in this tree was written until
+ * issue #645, which is a false "unguarded" finding rather than a tightening.
  * The vouching concern that keeps `LINES_BEFORE` at 2 applies here too, but
  * asymmetrically: this check is a REQUIREMENT on the site, not permission to
  * relay, so a neighbour's branch leaking into the window can only excuse a
@@ -442,13 +454,19 @@ describe('#570 — a tenth STS relay site cannot be added unguarded', () => {
     ]);
   });
 
-  it('recognizes no named renderer in the tree today', () => {
+  it('recognizes exactly the named renderers the tree deliberately defines', () => {
     // Pins the collector against silent over-collection: a name in this list
     // is a name `isHelperGuarded` accepts as vouching for a site, so an entry
-    // must arrive DELIBERATELY (the issue #613 refactor would land an
-    // `assumeRoleDetail` here by name), never as a side effect of an
-    // unrelated function happening to match the shape.
-    expect(renderers).toEqual([]);
+    // must arrive DELIBERATELY, never as a side effect of an unrelated
+    // function happening to match the shape.
+    //
+    // `assumeRoleDetail` (issue #645) is the first entry, and it arrived by
+    // exactly the route this pin anticipated: issue #644 taught the fence to
+    // model indirection, and the four duplicated ternaries it had been forcing
+    // inline were then factored into that one renderer. The list is asserted
+    // WHOLE rather than by `toContain`, so a second name cannot appear
+    // unnoticed.
+    expect(renderers.map((r) => r.name)).toEqual(['assumeRoleDetail']);
   });
 
   it('routes every one of them through a describeAwsFailureForWarn CALL or a named renderer', () => {


### PR DESCRIPTION
## Summary

The four duplicated `AssumeRoleFailure` ternaries become one named renderer, `assumeRoleDetail(err, op)`.

Closes #645

This was waiting on https://github.com/go-to-k/cdk-local/pull/644, which taught the STS relay source fence to model indirection: it now collects a **named renderer** defined in `src/cli/commands/*.ts` — a function carrying the full policy shape, not warning itself, closing within `RENDERER_BODY_MAX_LINES` — and accepts a site that delegates to it. Before that, the fence required a visible `describeAwsFailureForWarn` call in the window around each announcing line, which is exactly why these four sites were inlined.

| site | operation label |
|---|---|
| `local-invoke.ts:1089` | `STS AssumeRole` |
| `local-invoke-agentcore.ts:905` | `STS AssumeRole (--sigv4 signing)` |
| `local-invoke-agentcore.ts:1149` | `STS AssumeRole (fromS3 bundle download)` |
| `local-invoke-agentcore.ts:1480` | `STS AssumeRole` |

## The policy, stated once

Both branches matter and neither is the obvious one:

- **`AssumeRoleFailure`** carries a detail `assumeRoleCredentials` has *already* rendered through the policy, so it is taken verbatim. Re-rendering would hand `describeAwsFailureForWarn` a plain `Error` — cdk-local's own, so no `$fault` — and **withhold text that was already sanitized**: the `ExpiredTokenException: ... -> Error; 138-character message withheld` double-withhold found in https://github.com/go-to-k/cdk-local/issues/579 review round 4.
- **Anything else** is a raw SDK error and goes through `describeAwsFailureForWarn`, which keeps a modeled service exception's message (that message is the diagnosis) and withholds everything else — credential-chain failures above all, which can carry a `credential_process` command line.

The renderer is a **one-expression function by constraint, not by taste**, and its JSDoc says so: a longer body, or one that warned, would stop being collected by the fence and every delegating site would then be reported as an unguarded relay.

## Issue-vs-tree correction

The issue says *four* in-code comments claim that one level of indirection defeats the fence. It is **three**:

- `local-invoke-agentcore.ts:903` makes the claim — updated.
- `:1147` and `:1478` back-reference it ("Same inline shape and the same reason as the ... above") — updated.
- `local-invoke.ts:1079-1087` makes **no indirection claim at all**. It explains the `AssumeRoleFailure` branch and the withhold-vs-render policy, and is still correct as written, so it is left alone rather than edited to match a description of it.

A **fourth** comment is updated that the issue does not mention: the JSDoc on `assumeAgentCoreExecutionRole` said "all three callers re-render with `describeAwsFailureForWarn`" — still true in effect, but it no longer named the mechanism.

## Why this is safe

**Behaviour-neutrality is carried by the existing site-level suites**, which drive each `catch` separately and assert its own literal — 52 + 15 + 28 cases across `sts-error-relay-sites.test.ts`, `local-invoke-agentcore-creds.test.ts` and `role-arn.test.ts`, all green **unchanged**.

Three new cases fence the **renderer itself**, because the two are not the same guarantee: a renderer with its branches swapped keeps every site's wording byte-identical while inverting which errors are withheld, and the site tests alone stay green. Probed — swapping the branches reddens the suite.

The fence pin flips from `expect(renderers).toEqual([])` to naming `assumeRoleDetail`, asserted as the **whole list** so a second name cannot appear unnoticed. Probed rather than assumed:

| mutation to the renderer | fence |
|---|---|
| rename it (sites delegate to an uncollected name) | **red** (3 cases) |
| make it `warn` (a renderer renders; a site warns) | **red** (3 cases) |
| drop its own-throw branch | **red** (3 cases) |

And on the behavioural side:

| mutation to the renderer | site suites |
|---|---|
| swap the two branches (wording identical, policy inverted) | **red** |
| ignore `op` and hard-code the label | **red** |

## Two things review surfaced that are worth keeping in the record

**The fence pin is shape-only, so the new behavioural tests are load-bearing.** Driving the collector's real regexes over renderer variants: swapping the branches (the credential-disclosure inversion), ignoring `op`, and double-rendering all stay **collected** — the fence stays green. Only `.detail` -> `.message` reddens it. So the pin cannot substitute for the behavioural tests; the branch swap is caught **only** by the two new cases, which is what earns them.

**The fence now dictates module layout.** The natural home for this renderer is `src/local/credential-error.ts`, beside `describeAwsFailureForWarn`. It cannot go there: the fence's collector scans `src/cli/commands/*.ts` **non-recursively**, so a renderer defined anywhere else would not be collected and every delegating site would be reported as an unguarded relay. It stays in `local-invoke.ts`; if a third file ever needs it, extract to `src/cli/commands/assume-role-detail.ts` rather than deepening the import from a 1491-line command module.

## cdkd parity

All four categories **N/A**, walked via `/check-cdkd-parity`: no new subcommand factory, no `addOption(new Option(`, no `src/local/**` path in the diff, and no behaviour change. `assumeRoleDetail` is deliberately **not** re-exported from `internal.ts` — it is an internal policy detail shared by two command files, and the underlying `describeAwsFailureForWarn` is already host-facing there. Nothing for a host to inherit, so no tracking issue was filed.

## Test plan

- `vp run check` / `build` / `test` (251 files, 4500 tests) / `test:hooks` — all green.
- `/run-integ local-invoke`: `verify.sh` rc=0, `docker: 0 orphans, network: 0 orphans`, `AWS sweep: rc=0` (`VERDICT: clean (nothing to sweep, no AWS call made)`).
- Mutation probes for both the fence and the renderer's branches — tables above.
