### PR TITLE
ci: add Dependabot config for npm and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot version updates.
+#
+# Commit-message prefixes are chosen against this repo's semantic-release
+# rules (.releaserc): `chore(...)` / `ci(...)` do NOT cut a release, which is
+# deliberate — runtime deps use caret ranges, so users already pick up newer
+# AWS SDK clients on install; a lockfile/range bump only affects dev + CI.
+# All prefixes are in pr-title-check.yml's allowed types.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      # The @aws-sdk/client-* deps release in lockstep; one PR, not many.
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
+      dev-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` (version-update config; previously absent), mirroring go-to-k/cdkd#2486:

- **npm** (pnpm-lock.yaml), weekly (Mon, Asia/Tokyo): an `aws-sdk` group (the `@aws-sdk/*` clients release in lockstep, so they bump as one PR), a `dev-dependencies` group, individual PRs for the remaining production deps, `open-pull-requests-limit: 10`.
- **github-actions**, weekly, all actions grouped into one PR.

Commit-message prefixes (`chore(deps)` / `chore(deps-dev)` / `ci(deps)`) are allowed types in `pr-title-check.yml` and do not trigger a semantic-release release (`.releaserc` releases only on `feat` / `fix` / `perf` / breaking / revert) — deliberate, since runtime deps use caret ranges and a range/lockfile bump only affects dev + CI.

## Test plan

- `vp check --fix` + `vp run check` + `vp run build`: pass (the formatter normalized the YAML to this repo's quote style)
- `vp test run`: 251 files / 4627 tests passed, rooted in this worktree
- Config validated against SchemaStore's `dependabot-2.0.json` with ajv: valid
- Live behavior cannot be exercised pre-merge — Dependabot only reads the file from the default branch; the first scheduled run after merge is the real confirmation.

https://claude.ai/code/session_016o9o8ecyjHJxvUvSRs7tT5
