### PR TITLE
test: harden proxy profile-threading, spread-order and proxy-URL fences

### DIFF
--- a/tests/unit/local/ecr-puller-profile.test.ts
+++ b/tests/unit/local/ecr-puller-profile.test.ts
@@ -1,12 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from 'vite-plus/test';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 
-const { stsCtorArgs, ecrCtorArgs, stsSend, ecrSend, runFg, runStream } = vi.hoisted(() => ({
-  stsCtorArgs: [] as Array<Record<string, unknown>>,
-  ecrCtorArgs: [] as Array<Record<string, unknown>>,
-  stsSend: vi.fn(),
-  ecrSend: vi.fn(),
-  runFg: vi.fn(),
-  runStream: vi.fn(),
+const { stsCtorArgs, ecrCtorArgs, stsSend, ecrSend, runFg, runStream, defaultProviderMock, chainMock } =
+  vi.hoisted(() => {
+    const chainMock = vi.fn();
+    return {
+      stsCtorArgs: [] as Array<Record<string, unknown>>,
+      ecrCtorArgs: [] as Array<Record<string, unknown>>,
+      stsSend: vi.fn(),
+      ecrSend: vi.fn(),
+      runFg: vi.fn(),
+      runStream: vi.fn(),
+      chainMock,
+      defaultProviderMock: vi.fn(() => chainMock),
+    };
+  });
+
+// Only reached through the proxy fragment's `credentials` provider, which is
+// what the issue go-to-k/cdk-local#648 cases below invoke; the rest of the
+// file never resolves credentials at all.
+vi.mock('@aws-sdk/credential-provider-node', () => ({
+  defaultProvider: defaultProviderMock,
 }));
 
 vi.mock('@aws-sdk/client-sts', () => ({
@@ -117,5 +130,77 @@ describe('pullEcrImage — --profile threading', () => {
     // The ECR client authenticates with the assumed creds, not the profile.
     expect(ecrCtorArgs[0]!['credentials']).toMatchObject({ accessKeyId: 'AKIA' });
     expect(ecrCtorArgs[0]!).not.toHaveProperty('profile');
+  });
+
+  /**
+   * Issue go-to-k/cdk-local#648. Both failures below exist ONLY when a proxy
+   * variable is set: with a clean environment `buildProxyClientConfig()`
+   * returns `{}`, so neither the profile it carries nor its position in the
+   * config object can change anything — which is exactly why the cases above
+   * stayed green through both mutations (measured on origin/main: the full
+   * 4497-test suite passed with the profile dropped at all nine fragment call
+   * sites, and again with this site's spread moved last).
+   */
+  describe('under a proxy (issue #648)', () => {
+    const PROXY_KEYS = ['https_proxy', 'HTTPS_PROXY', 'http_proxy', 'HTTP_PROXY'] as const;
+    const saved = new Map<string, string | undefined>();
+
+    beforeEach(() => {
+      for (const key of PROXY_KEYS) {
+        saved.set(key, process.env[key]);
+        delete process.env[key];
+      }
+      defaultProviderMock.mockClear();
+      chainMock.mockReset();
+      chainMock.mockResolvedValue({ accessKeyId: 'AKIA-CHAIN', secretAccessKey: 'chain' });
+      process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+    });
+
+    afterEach(() => {
+      for (const key of PROXY_KEYS) {
+        const value = saved.get(key);
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    });
+
+    it('threads --profile INTO the proxy fragment, so the chain resolves the NAMED profile and not the default account', async () => {
+      await pullEcrImage(IMAGE, {
+        skipPull: false,
+        region: 'ap-northeast-1',
+        profile: 'mates_dev',
+      });
+
+      const cfg = ecrCtorArgs[0]!;
+      expect(cfg['requestHandler']).toBeDefined();
+      // The site ALSO passes `profile`, but under a proxy that key is inert:
+      // the fragment supplies explicit `credentials`, and explicit
+      // credentials beat a profile key in the AWS SDK. So the profile only
+      // takes effect if it reached the credential chain — assert that, not
+      // the decorative key.
+      expect(cfg['profile']).toBe('mates_dev');
+      expect(typeof cfg['credentials']).toBe('function');
+      await (cfg['credentials'] as () => Promise<unknown>)();
+      expect(defaultProviderMock).toHaveBeenCalledTimes(1);
+      expect(defaultProviderMock.mock.calls[0]![0]).toMatchObject({ profile: 'mates_dev' });
+    });
+
+    it('keeps the site’s assumed-role credentials — the fragment is spread FIRST, so it never replaces them', async () => {
+      await pullEcrImage(IMAGE, {
+        skipPull: false,
+        region: 'ap-northeast-1',
+        profile: 'mates_dev',
+        ecrRoleArn: 'arn:aws:iam::583942117338:role/EcrPull',
+      });
+
+      const cfg = ecrCtorArgs[0]!;
+      // Spread LAST and this is the fragment's default-chain PROVIDER
+      // (a function), silently authenticating as whoever the chain resolves
+      // instead of as the assumed role.
+      expect(typeof cfg['credentials']).toBe('object');
+      expect(cfg['credentials']).toMatchObject({ accessKeyId: 'AKIA' });
+      // ...while the proxy plumbing itself still survives the override.
+      expect(cfg['requestHandler']).toBeDefined();
+    });
   });
 });

--- a/tests/unit/local/ecr-puller-profile.test.ts
+++ b/tests/unit/local/ecr-puller-profile.test.ts
@@ -164,16 +164,16 @@ describe('pullEcrImage — --profile threading', () => {
       process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
     });
 
+    // No teardown of the `NodeHttpHandler`s the fragment builds, deliberately.
+    // A round of this review added one, and it was measured to do NOTHING:
+    // `NodeHttpHandler.destroy()` is `this.config?.httpAgent?.destroy()`, and
+    // `config` is assigned only inside `handle()` — which no case here calls,
+    // because the SDK clients are mocked. So the loop reached no agent, could
+    // not reach the second handler `credentials()` builds either, and its
+    // comment claimed a discipline it was not performing. Nothing leaks (no
+    // socket is ever opened); an assertion-free loop that reads as cleanup is
+    // worse than the absence it replaced.
     afterEach(() => {
-      // The SDK clients are mocked, so their `destroy()` is a stub and the
-      // real `NodeHttpHandler`s the fragment built would outlive the case.
-      // No socket is ever opened here, so nothing leaks today — this keeps
-      // the same discipline `aws-proxy.test.ts` follows, so a future case
-      // that does open one cannot strand it.
-      for (const cfg of [...stsCtorArgs, ...ecrCtorArgs]) {
-        const handler = cfg['requestHandler'] as { destroy?: () => void } | undefined;
-        handler?.destroy?.();
-      }
       for (const key of PROXY_KEYS) {
         const value = saved.get(key);
         if (value === undefined) delete process.env[key];

--- a/tests/unit/local/ecr-puller-profile.test.ts
+++ b/tests/unit/local/ecr-puller-profile.test.ts
@@ -1,19 +1,27 @@
 import { afterEach, describe, it, expect, vi, beforeEach } from 'vite-plus/test';
 
-const { stsCtorArgs, ecrCtorArgs, stsSend, ecrSend, runFg, runStream, defaultProviderMock, chainMock } =
-  vi.hoisted(() => {
-    const chainMock = vi.fn();
-    return {
-      stsCtorArgs: [] as Array<Record<string, unknown>>,
-      ecrCtorArgs: [] as Array<Record<string, unknown>>,
-      stsSend: vi.fn(),
-      ecrSend: vi.fn(),
-      runFg: vi.fn(),
-      runStream: vi.fn(),
-      chainMock,
-      defaultProviderMock: vi.fn(() => chainMock),
-    };
-  });
+const {
+  stsCtorArgs,
+  ecrCtorArgs,
+  stsSend,
+  ecrSend,
+  runFg,
+  runStream,
+  defaultProviderMock,
+  chainMock,
+} = vi.hoisted(() => {
+  const chainMock = vi.fn();
+  return {
+    stsCtorArgs: [] as Array<Record<string, unknown>>,
+    ecrCtorArgs: [] as Array<Record<string, unknown>>,
+    stsSend: vi.fn(),
+    ecrSend: vi.fn(),
+    runFg: vi.fn(),
+    runStream: vi.fn(),
+    chainMock,
+    defaultProviderMock: vi.fn(() => chainMock),
+  };
+});
 
 // Only reached through the proxy fragment's `credentials` provider, which is
 // what the issue go-to-k/cdk-local#648 cases below invoke; the rest of the
@@ -157,6 +165,15 @@ describe('pullEcrImage — --profile threading', () => {
     });
 
     afterEach(() => {
+      // The SDK clients are mocked, so their `destroy()` is a stub and the
+      // real `NodeHttpHandler`s the fragment built would outlive the case.
+      // No socket is ever opened here, so nothing leaks today — this keeps
+      // the same discipline `aws-proxy.test.ts` follows, so a future case
+      // that does open one cannot strand it.
+      for (const cfg of [...stsCtorArgs, ...ecrCtorArgs]) {
+        const handler = cfg['requestHandler'] as { destroy?: () => void } | undefined;
+        handler?.destroy?.();
+      }
       for (const key of PROXY_KEYS) {
         const value = saved.get(key);
         if (value === undefined) delete process.env[key];

--- a/tests/unit/utils/aws-proxy-client-audit.test.ts
+++ b/tests/unit/utils/aws-proxy-client-audit.test.ts
@@ -18,16 +18,34 @@ import {
  * the same relapse shape as the `--profile` half-wiring the sibling audit
  * (`tests/unit/cli/sts-client-profile-audit.test.ts`) fences for STS.
  *
- * This audit walks all of `src/**` and asserts every AWS SDK client
- * construction — static import, dynamic `await import` destructure, or the
- * member form `new mod.SQSClient(` — either:
+ * This audit walks all of `src/**` and applies THREE policies to every AWS
+ * SDK client construction — static import, dynamic `await import`
+ * destructure, or the member form `new mod.SQSClient(`. All three are
+ * population rules over the same scan, because each of them is a shape that
+ * gets re-written every time a construction site is added:
  *
- *   - spreads `buildProxyClientConfig(` in the construction's OWN argument
- *     list, OR
- *   - goes through `buildStsClientConfig(` (which spreads the proxy config
- *     internally; its contract is locked by `profile-resolver.test.ts`), OR
- *   - carries a `// proxy-audit: ignore: <reason>` comment directly above —
- *     explicit, reasoned opt-out.
+ * 1. PRESENCE — the construction either spreads `buildProxyClientConfig(` in
+ *    its OWN argument list, or goes through `buildStsClientConfig(` (which
+ *    spreads the proxy config internally; its contract is locked by
+ *    `profile-resolver.test.ts`), or carries a
+ *    `// proxy-audit: ignore: <reason>` comment directly above.
+ *
+ * 2. PROFILE — a construction that knows a `profile` must pass it INTO
+ *    `buildProxyClientConfig({ profile })`, not only alongside it. Under a
+ *    proxy the fragment carries a `credentials` provider, and in the AWS SDK
+ *    explicit `credentials` beat a `profile` key — so a site spelling
+ *    `{ ...buildProxyClientConfig(), profile }` resolves the DEFAULT
+ *    account's credentials while looking correct. That is the
+ *    `--profile` half-wiring recurrence in its proxy-shaped form, and it is
+ *    invisible without a proxy variable set, so no ordinary site test sees
+ *    it (issue go-to-k/cdk-local#648).
+ *
+ * 3. ORDER — the proxy seam must be spread BEFORE any `credentials` in the
+ *    same argument list. A site that resolves its own explicit credentials
+ *    (`ecr-puller`'s assumed-role creds, the KVS / S3-origin / CloudFront
+ *    readers' caller creds) must keep them; with the spread moved LAST the
+ *    fragment's default-chain provider silently REPLACES them, again only
+ *    under a proxy (issue go-to-k/cdk-local#648).
  *
  * POPULATION is derived from the defect, not from a site list: a
  * construction is in scope when its class name ends in `Client` AND the
@@ -43,57 +61,171 @@ const SCAN_ROOTS = [join(repoRoot, 'src')];
 
 const CLIENT_NAME = /^[A-Z][A-Za-z0-9_$]*Client$/;
 
-function findOffenders(filePath: string): { line: number; text: string }[] {
+/** The proxy seam itself, and the STS config builder that spreads it. */
+const PROXY_SEAM = 'buildProxyClientConfig(';
+const STS_SEAM = 'buildStsClientConfig(';
+
+/** A `profile` identifier — a key, or the value expression that feeds one. */
+const PROFILE_TOKEN = /\bprofile\b/;
+
+interface Construction {
+  /** 1-based line of the `new` keyword. */
+  readonly line: number;
+  /** The trimmed source line, for the failure message. */
+  readonly text: string;
+  /** Balanced argument text (literal-blanked), or `null` when unbalanced. */
+  readonly args: string | null;
+  readonly optedOut: boolean;
+}
+
+/**
+ * Every AWS SDK client construction in one file. Membership is decided on
+ * the RAW source (imports live in string literals), constructions on the
+ * literal-blanked copy so a comment quoting `new XxxClient(` is not a site
+ * and a bracket in a string cannot unbalance the argument scan.
+ */
+function constructions(filePath: string): Construction[] {
   const raw = readFileSync(filePath, 'utf-8');
-  // Membership is decided on the RAW source (imports live in string
-  // literals), constructions on the literal-blanked copy so a comment
-  // quoting `new XxxClient(` is not a site and a bracket in a string cannot
-  // unbalance the argument scan.
   if (!raw.includes('@aws-sdk/client-')) return [];
   const code = blankLiterals(raw);
   const lines = raw.split('\n');
   const lineOf = (index: number) => raw.slice(0, index).split('\n').length;
-  const offenders: { line: number; text: string }[] = [];
+  const found: Construction[] = [];
   for (const m of code.matchAll(/\bnew\b/g)) {
     const construction = constructionAt(code, m.index!);
     if (!construction || !CLIENT_NAME.test(construction.name)) continue;
-    const lineNo = lineOf(m.index!);
-    const trimmed = (lines[lineNo - 1] ?? '').trim();
-    const args = argumentText(code, construction.argOpen);
+    const line = lineOf(m.index!);
+    found.push({
+      line,
+      text: (lines[line - 1] ?? '').trim(),
+      args: argumentText(code, construction.argOpen),
+      optedOut: hasOptOutMarker(lines, line, 'proxy-audit: ignore'),
+    });
+  }
+  return found;
+}
+
+/** Policy 1: the construction threads the proxy environment at all. */
+function findOffenders(filePath: string): { line: number; text: string }[] {
+  const offenders: { line: number; text: string }[] = [];
+  for (const c of constructions(filePath)) {
     // Unbalanced: report it rather than reading on to EOF.
-    if (args === null) {
-      offenders.push({ line: lineNo, text: trimmed });
+    if (c.args === null) {
+      offenders.push({ line: c.line, text: c.text });
       continue;
     }
-    if (args.includes('buildProxyClientConfig(')) continue;
-    if (args.includes('buildStsClientConfig(')) continue;
-    if (hasOptOutMarker(lines, lineNo, 'proxy-audit: ignore')) continue;
-    offenders.push({ line: lineNo, text: trimmed });
+    if (c.args.includes(PROXY_SEAM)) continue;
+    if (c.args.includes(STS_SEAM)) continue;
+    if (c.optedOut) continue;
+    offenders.push({ line: c.line, text: c.text });
   }
   return offenders;
 }
 
-describe('AWS SDK client proxy-config audit (issue #634)', () => {
-  it('every AWS SDK client construction under src/** spreads the proxy-aware config', () => {
-    const allOffenders: { file: string; line: number; text: string }[] = [];
-    for (const root of SCAN_ROOTS) {
-      for (const file of collectTsFiles(root)) {
-        for (const off of findOffenders(file)) {
-          allOffenders.push({ file: file.slice(repoRoot.length + 1), ...off });
-        }
+/**
+ * Split an argument list at its `buildProxyClientConfig(...)` call: the
+ * call's OWN arguments, and everything else with that span blanked out. The
+ * split is what makes policy 2 answerable — `profile` inside the fragment is
+ * the threading, `profile` outside it is the site's own key, and a plain
+ * `includes('profile')` over the whole text cannot tell them apart.
+ */
+function splitAtProxySeam(args: string): { fragment: string; rest: string } | null {
+  const at = args.indexOf(PROXY_SEAM);
+  if (at === -1) return null;
+  // `argumentText` takes the index of the `(` and returns the text BETWEEN
+  // the parens, so the whole call spans `open` .. `open + fragment.length + 1`.
+  const open = at + PROXY_SEAM.length - 1;
+  const fragment = argumentText(args, open);
+  if (fragment === null) return null;
+  return {
+    fragment,
+    rest: args.slice(0, open) + args.slice(open + fragment.length + 2),
+  };
+}
+
+/** Policy 2: a site that knows a profile threads it INTO the fragment. */
+function findProfileOffenders(filePath: string): { line: number; text: string }[] {
+  const offenders: { line: number; text: string }[] = [];
+  for (const c of constructions(filePath)) {
+    if (c.args === null || c.optedOut) continue;
+    // `buildStsClientConfig` takes the profile as its own argument and
+    // forwards it; `profile-resolver.test.ts` locks that forwarding.
+    if (c.args.includes(STS_SEAM)) continue;
+    const split = splitAtProxySeam(c.args);
+    if (split === null) continue;
+    if (!PROFILE_TOKEN.test(split.rest)) continue;
+    if (PROFILE_TOKEN.test(split.fragment)) continue;
+    offenders.push({ line: c.line, text: c.text });
+  }
+  return offenders;
+}
+
+/** Policy 3: the proxy seam is spread before any `credentials`. */
+function findOrderOffenders(filePath: string): { line: number; text: string }[] {
+  const offenders: { line: number; text: string }[] = [];
+  for (const c of constructions(filePath)) {
+    if (c.args === null || c.optedOut) continue;
+    const seamIndexes = [c.args.indexOf(PROXY_SEAM), c.args.indexOf(STS_SEAM)].filter(
+      (i) => i >= 0
+    );
+    // No seam at all is policy 1's business, not this one.
+    if (seamIndexes.length === 0) continue;
+    const credentialsAt = c.args.indexOf('credentials');
+    if (credentialsAt === -1) continue;
+    if (Math.min(...seamIndexes) < credentialsAt) continue;
+    offenders.push({ line: c.line, text: c.text });
+  }
+  return offenders;
+}
+
+function scanAll(
+  find: (filePath: string) => { line: number; text: string }[]
+): { file: string; line: number; text: string }[] {
+  const all: { file: string; line: number; text: string }[] = [];
+  for (const root of SCAN_ROOTS) {
+    for (const file of collectTsFiles(root)) {
+      for (const off of find(file)) {
+        all.push({ file: file.slice(repoRoot.length + 1), ...off });
       }
     }
-    if (allOffenders.length > 0) {
-      const msg = allOffenders.map((o) => `  ${o.file}:${o.line}  ${o.text}`).join('\n');
-      throw new Error(
-        `Found ${allOffenders.length} AWS SDK client construction(s) that do not thread the proxy environment:\n${msg}\n\n` +
-          'Fix: spread `...buildProxyClientConfig({ profile? })` FIRST in the constructor config ' +
-          '(import from `src/utils/aws-proxy.ts`), or route an STS site through ' +
-          '`buildStsClientConfig(...)`. If the construction genuinely never reaches the network ' +
-          '(or is not an AWS SDK client), add a single-line `// proxy-audit: ignore: <reason>` ' +
-          'directly above it.'
-      );
-    }
+  }
+  return all;
+}
+
+const render = (offenders: { file: string; line: number; text: string }[]) =>
+  offenders.map((o) => `${o.file}:${o.line}  ${o.text}`);
+
+describe('AWS SDK client proxy-config audit (issue #634)', () => {
+  it('every AWS SDK client construction under src/** spreads the proxy-aware config', () => {
+    expect(
+      render(scanAll(findOffenders)),
+      'Fix: spread `...buildProxyClientConfig({ profile? })` FIRST in the constructor config ' +
+        '(import from `src/utils/aws-proxy.ts`), or route an STS site through ' +
+        '`buildStsClientConfig(...)`. If the construction genuinely never reaches the network ' +
+        '(or is not an AWS SDK client), add a single-line `// proxy-audit: ignore: <reason>` ' +
+        'directly above it.'
+    ).toEqual([]);
+  });
+
+  it('every construction that knows a profile threads it INTO buildProxyClientConfig (issue #648)', () => {
+    expect(
+      render(scanAll(findProfileOffenders)),
+      'A construction passes a `profile` alongside the proxy fragment but not INTO it. Under a ' +
+        'proxy the fragment supplies a `credentials` provider, and explicit credentials beat a ' +
+        '`profile` key in the AWS SDK — so this site resolves the DEFAULT account under ' +
+        '`HTTPS_PROXY` while looking correct without one. Fix: ' +
+        '`...buildProxyClientConfig({ profile: <the same profile> })`.'
+    ).toEqual([]);
+  });
+
+  it('spreads the proxy fragment BEFORE any credentials the site resolves itself (issue #648)', () => {
+    expect(
+      render(scanAll(findOrderOffenders)),
+      'A construction spreads the proxy fragment AFTER its own `credentials`, so the fragment’s ' +
+        'default-chain provider silently replaces them whenever a proxy variable is set (and only ' +
+        'then, which is why no site test sees it). Fix: move `...buildProxyClientConfig(...)` to ' +
+        'the FIRST position in the config object.'
+    ).toEqual([]);
   });
 
   // The audit is only evidence if it can go red: the pre-#634 spelling of a
@@ -143,6 +275,106 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
           `export const c = new SecretsManagerClient({});\n`
       );
       expect(findOffenders(optedOut)).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Same guard-the-guard for the two #648 policies. Each is written as the
+  // BROKEN spelling next to the REPAIRED one, because a policy that flags
+  // nothing and a policy that flags everything both leave the live scan
+  // above green.
+  it('flags a profile passed alongside the fragment rather than into it (self-check)', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const dir = mkdtempSync(join(tmpdir(), 'proxy-audit-profile-'));
+    try {
+      const header =
+        `import { S3Client } from '@aws-sdk/client-s3';\n` +
+        `import { buildProxyClientConfig } from '../utils/aws-proxy.js';\n`;
+
+      const halfWired = join(dir, 'half-wired.ts');
+      writeFileSync(
+        halfWired,
+        `${header}export const c = new S3Client({\n` +
+          `  ...buildProxyClientConfig(),\n` +
+          `  ...(options.profile && { profile: options.profile }),\n` +
+          `});\n`
+      );
+      expect(findProfileOffenders(halfWired)).toHaveLength(1);
+
+      const threaded = join(dir, 'threaded.ts');
+      writeFileSync(
+        threaded,
+        `${header}export const c = new S3Client({\n` +
+          `  ...buildProxyClientConfig({ profile: options.profile }),\n` +
+          `  ...(options.profile && { profile: options.profile }),\n` +
+          `});\n`
+      );
+      expect(findProfileOffenders(threaded)).toHaveLength(0);
+
+      // A site with no profile at all is not this policy's business — the
+      // rule must not degenerate into "always pass a profile".
+      const noProfile = join(dir, 'no-profile.ts');
+      writeFileSync(
+        noProfile,
+        `${header}export const c = new S3Client({ ...buildProxyClientConfig(), region });\n`
+      );
+      expect(findProfileOffenders(noProfile)).toHaveLength(0);
+
+      // `buildStsClientConfig` takes the profile itself and forwards it.
+      const viaSts = join(dir, 'via-sts.ts');
+      writeFileSync(
+        viaSts,
+        `import { STSClient } from '@aws-sdk/client-sts';\n` +
+          `import { buildStsClientConfig } from '../utils/profile-resolver.js';\n` +
+          `export const c = new STSClient(buildStsClientConfig({ region, profile }));\n`
+      );
+      expect(findProfileOffenders(viaSts)).toHaveLength(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('flags a proxy fragment spread AFTER the site’s own credentials (self-check)', async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const dir = mkdtempSync(join(tmpdir(), 'proxy-audit-order-'));
+    try {
+      const header =
+        `import { ECRClient } from '@aws-sdk/client-ecr';\n` +
+        `import { buildProxyClientConfig } from '../utils/aws-proxy.js';\n`;
+
+      const spreadLast = join(dir, 'spread-last.ts');
+      writeFileSync(
+        spreadLast,
+        `${header}export const c = new ECRClient({\n` +
+          `  region: parsed.region,\n` +
+          `  ...(assumed ? { credentials: assumed } : {}),\n` +
+          `  ...buildProxyClientConfig({ profile: options.profile }),\n` +
+          `});\n`
+      );
+      expect(findOrderOffenders(spreadLast)).toHaveLength(1);
+
+      const spreadFirst = join(dir, 'spread-first.ts');
+      writeFileSync(
+        spreadFirst,
+        `${header}export const c = new ECRClient({\n` +
+          `  ...buildProxyClientConfig({ profile: options.profile }),\n` +
+          `  region: parsed.region,\n` +
+          `  ...(assumed ? { credentials: assumed } : {}),\n` +
+          `});\n`
+      );
+      expect(findOrderOffenders(spreadFirst)).toHaveLength(0);
+
+      // No credentials in the argument list: nothing for the fragment to
+      // clobber, so position is not this policy's business.
+      const noCredentials = join(dir, 'no-credentials.ts');
+      writeFileSync(
+        noCredentials,
+        `${header}export const c = new ECRClient({ region, ...buildProxyClientConfig() });\n`
+      );
+      expect(findOrderOffenders(noCredentials)).toHaveLength(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/utils/aws-proxy-client-audit.test.ts
+++ b/tests/unit/utils/aws-proxy-client-audit.test.ts
@@ -52,7 +52,12 @@ import {
  * ALL THREE policies, not only from policy 1. The marker's meaning is "this
  * is not an AWS SDK client construction that reaches the network", and a
  * thing outside the population has no profile to thread and no order to
- * keep. Nothing in `src/**` carries one today.
+ * keep. No client construction is exempted by one today — the markers that
+ * DO exist in `src/**` belong to the sibling `aws-proxy-fetch-audit.test.ts`,
+ * which deliberately shares the string through `hasOptOutMarker`. They are
+ * inert here only because none of their files references `@aws-sdk/client-`;
+ * a marker written for the fetch audit in a file that also constructs an SDK
+ * client would silently exempt that construction from all three policies.
  *
  * POPULATION is derived from the defect, not from a site list: a
  * construction is in scope when its class name ends in `Client` AND the
@@ -179,6 +184,10 @@ function splitAtSeam(args: string): { fragment: string; rest: string } | null {
  *   a property of the current tree, not something this policy proves.
  * - an unbalanced (`args === null`) construction is skipped here and REPORTED
  *   by policy 1, so it cannot hide by being unparseable.
+ * - when BOTH seams appear, only the first BY INDEX is split at, so a profile
+ *   threaded into the second one lands in `rest` and is reported. A false
+ *   positive, in the safe direction and with a self-clearing message. No live
+ *   site spells both.
  */
 function findProfileOffenders(filePath: string): { line: number; text: string }[] {
   const offenders: { line: number; text: string }[] = [];
@@ -405,6 +414,25 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
       expect(findProfileOffenders(stsHalfWired)).toEqual([
         { line: 3, text: 'export const c = new STSClient({' },
       ]);
+
+      // BOTH seams in one construction: the split takes the FIRST by index,
+      // so the profile threaded into `buildProxyClientConfig` is found even
+      // though `buildStsClientConfig` appears later without one. Flipping the
+      // selection to last-wins reports this as an offender, and nothing else
+      // in the suite or the live scan notices — no real site spells both.
+      const bothSeams = join(dir, 'both-seams.ts');
+      writeFileSync(
+        bothSeams,
+        `import { STSClient } from '@aws-sdk/client-sts';\n` +
+          `import { buildProxyClientConfig } from '../utils/aws-proxy.js';\n` +
+          `import { buildStsClientConfig } from '../utils/profile-resolver.js';\n` +
+          `export const c = new STSClient({\n` +
+          `  ...buildProxyClientConfig({ profile: options.profile }),\n` +
+          `  ...buildStsClientConfig({ region }),\n` +
+          `  profile: options.profile,\n` +
+          `});\n`
+      );
+      expect(findProfileOffenders(bothSeams)).toHaveLength(0);
 
       // An opt-out removes the construction from THIS policy too, not only
       // from policy 1 — the marker means "not in the population at all".

--- a/tests/unit/utils/aws-proxy-client-audit.test.ts
+++ b/tests/unit/utils/aws-proxy-client-audit.test.ts
@@ -30,10 +30,11 @@ import {
  *    `profile-resolver.test.ts`), or carries a
  *    `// proxy-audit: ignore: <reason>` comment directly above.
  *
- * 2. PROFILE — a construction that knows a `profile` must pass it INTO
- *    `buildProxyClientConfig({ profile })`, not only alongside it. Under a
- *    proxy the fragment carries a `credentials` provider, and in the AWS SDK
- *    explicit `credentials` beat a `profile` key — so a site spelling
+ * 2. PROFILE — a construction that knows a `profile` must pass it INTO the
+ *    seam (`buildProxyClientConfig({ profile })`, or `buildStsClientConfig`'s
+ *    own `profile` argument), not only alongside it. Under a proxy the
+ *    fragment carries a `credentials` provider, and in the AWS SDK explicit
+ *    `credentials` beat a `profile` key — so a site spelling
  *    `{ ...buildProxyClientConfig(), profile }` resolves the DEFAULT
  *    account's credentials while looking correct. That is the
  *    `--profile` half-wiring recurrence in its proxy-shaped form, and it is
@@ -46,6 +47,12 @@ import {
  *    readers' caller creds) must keep them; with the spread moved LAST the
  *    fragment's default-chain provider silently REPLACES them, again only
  *    under a proxy (issue go-to-k/cdk-local#648).
+ *
+ * A `// proxy-audit: ignore: <reason>` marker exempts a construction from
+ * ALL THREE policies, not only from policy 1. The marker's meaning is "this
+ * is not an AWS SDK client construction that reaches the network", and a
+ * thing outside the population has no profile to thread and no order to
+ * keep. Nothing in `src/**` carries one today.
  *
  * POPULATION is derived from the defect, not from a site list: a
  * construction is in scope when its class name ends in `Client` AND the
@@ -123,18 +130,31 @@ function findOffenders(filePath: string): { line: number; text: string }[] {
 }
 
 /**
- * Split an argument list at its `buildProxyClientConfig(...)` call: the
- * call's OWN arguments, and everything else with that span blanked out. The
- * split is what makes policy 2 answerable — `profile` inside the fragment is
- * the threading, `profile` outside it is the site's own key, and a plain
+ * Split an argument list at its FIRST seam call: the call's OWN arguments,
+ * and everything else with that span blanked out. The split is what makes
+ * policy 2 answerable — `profile` inside the fragment is the threading,
+ * `profile` outside it is the site's own key, and a plain
  * `includes('profile')` over the whole text cannot tell them apart.
+ *
+ * Both seams are split at, not just `buildProxyClientConfig`. Skipping the
+ * STS spelling outright is what an earlier revision did, and it left the
+ * exact defect this audit exists for unfenced:
+ * `new STSClient({ ...buildStsClientConfig({ region }), profile })` gives the
+ * helper no profile, so the fragment it builds resolves the DEFAULT account
+ * under a proxy. The plain `new STSClient(buildStsClientConfig({ profile }))`
+ * form every live site uses is unaffected — its whole argument list IS the
+ * call, so nothing is left in `rest` to spell `profile`.
  */
-function splitAtProxySeam(args: string): { fragment: string; rest: string } | null {
-  const at = args.indexOf(PROXY_SEAM);
-  if (at === -1) return null;
+function splitAtSeam(args: string): { fragment: string; rest: string } | null {
+  let best: { at: number; seam: string } | undefined;
+  for (const seam of [PROXY_SEAM, STS_SEAM]) {
+    const at = args.indexOf(seam);
+    if (at >= 0 && (best === undefined || at < best.at)) best = { at, seam };
+  }
+  if (best === undefined) return null;
   // `argumentText` takes the index of the `(` and returns the text BETWEEN
   // the parens, so the whole call spans `open` .. `open + fragment.length + 1`.
-  const open = at + PROXY_SEAM.length - 1;
+  const open = best.at + best.seam.length - 1;
   const fragment = argumentText(args, open);
   if (fragment === null) return null;
   return {
@@ -143,15 +163,28 @@ function splitAtProxySeam(args: string): { fragment: string; rest: string } | nu
   };
 }
 
-/** Policy 2: a site that knows a profile threads it INTO the fragment. */
+/**
+ * Policy 2: a site that knows a profile threads it INTO the seam.
+ *
+ * BOUNDS, stated so the next sweep finds a decision rather than an oversight:
+ *
+ * - it checks SHAPE, not value. `buildProxyClientConfig({ profile: undefined })`
+ *   and a profile read from the wrong variable both pass. The behavioural
+ *   fences (`tests/unit/local/ecr-puller-profile.test.ts`,
+ *   `tests/unit/utils/profile-resolver.test.ts`) are what check the value, by
+ *   invoking the resolved provider.
+ * - a site that KNOWS a profile without spelling `profile` in its own argument
+ *   list is invisible here. Every such site in the tree today passes explicit
+ *   `credentials` instead — which win over a profile key anyway — but that is
+ *   a property of the current tree, not something this policy proves.
+ * - an unbalanced (`args === null`) construction is skipped here and REPORTED
+ *   by policy 1, so it cannot hide by being unparseable.
+ */
 function findProfileOffenders(filePath: string): { line: number; text: string }[] {
   const offenders: { line: number; text: string }[] = [];
   for (const c of constructions(filePath)) {
     if (c.args === null || c.optedOut) continue;
-    // `buildStsClientConfig` takes the profile as its own argument and
-    // forwards it; `profile-resolver.test.ts` locks that forwarding.
-    if (c.args.includes(STS_SEAM)) continue;
-    const split = splitAtProxySeam(c.args);
+    const split = splitAtSeam(c.args);
     if (split === null) continue;
     if (!PROFILE_TOKEN.test(split.rest)) continue;
     if (PROFILE_TOKEN.test(split.fragment)) continue;
@@ -160,7 +193,21 @@ function findProfileOffenders(filePath: string): { line: number; text: string }[
   return offenders;
 }
 
-/** Policy 3: the proxy seam is spread before any `credentials`. */
+/**
+ * Policy 3: the proxy seam is spread before any `credentials`.
+ *
+ * BOUNDS: the scan is for the literal token `credentials`, so a site whose
+ * own credentials arrive through a spread that never spells it
+ * (`...credsFragment`) is invisible. All seven credential-carrying sites in
+ * the tree spell it literally. Two directions that are deliberately safe:
+ * matching a CONDITION (`options.credentials &&`) rather than the key only
+ * makes the rule STRICTER, since `indexOf` returns the FIRST occurrence and a
+ * seam earlier than it is earlier than every occurrence; and a false positive
+ * (a `credentialsProvider` key, a nested `clientConfig`) reports an
+ * actionable message rather than passing silently. The one direction that
+ * fails OPEN is a seam call NESTED inside an earlier argument, whose index
+ * would satisfy the comparison on behalf of an outer spread placed last.
+ */
 function findOrderOffenders(filePath: string): { line: number; text: string }[] {
   const offenders: { line: number; text: string }[] = [];
   for (const c of constructions(filePath)) {
@@ -207,14 +254,17 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
     ).toEqual([]);
   });
 
-  it('every construction that knows a profile threads it INTO buildProxyClientConfig (issue #648)', () => {
+  it('every construction that knows a profile threads it INTO the proxy seam (issue #648)', () => {
     expect(
       render(scanAll(findProfileOffenders)),
-      'A construction passes a `profile` alongside the proxy fragment but not INTO it. Under a ' +
+      'A construction passes a `profile` alongside the proxy seam but not INTO it. Under a ' +
         'proxy the fragment supplies a `credentials` provider, and explicit credentials beat a ' +
         '`profile` key in the AWS SDK — so this site resolves the DEFAULT account under ' +
         '`HTTPS_PROXY` while looking correct without one. Fix: ' +
-        '`...buildProxyClientConfig({ profile: <the same profile> })`.'
+        '`...buildProxyClientConfig({ profile: <the same profile> })`, or for an STS site ' +
+        '`buildStsClientConfig({ region, profile })`. If the construction is not an AWS SDK ' +
+        'client that reaches the network, a `// proxy-audit: ignore: <reason>` comment above it ' +
+        'exempts it from all three policies.'
     ).toEqual([]);
   });
 
@@ -223,8 +273,10 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
       render(scanAll(findOrderOffenders)),
       'A construction spreads the proxy fragment AFTER its own `credentials`, so the fragment’s ' +
         'default-chain provider silently replaces them whenever a proxy variable is set (and only ' +
-        'then, which is why no site test sees it). Fix: move `...buildProxyClientConfig(...)` to ' +
-        'the FIRST position in the config object.'
+        'then, which is why no site test sees it). Fix: move `...buildProxyClientConfig(...)` — ' +
+        'or `...buildStsClientConfig(...)` — to the FIRST position in the config object. If the ' +
+        'construction is not an AWS SDK client that reaches the network, a ' +
+        '`// proxy-audit: ignore: <reason>` comment above it exempts it from all three policies.'
     ).toEqual([]);
   });
 
@@ -301,7 +353,11 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
           `  ...(options.profile && { profile: options.profile }),\n` +
           `});\n`
       );
-      expect(findProfileOffenders(halfWired)).toHaveLength(1);
+      // The reported LINE, not just a count: a policy that reports the wrong
+      // construction satisfies `toHaveLength(1)` exactly as well.
+      expect(findProfileOffenders(halfWired)).toEqual([
+        { line: 3, text: 'export const c = new S3Client({' },
+      ]);
 
       const threaded = join(dir, 'threaded.ts');
       writeFileSync(
@@ -322,15 +378,46 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
       );
       expect(findProfileOffenders(noProfile)).toHaveLength(0);
 
-      // `buildStsClientConfig` takes the profile itself and forwards it.
+      // `buildStsClientConfig` takes the profile itself and forwards it, and
+      // in the form every live STS site uses the whole argument list IS the
+      // call — nothing is left outside it to spell `profile`.
+      const stsHeader =
+        `import { STSClient } from '@aws-sdk/client-sts';\n` +
+        `import { buildStsClientConfig } from '../utils/profile-resolver.js';\n`;
       const viaSts = join(dir, 'via-sts.ts');
       writeFileSync(
         viaSts,
-        `import { STSClient } from '@aws-sdk/client-sts';\n` +
-          `import { buildStsClientConfig } from '../utils/profile-resolver.js';\n` +
-          `export const c = new STSClient(buildStsClientConfig({ region, profile }));\n`
+        `${stsHeader}export const c = new STSClient(buildStsClientConfig({ region, profile }));\n`
       );
       expect(findProfileOffenders(viaSts)).toHaveLength(0);
+
+      // ...but the SPREAD form of the same helper can still be half-wired,
+      // and skipping every STS site outright — which an earlier revision did
+      // — left exactly this unfenced.
+      const stsHalfWired = join(dir, 'sts-half-wired.ts');
+      writeFileSync(
+        stsHalfWired,
+        `${stsHeader}export const c = new STSClient({\n` +
+          `  ...buildStsClientConfig({ region }),\n` +
+          `  profile: options.profile,\n` +
+          `});\n`
+      );
+      expect(findProfileOffenders(stsHalfWired)).toEqual([
+        { line: 3, text: 'export const c = new STSClient({' },
+      ]);
+
+      // An opt-out removes the construction from THIS policy too, not only
+      // from policy 1 — the marker means "not in the population at all".
+      const optedOut = join(dir, 'opted-out.ts');
+      writeFileSync(
+        optedOut,
+        `${header}// proxy-audit: ignore: a stub, never reaches the network\n` +
+          `export const c = new S3Client({\n` +
+          `  ...buildProxyClientConfig(),\n` +
+          `  ...(options.profile && { profile: options.profile }),\n` +
+          `});\n`
+      );
+      expect(findProfileOffenders(optedOut)).toHaveLength(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -354,7 +441,9 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
           `  ...buildProxyClientConfig({ profile: options.profile }),\n` +
           `});\n`
       );
-      expect(findOrderOffenders(spreadLast)).toHaveLength(1);
+      expect(findOrderOffenders(spreadLast)).toEqual([
+        { line: 3, text: 'export const c = new ECRClient({' },
+      ]);
 
       const spreadFirst = join(dir, 'spread-first.ts');
       writeFileSync(
@@ -375,6 +464,47 @@ describe('AWS SDK client proxy-config audit (issue #634)', () => {
         `${header}export const c = new ECRClient({ region, ...buildProxyClientConfig() });\n`
       );
       expect(findOrderOffenders(noCredentials)).toHaveLength(0);
+
+      // The STS_SEAM arm of `seamIndexes`. No live site spreads
+      // `buildStsClientConfig` alongside its own credentials, so deleting
+      // that arm leaves BOTH the live scan and every other self-check green
+      // — this pair is the only thing holding it.
+      const stsHeader =
+        `import { STSClient } from '@aws-sdk/client-sts';\n` +
+        `import { buildStsClientConfig } from '../utils/profile-resolver.js';\n`;
+      const stsSpreadLast = join(dir, 'sts-spread-last.ts');
+      writeFileSync(
+        stsSpreadLast,
+        `${stsHeader}export const c = new STSClient({\n` +
+          `  ...(assumed && { credentials: assumed }),\n` +
+          `  ...buildStsClientConfig({ region, profile }),\n` +
+          `});\n`
+      );
+      expect(findOrderOffenders(stsSpreadLast)).toEqual([
+        { line: 3, text: 'export const c = new STSClient({' },
+      ]);
+
+      const stsSpreadFirst = join(dir, 'sts-spread-first.ts');
+      writeFileSync(
+        stsSpreadFirst,
+        `${stsHeader}export const c = new STSClient({\n` +
+          `  ...buildStsClientConfig({ region, profile }),\n` +
+          `  ...(assumed && { credentials: assumed }),\n` +
+          `});\n`
+      );
+      expect(findOrderOffenders(stsSpreadFirst)).toHaveLength(0);
+
+      // An opt-out removes the construction from THIS policy too.
+      const optedOut = join(dir, 'order-opted-out.ts');
+      writeFileSync(
+        optedOut,
+        `${header}// proxy-audit: ignore: a stub, never reaches the network\n` +
+          `export const c = new ECRClient({\n` +
+          `  ...(assumed ? { credentials: assumed } : {}),\n` +
+          `  ...buildProxyClientConfig(),\n` +
+          `});\n`
+      );
+      expect(findOrderOffenders(optedOut)).toHaveLength(0);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/tests/unit/utils/aws-proxy.test.ts
+++ b/tests/unit/utils/aws-proxy.test.ts
@@ -303,10 +303,13 @@ describe('aws-proxy (issue #634)', () => {
     it('sets keepAlive + maxSockets explicitly — the SDK applies its defaults only to plain option bags, never to external Agent instances', () => {
       // NO_PROXY is set BEFORE the exempt host is connected. An earlier
       // revision connected it first and named the result `direct`, so it was
-      // the cached HttpsProxyAgent and the loop asserted the proxied agent
-      // twice while its name claimed to cover both (issue
-      // go-to-k/cdk-local#648). The two instanceof lines below are the
-      // guard-the-guard that keeps the pair distinct.
+      // in fact the cached HttpsProxyAgent (issue go-to-k/cdk-local#648).
+      // That cost no COVERAGE — a third connect, after NO_PROXY was set, put
+      // a genuinely direct agent in the same loop — so what was wrong was the
+      // name, and a name that lies about which agent is under assertion is
+      // what makes the next edit here unsafe. The two instanceof lines below
+      // are the guard-the-guard that keeps the pair distinct without relying
+      // on the reader trusting the variable names.
       process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
       process.env['NO_PROXY'] = 'proxy-exempt.internal';
       const agent = new EnvRoutingProxyAgent();

--- a/tests/unit/utils/aws-proxy.test.ts
+++ b/tests/unit/utils/aws-proxy.test.ts
@@ -202,6 +202,64 @@ describe('aws-proxy (issue #634)', () => {
       agent.destroy();
     });
 
+    it('a leading ASTERISK is a suffix match too: *.example.com exempts api.example.com but NOT the apex', () => {
+      // The doc comment on `EnvRoutingProxyAgent` promises `.`-OR-`*`; only
+      // the dot form was covered (issue go-to-k/cdk-local#648). The asterisk
+      // is STRIPPED and the remainder is an `endsWith` test, so `example.com`
+      // — which does not end in `.example.com` — is still proxied. That
+      // asymmetry is the part worth pinning: a user writing `*.example.com`
+      // to mean "the whole domain" does not get the apex.
+      process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+      process.env['NO_PROXY'] = '*.example.com';
+      const agent = new EnvRoutingProxyAgent();
+      expect(agent.connect(REQ, httpsOpts('api.example.com'))).not.toBeInstanceOf(HttpsProxyAgent);
+      expect(agent.connect(REQ, httpsOpts('example.com'))).toBeInstanceOf(HttpsProxyAgent);
+      agent.destroy();
+    });
+
+    it('honors the lowercase no_proxy spelling', () => {
+      // The uppercase spelling was covered; the lowercase one — which
+      // `getProxyForUrl` prefers when both are set — was not
+      // (issue go-to-k/cdk-local#648). The second assertion is the
+      // guard-the-guard: it must exempt THE ENTRY, not proxying at large.
+      process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+      process.env['no_proxy'] = 'example.com';
+      const agent = new EnvRoutingProxyAgent();
+      expect(agent.connect(REQ, httpsOpts('example.com'))).not.toBeInstanceOf(HttpsProxyAgent);
+      expect(agent.connect(REQ, httpsOpts('sts.us-east-1.amazonaws.com'))).toBeInstanceOf(
+        HttpsProxyAgent
+      );
+      agent.destroy();
+    });
+
+    it('routes an IPv6 target through the proxy — the authority it builds is BRACKETED, and a bare `host:port` does not parse', () => {
+      // `connect()` receives the host BARE (`2001:db8::1`), so composing the
+      // probe URL as `${host}:${port}` yields `https://2001:db8::1:443`,
+      // which `getProxyForUrl` cannot parse and answers `''` for — i.e. a
+      // DIRECT connection, silently unproxied, for every IPv6 endpoint.
+      // `formatAuthority` is what prevents that (issue
+      // go-to-k/cdk-local#599's composition rule).
+      process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+      const agent = new EnvRoutingProxyAgent();
+      expect(agent.connect(REQ, httpsOpts('2001:db8::1'))).toBeInstanceOf(HttpsProxyAgent);
+      agent.destroy();
+    });
+
+    it('a NO_PROXY entry exempts an IPv6 target in its BRACKETED spelling', () => {
+      // `getProxyForUrl` compares against `URL.host` MINUS the port, and that
+      // keeps an IPv6 literal's brackets — so `NO_PROXY=2001:db8::1` does
+      // NOT exempt this target and `NO_PROXY=[2001:db8::1]` does. Surprising
+      // enough to pin. The second assertion keeps the case honest: with the
+      // bracketing removed both hosts go direct, which would satisfy the
+      // first assertion for the wrong reason.
+      process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+      process.env['NO_PROXY'] = '[2001:db8::1]';
+      const agent = new EnvRoutingProxyAgent();
+      expect(agent.connect(REQ, httpsOpts('2001:db8::1'))).not.toBeInstanceOf(HttpsProxyAgent);
+      expect(agent.connect(REQ, httpsOpts('2001:db8::2'))).toBeInstanceOf(HttpsProxyAgent);
+      agent.destroy();
+    });
+
     it('a NO_PROXY :port entry applies only to that port', () => {
       process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
       process.env['NO_PROXY'] = 'example.com:8443';
@@ -243,13 +301,20 @@ describe('aws-proxy (issue #634)', () => {
     });
 
     it('sets keepAlive + maxSockets explicitly — the SDK applies its defaults only to plain option bags, never to external Agent instances', () => {
+      // NO_PROXY is set BEFORE the exempt host is connected. An earlier
+      // revision connected it first and named the result `direct`, so it was
+      // the cached HttpsProxyAgent and the loop asserted the proxied agent
+      // twice while its name claimed to cover both (issue
+      // go-to-k/cdk-local#648). The two instanceof lines below are the
+      // guard-the-guard that keeps the pair distinct.
       process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+      process.env['NO_PROXY'] = 'proxy-exempt.internal';
       const agent = new EnvRoutingProxyAgent();
       const proxied = agent.connect(REQ, httpsOpts('sts.us-east-1.amazonaws.com')) as HttpAgent;
       const direct = agent.connect(REQ, httpsOpts('proxy-exempt.internal')) as HttpAgent;
-      process.env['NO_PROXY'] = 'proxy-exempt.internal';
-      const directPicked = agent.connect(REQ, httpsOpts('proxy-exempt.internal')) as HttpAgent;
-      for (const a of [proxied, direct, directPicked]) {
+      expect(proxied).toBeInstanceOf(HttpsProxyAgent);
+      expect(direct).not.toBeInstanceOf(HttpsProxyAgent);
+      for (const a of [proxied, direct]) {
         // Instance properties, not `.options`: HttpsProxyAgent overwrites
         // `this.options` after `super(opts)`, but `keepAlive` / `maxSockets`
         // are captured onto the instance by the base constructors first.
@@ -266,6 +331,68 @@ describe('aws-proxy (issue #634)', () => {
       const destroySpy = vi.spyOn(proxied as HttpAgent, 'destroy');
       agent.destroy();
       expect(destroySpy).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * How the value of the proxy variable itself is read (issue
+   * go-to-k/cdk-local#648). Both shapes below are ordinary things a user
+   * types, and neither had a test: the first is silently reinterpreted, the
+   * second fails at a point far from where it was configured.
+   */
+  describe('EnvRoutingProxyAgent — proxy URL spellings', () => {
+    it('a SCHEME-LESS value takes the REQUEST scheme: `HTTPS_PROXY=proxy.internal:3128` means TLS to the PROXY', () => {
+      // The common spelling, and it does not mean what it looks like.
+      // `proxy-from-env` prepends the scheme of the URL BEING REQUESTED, not
+      // `http:` — so an https target speaks TLS to the proxy itself, which a
+      // plain HTTP forward proxy will not answer. Writing
+      // `HTTPS_PROXY=http://proxy.internal:3128` is what gets a CONNECT
+      // tunnel over plain HTTP.
+      process.env['HTTPS_PROXY'] = 'proxy.internal:3128';
+      const agent = new EnvRoutingProxyAgent();
+      const picked = agent.connect(REQ, httpsOpts('sts.us-east-1.amazonaws.com'));
+      expect(picked).toBeInstanceOf(HttpsProxyAgent);
+      expect((picked as HttpsProxyAgent<string>).proxy.href).toBe('https://proxy.internal:3128/');
+      agent.destroy();
+    });
+
+    it('the same scheme-less value stays plain HTTP for an http target', () => {
+      process.env['HTTP_PROXY'] = 'proxy.internal:3128';
+      const agent = new EnvRoutingProxyAgent();
+      const picked = agent.connect(REQ, httpOpts('example.com'));
+      expect(picked).toBeInstanceOf(HttpProxyAgent);
+      expect((picked as HttpProxyAgent<string>).proxy.href).toBe('http://proxy.internal:3128/');
+      agent.destroy();
+    });
+
+    it('an UNPARSABLE value throws at connect time rather than silently connecting DIRECT', () => {
+      // The failure direction matters more than the exception type. A
+      // machine with a proxy configured has no direct egress — falling back
+      // to a direct connection would turn a typo in the variable into a hang
+      // or a self-signed-certificate error at some unrelated AWS call, with
+      // nothing pointing back at the proxy variable. Throwing keeps the
+      // cause attached to the request.
+      process.env['HTTPS_PROXY'] = 'http://[';
+      const agent = new EnvRoutingProxyAgent();
+      expect(() => agent.connect(REQ, httpsOpts('sts.us-east-1.amazonaws.com'))).toThrow(TypeError);
+      agent.destroy();
+    });
+
+    it('an unparsable value on the http side throws the same way', () => {
+      process.env['HTTP_PROXY'] = '%%%';
+      const agent = new EnvRoutingProxyAgent();
+      expect(() => agent.connect(REQ, httpOpts('example.com'))).toThrow(TypeError);
+      agent.destroy();
+    });
+
+    it('a NO_PROXY-exempt target is unaffected by an unparsable proxy value — the URL is never built', () => {
+      // Guard-the-guard for the pair above: they must fail on the PROXY
+      // value, not on merely having a proxy variable set.
+      process.env['HTTPS_PROXY'] = 'http://[';
+      process.env['NO_PROXY'] = 'exempt.internal';
+      const agent = new EnvRoutingProxyAgent();
+      expect(agent.connect(REQ, httpsOpts('exempt.internal'))).not.toBeInstanceOf(HttpsProxyAgent);
+      agent.destroy();
     });
   });
 });

--- a/tests/unit/utils/profile-resolver.test.ts
+++ b/tests/unit/utils/profile-resolver.test.ts
@@ -198,10 +198,12 @@ describe('buildStsClientConfig — proxy environment threading (issue #634)', ()
     chainMock.mockResolvedValue({ accessKeyId: 'AKIA', secretAccessKey: 's' });
     const config = buildStsClientConfig({ region: 'us-east-1' });
     await config.credentials!();
-    // Without the call-count assertion this passes when `defaultProvider` was
-    // called with NO argument at all — `expect(undefined).not.toHaveProperty`
-    // is satisfied by the absence of the whole init bag, not by the absence
-    // of the key.
+    // `toBeDefined` is the load-bearing line: on its own,
+    // `expect(undefined).not.toHaveProperty('profile')` is satisfied by the
+    // absence of the whole init bag rather than by the absence of the key, so
+    // a `defaultProvider()` called with NO argument would pass. The call
+    // count does not cover that case — it is satisfied by such a call too —
+    // and is here to pin that the chain is resolved exactly once.
     expect(defaultProviderMock).toHaveBeenCalledTimes(1);
     expect(defaultProviderMock.mock.calls[0]![0]).toBeDefined();
     expect(defaultProviderMock.mock.calls[0]![0]).not.toHaveProperty('profile');

--- a/tests/unit/utils/profile-resolver.test.ts
+++ b/tests/unit/utils/profile-resolver.test.ts
@@ -198,6 +198,12 @@ describe('buildStsClientConfig — proxy environment threading (issue #634)', ()
     chainMock.mockResolvedValue({ accessKeyId: 'AKIA', secretAccessKey: 's' });
     const config = buildStsClientConfig({ region: 'us-east-1' });
     await config.credentials!();
+    // Without the call-count assertion this passes when `defaultProvider` was
+    // called with NO argument at all — `expect(undefined).not.toHaveProperty`
+    // is satisfied by the absence of the whole init bag, not by the absence
+    // of the key.
+    expect(defaultProviderMock).toHaveBeenCalledTimes(1);
+    expect(defaultProviderMock.mock.calls[0]![0]).toBeDefined();
     expect(defaultProviderMock.mock.calls[0]![0]).not.toHaveProperty('profile');
   });
 

--- a/tests/unit/utils/profile-resolver.test.ts
+++ b/tests/unit/utils/profile-resolver.test.ts
@@ -19,6 +19,18 @@ vi.mock('@aws-sdk/client-sts', () => ({
   }),
 }));
 
+// Reached only through the proxy fragment's `credentials` provider (issue
+// go-to-k/cdk-local#648), which the proxy describe below invokes; nothing
+// else in this file resolves a credential chain.
+const { defaultProviderMock, chainMock } = vi.hoisted(() => {
+  const chainMock = vi.fn();
+  return { chainMock, defaultProviderMock: vi.fn(() => chainMock) };
+});
+
+vi.mock('@aws-sdk/credential-provider-node', () => ({
+  defaultProvider: defaultProviderMock,
+}));
+
 import {
   resolveProfileCredentials,
   buildStsClientConfig,
@@ -145,6 +157,8 @@ describe('buildStsClientConfig — proxy environment threading (issue #634)', ()
       saved.set(key, process.env[key]);
       delete process.env[key];
     }
+    defaultProviderMock.mockClear();
+    chainMock.mockReset();
   });
 
   afterEach(() => {
@@ -162,6 +176,29 @@ describe('buildStsClientConfig — proxy environment threading (issue #634)', ()
     expect(config.profile).toBe('dev');
     expect(config.requestHandler).toBeDefined();
     expect(typeof config.credentials).toBe('function');
+  });
+
+  it('threads the profile INTO the fragment, so the chain resolves the named profile (issue #648)', async () => {
+    // The `profile` key asserted above is INERT under a proxy: the fragment
+    // supplies explicit `credentials`, and explicit credentials beat a
+    // profile key in the AWS SDK. So `buildStsClientConfig({ profile })`
+    // silently authenticating as the DEFAULT account is a shape the
+    // key-shaped assertion cannot see — every STS site in cdk-local goes
+    // through this helper, so it is the single widest instance of it.
+    process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+    chainMock.mockResolvedValue({ accessKeyId: 'AKIA', secretAccessKey: 's' });
+    const config = buildStsClientConfig({ region: 'us-east-1', profile: 'dev' });
+    await config.credentials!();
+    expect(defaultProviderMock).toHaveBeenCalledTimes(1);
+    expect(defaultProviderMock.mock.calls[0]![0]).toMatchObject({ profile: 'dev' });
+  });
+
+  it('leaves the chain profile-less when no profile is given', async () => {
+    process.env['HTTPS_PROXY'] = 'http://proxy.internal:3128';
+    chainMock.mockResolvedValue({ accessKeyId: 'AKIA', secretAccessKey: 's' });
+    const config = buildStsClientConfig({ region: 'us-east-1' });
+    await config.credentials!();
+    expect(defaultProviderMock.mock.calls[0]![0]).not.toHaveProperty('profile');
   });
 
   it('stays the plain { region, profile } shape when no proxy variable is set', () => {


### PR DESCRIPTION
## Summary

Test-only hardening. No `src/**` change, so the `integ` gate's scope short-circuit applies and no Docker run is needed.

The PR https://github.com/go-to-k/cdk-local/pull/646 test-adequacy review named mutations that survived the proxy suite. This closes the ones that are still real, having first re-screened every ask against `origin/main` — the issue was filed before https://github.com/go-to-k/cdk-local/pull/656 merged, and that PR landed four new proxy test files plus a substantial rewrite of `src/utils/aws-proxy.ts`.

## The already-shipped screen

Each ask re-checked at `origin/main` before any test was written.

| Ask | Verdict | Evidence |
|---|---|---|
| 1. Profile threading through the fragment is unfenced | **Real gap** | Dropping `{ profile }` from all nine `buildProxyClientConfig({ profile: ... })` calls (`ecs-secrets-resolver.ts:86,93`, `ecr-puller.ts:292`, `agentcore-s3-bundle.ts:142`, `cfn-local-state-provider.ts:184,198,212,231`, `profile-resolver.ts:100`) left the full suite at **4497 passed, 0 failed**. |
| 2. Spread order (fragment FIRST) is unfenced | **Real gap** | Moving the spread last at `ecr-puller.ts:292`, which replaces the assumed-role credentials with the default chain, left the suite at **4497 passed, 0 failed**. |
| 3. Scheme-less / malformed proxy URLs untested | **Real gap** | No case sets a scheme-less or unparsable proxy value anywhere in the suite. Measured behaviour: `proxy-from-env` prepends the **request** scheme, so `HTTPS_PROXY=proxy.internal:3128` yields `https://proxy.internal:3128/` — TLS to the proxy. An unparsable value (`http://[`, `%%%`) throws `TypeError: Invalid URL` from the agent constructor inside `connect()`. |
| 4a. `no_proxy` lowercase untested | **Real gap** | No case set the lowercase spelling. |
| 4b. `*.example.com` leading-asterisk form untested | **Real gap** | Only the leading-dot form was covered. Measured: `*` is stripped and the remainder is an `endsWith` test, so the form exempts `api.example.com` but **not** the apex `example.com`. |
| 4c. `formatAuthority` mutated to bare concatenation "silently bypasses the proxy for IPv6" | **Behaviour confirmed, but NOT silent — partially superseded** | The behaviour claim is right (`getProxyForUrl('https://2001:db8::1:443')` returns `''`, i.e. a direct agent). "Silently" is wrong: the mutation in its template spelling reddens `url-authority-call-sites.test.ts`'s negative fence, and in a non-template spelling (`host + ':' + port`) it reddens `aws-proxy-fetch.test.ts`'s `[::2]` case. The latter only surfaces as a **5-second timeout**, in the fetch suite rather than the agent suite. Added a direct 3 ms `connect()` assertion in `aws-proxy.test.ts` that names the cause; kept it out of `url-authority-call-sites.test.ts`'s `CONVERTED` list, whose stated contract is "every site issue 599 converted". |
| 4d. The `direct` agent comment at `aws-proxy.test.ts` contradicts the code | **Real defect** | Confirmed: it was connected before `NO_PROXY` was set, so it was the cached `HttpsProxyAgent` (the file's own `caches the inner proxy agent per proxy URL` case establishes that). The loop asserted the proxied agent twice under a name claiming to cover both. Corrected. |

Out of scope as filed: `layer-arn-materializer.ts` calls `buildProxyClientConfig()` with no profile as a documented deferral. Verified the new audit policy leaves it alone for the right reason — its argument list carries no `profile` token at all — rather than by accident.

## What was added

**Two repo-wide population policies** joined the client-construction audit, so the fence is the whole set of sites rather than a representative one:

- a construction that knows a `profile` must pass it **into** `buildProxyClientConfig({ profile })`. Under a proxy the fragment supplies a `credentials` provider, and explicit credentials beat a `profile` key in the AWS SDK — so the half-wired spelling resolves the **default** account while looking correct, and is invisible with no proxy variable set.
- the fragment must be spread **before** any `credentials` the site resolves itself.

Each carries a self-check asserting the broken *and* the repaired spelling, because a policy that flags nothing and one that flags everything both leave the live scan green.

**Behavioural fences** cover what a static rule cannot. `ecr-puller` under `HTTPS_PROXY` invokes the resolved provider and asserts `defaultProvider` received the named profile, and asserts its assumed-role credentials survive as an object rather than being replaced by the fragment's provider function. `buildStsClientConfig` gets the same profile assertion — the audit skips STS sites by design, so this helper, which every STS site in cdk-local goes through, has no other cover.

**Environment-variable spellings**: scheme-less values on both protocols, unparsable values on both protocols, `no_proxy`, `*.example.com` including the un-exempted apex, and IPv6 routing.

## Review round

Two reviewers (test-adequacy, code) converged on the same under-modelled seam from opposite ends, and the second commit closes it.

The profile policy **skipped** any construction mentioning `buildStsClientConfig(`, on the reasoning that the helper forwards the profile itself. It does — but only when it is *given* one, and `new STSClient({ ...buildStsClientConfig({ region }), profile })` is the exact half-wire this audit exists for. The skip made that spelling unreachable and the `via-sts` self-check locked the weaker rule in. `splitAtProxySeam` became `splitAtSeam` and splits at whichever seam comes first, so the STS spelling is judged by the same in/out test; the form every live site uses is unaffected, because its whole argument list *is* the call, leaving nothing outside it to spell `profile`.

From the other end, the ORDER policy already carried an STS arm that **nothing exercised** — deleting it left the live scan and every self-check green. It now has a self-check pair that is the only thing holding it.

Also from the round: the self-checks assert the reported **line**, not only a count; the opt-out marker's coupling to all three policies is documented, named in both failure messages, and covered by a case each; both new policies state their bounds in full, including the one direction that fails open (a seam nested inside an earlier argument); `leaves the chain profile-less` was pinned with a call count, since `expect(undefined).not.toHaveProperty` passes when `defaultProvider` was called with no argument at all; and the mocked clients' stub `destroy()` no longer strands the real `NodeHttpHandler`s.

One reviewer finding **corrected a claim of mine rather than the code**: the pre-existing keepAlive loop *did* assert a genuinely direct agent, as a third element. So no coverage was missing — what was wrong was a variable named `direct` holding the proxied agent. The comment and this body now say that.

### Second round, scoped to the delta of the first

Three of its five findings were about artifacts the *first fix round* had added, which is the useful half — a fix round is where new claims get written and nothing re-checks them.

- The header claimed no `// proxy-audit: ignore:` marker exists in `src/**`. **Nine do**, in `aws-proxy.ts`, `rie-client.ts`, `rest-v1-integrations.ts` and `agentcore-client.ts`. They belong to the sibling fetch audit, which shares the marker string through `hasOptOutMarker`, and are inert here only because none of those files references `@aws-sdk/client-`. The header now states that condition, since it is what would make one exempt a construction from all three policies.
- The `afterEach` handler teardown added in the first round is **withdrawn, not repaired**. Measured: `NodeHttpHandler.destroy()` is `this.config?.httpAgent?.destroy()` and `config` is assigned only inside `handle()`, which no case here calls because the clients are mocked — so the loop reached no agent and its comment claimed a discipline it was not performing. Nothing leaks, so the honest artifact is the absence plus a note, not a loop that reads as cleanup and does nothing.
- `splitAtSeam`'s first-wins seam selection was **the one changed line with no killing mutation** — flipping it to last-wins left all six cases and the live scan green, because no fixture spelled both seams. A both-seams fixture now kills it, and the residual it exposes joins the bounds list.
- The `profile-resolver` comment credited the wrong assertion: the call count is satisfied by a `defaultProvider()` called with no argument; `toBeDefined` is what rejects it.

## Mutation probe

Every fence was probed against the **full 4514-test suite** on this branch. `mutation -> tests that went red`:

| Mutation | Red |
|---|---|
| drop `{ profile }` at `ecr-puller.ts:292` | 2 — audit policy 2; `threads --profile INTO the proxy fragment` |
| drop it at `ecs-secrets-resolver.ts` | 1 — audit policy 2 |
| drop it at `agentcore-s3-bundle.ts` | 1 — audit policy 2 |
| drop it at `cfn-local-state-provider.ts` | 1 — audit policy 2 |
| drop it inside `buildStsClientConfig` | 1 — `threads the profile INTO the fragment` |
| `buildStsClientConfig` passes `profile ?? 'default'` | 1 — `leaves the chain profile-less when no profile is given` |
| move the spread LAST at `ecr-puller.ts:292` | 2 — audit policy 3; `keeps the site's assumed-role credentials` |
| move the spread LAST at `cloudfront-kvs-client.ts:73` | 1 — audit policy 3 |
| `formatAuthority(host, port)` -> `${host}:${port}` | 4 — the 2 new IPv6 cases; `composes no ${host}:${port} authority`; the fetch `[::2]` timeout |
| `formatAuthority(host, port)` -> `host + ':' + port` | 3 — the 2 new IPv6 cases; the fetch `[::2]` timeout |
| drop `AGENT_OPTS` from the direct agents | 1 — the corrected keepAlive case |
| drop `AGENT_OPTS` from the proxied agents | 1 — the corrected keepAlive case |
| swallow a malformed proxy URL into a direct fallback | 2 — both `UNPARSABLE value throws` cases |
| validate the proxy value eagerly, before the `NO_PROXY` decision | 1 — `a NO_PROXY-exempt target is unaffected by an unparsable proxy value` |
| hand-rolled `NO_PROXY` honouring only the UPPERCASE spelling | 1 — `honors the lowercase no_proxy spelling` |
| hand-rolled `NO_PROXY` without the `*` arm | 1 — `a leading ASTERISK is a suffix match too` |
| rewrite the resolved proxy URL to `http://` | 1 — `a SCHEME-LESS value takes the REQUEST scheme` |

And the fences added by the review round, probed the same way against the audit's own suite:

| Mutation | Red |
|---|---|
| drop the `STS_SEAM` arm from the order policy's seam scan | 1 — the order self-check (**green before this round**) |
| restore the profile policy's `continue` on `buildStsClientConfig(` | 1 — the profile self-check (**green before this round**) |
| make policies 2 and 3 ignore the opt-out marker | 2 — both new self-checks |
| report a wrong LINE from policies 2 and 3 | 2 — both new self-checks (**green before this round**, which asserted counts only) |
| `splitAtSeam` picks the LAST seam instead of the first | 1 — the profile self-check (**green before the second round**, which had no both-seams fixture) |
| `splitAtSeam` iterates `[PROXY_SEAM]` only | 1 — the profile self-check |
| use `PROXY_SEAM.length` for `open` unconditionally | 1 — the index arithmetic is pinned |

### Which cases are fences and which are characterization

Stated because the distinction is the whole point of the issue, and counting the second kind as the first is how a suite gets credited with cover it does not have.

**Discriminating fences** — killed by a plausible single edit to cdk-local's own code: both audit policies, all four behavioural profile/credentials cases, the IPv6 routing case, the two unparsable-value cases, and the corrected keepAlive case.

**Characterization of `proxy-from-env` / `https-proxy-agent`** — they pin behaviour cdk-local *depends on* but does not implement, so the "mutation" that kills them is a re-implementation rather than an edit: the `no_proxy` lowercase case, the `*.example.com` case, and the scheme-less pair. That is still worth having — a hand-rolled `NO_PROXY` matcher is exactly the plausible rewrite, and the probes above show one is caught — but they are not evidence about a line of cdk-local.

**Weakest of the set**, named rather than quietly counted: `a NO_PROXY entry exempts an IPv6 target in its BRACKETED spelling` shares its entire kill-set with the IPv6 routing case above it, and `the same scheme-less value stays plain HTTP for an http target` is killed only by a mutation that reddens **35** tests. Both earn their place as the second half of a pair and as documentation of a surprising spelling, not on an isolated kill.

## Verification

- `vp run verify` green, rc=0 (typecheck + lint + format, build, 251 files / 4514 tests, all 12 hook shell suites) — re-run after the rebase onto the peer merge and again after the review round.
- Diff is `tests/unit/**` only — no `src/**`, no `tests/integration/**` — so `integ-gate`'s scope short-circuit applies and no Docker run is owed.
- `/review-pr` tier: **inline** (591 LOC but 4 files → base inline; tests-only → down-bias, clamped). No `pr-review` marker is set: the tier does not require one, and a lane must never self-certify that marker.

## Not covered here

**TODO, filed as https://github.com/go-to-k/cdk-local/issues/669** — two user-facing gotchas this work measured are absent from the docs, and are left for a follow-up rather than widened into a tests-only PR: `HTTPS_PROXY=proxy.internal:3128` silently meaning TLS-to-proxy, and `NO_PROXY=*.example.com` not exempting the apex. Both behaviours are now pinned by tests here, so the evidence does not expire.

**Won't-do, decided and recorded:**

- The characterization cases named above are kept rather than deleted. They pin behaviour cdk-local depends on but does not implement; a hand-rolled `NO_PROXY` matcher is the plausible rewrite, and the probe table shows one is caught.
- Policy 2 flags a pre-built option bag (`buildProxyClientConfig(options)`) and a legitimate `credentials: fromIni({ profile: p })`. Both are false positives in the SAFE direction — an actionable, self-clearing message rather than a silent pass — and narrowing the rule to avoid them would cost the shape check its simplicity.
- An unbalanced (`args === null`) construction is skipped by policies 2 and 3 rather than reported twice. Policy 1 already reports it, so it cannot hide by being unparseable; stated in the bounds docblock.
- `aws-proxy.ts`'s `options.host ?? 'localhost'` / `options.port || (secure ? 443 : 80)` defaults remain unfenced. Pre-existing, outside this issue's asks, and unreachable through every current caller, which supplies both.
- No teardown of the `NodeHttpHandler`s in `ecr-puller-profile.test.ts`, with the measurement recorded in an in-file comment. The handler never wires its agent until `handle()` runs, so there is nothing to destroy and no leak to prevent.
- `splitAtSeam`'s `at >= 0` guard has no killing mutation, and none is added. Narrowing it to `at > 0` only skips a seam at index 0, which occurs solely in `new X(buildStsClientConfig(...))` — where the whole argument list *is* the call, so nothing outside it can spell `profile` and the verdict is unchanged. It is an equivalent mutant on every reachable input, not a coverage gap.

Closes #648
