### PR TITLE
chore(ci): add workflow_dispatch to Release and document the stale release-PR trap

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -179,6 +179,31 @@ would restore CI on it. (Unlike the sibling cdkd, this repo has no
 ci-green-gate hook, so nothing agent-side blocks on the missing checks
 either.)
 
+**A standing release PR goes STALE, and looks fine while it is.**
+release-please does NOT rebuild a release PR whose computed release is
+unchanged — it logs `PR #N remained the same` and leaves the branch on the
+base it was cut from. So anything that lands on `main` afterwards in a file
+release-please OWNS (`CHANGELOG.md`, `package.json`'s version,
+`.release-please-manifest.json`) is missing from that branch, and GitHub
+still reports the PR **MERGEABLE** — a stale copy is not a conflict.
+Merging it then REVERTS that change. Measured in the sibling cdkd: release
+PR go-to-k/cdkd#2503 was cut before the CHANGELOG normalization merged, its
+branch still carried the pre-normalization file, and merging it would have
+undone 285 header conversions.
+
+**Rule: after any PR that edits `CHANGELOG.md`, the version in
+`package.json`, or `.release-please-manifest.json`, check whether a release
+PR is open — and if one is, recreate it.** Close it, delete its branch, and
+re-run the Release workflow (`workflow_dispatch`, added for exactly this;
+`gh workflow run release.yml`). release-please then recomputes the identical
+release from current `main`. Firing it is always safe: release-please is
+idempotent — with no new releasable commits it recreates the same release
+PR, and with none at all it does nothing.
+
+```bash
+gh pr list --state open --search "chore(release) in:title"   # is one standing?
+```
+
 ## Important implementation details
 
 - **ESM Modules**: `package.json` declares `"type": "module"`. All imports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,32 @@ name: Release
 # merges it via the web UI. To get CI on release PRs, hand the release-please
 # step a PAT. (Unlike the sibling cdkd, this repo has no ci-green-gate hook,
 # so nothing agent-side blocks on the missing checks either.)
+#
+# Known behavior 2 — a STANDING release PR goes STALE, and looks fine while it
+# is: release-please does not rebuild a release PR whose computed release is
+# unchanged. It logs `PR #N remained the same` and leaves the branch on the
+# base it was cut from. So anything that lands on main afterwards in a file
+# release-please OWNS (CHANGELOG.md, package.json's version,
+# .release-please-manifest.json) is simply missing from that branch — and
+# GitHub still reports the PR MERGEABLE, because a stale copy is not a
+# conflict. Merging it then REVERTS that change. Measured in the sibling cdkd:
+# release PR go-to-k/cdkd#2503 was cut before the CHANGELOG normalization
+# merged, its branch still carried the pre-normalization file, and merging it
+# would have undone 285 header conversions.
+#
+# Remedy: CLOSE the release PR, DELETE its branch, and re-run this workflow —
+# release-please recomputes the identical release from current main. That is
+# what the `workflow_dispatch` trigger below is for; without it the only way
+# to re-run is `gh run rerun` on an old push run. It is safe to fire at any
+# time because release-please is idempotent: with no new releasable commits it
+# recreates the same release PR, and with none at all it does nothing.
 
 on:
   push:
     branches:
       - main
+  # Manual re-run, for the stale-standing-PR remedy above.
+  workflow_dispatch:
 
 # Serialize Release workflow runs so a back-to-back merge (#204 + #205
 # landed within ~30s and the earlier run's `git push --tags HEAD:main`


### PR DESCRIPTION
## Summary

Final follow-up to the release-please migration (go-to-k/cdk-local#692 and go-to-k/cdk-local#696), from an operational trap measured live in the sibling cdkd. Two changes: a `workflow_dispatch` trigger on the Release workflow, and the trap written down where an agent or maintainer will read it.

## Mechanism

release-please does **not** rebuild a standing release PR whose computed release is unchanged. It logs `PR #N remained the same` and leaves the branch on the base it was cut from.

So anything that lands on `main` afterwards in a file release-please **owns** — `CHANGELOG.md`, `package.json`'s version, `.release-please-manifest.json` — is simply missing from that branch. The dangerous part is the symptom: GitHub still reports the PR **MERGEABLE**, because a stale copy is not a conflict. Merging it takes the branch's stale copy and **REVERTS** that change.

**Measured in cdkd**: release PR go-to-k/cdkd#2503 was cut before the CHANGELOG normalization merged; its branch still carried the pre-normalization file, and merging it would have undone **285 header conversions**. The remedy — close the release PR, delete its branch, re-run the release workflow so release-please recomputes the identical release from current `main` — was verified there (go-to-k/cdkd#2508 now inserts the entry at the top).

Executing that remedy exposed a second gap: the workflow triggers only on `push: main`, so there is no way to re-run it on demand — it took a `gh run rerun` against an old push run.

## Changes

**1. `.github/workflows/release.yml`** — `workflow_dispatch:` added beside the existing `push: main` trigger, so the remedy has a supported way to run (`gh workflow run release.yml`, or the Actions UI). A header note records the behavior, its MERGEABLE-while-stale symptom, the cdkd measurement, and why firing the trigger is always safe: release-please is idempotent — with no new releasable commits it recreates the same release PR, and with none at all it does nothing.

The filename is unchanged, so the npm OIDC trusted-publishing binding (which is to the workflow *filename* on npmjs.com) is untouched — adding a trigger does not affect it.

**2. `.claude/CLAUDE.md`** — the release-flow section carries the same warning, ending with the actionable rule:

> After any PR that edits `CHANGELOG.md`, the version in `package.json`, or `.release-please-manifest.json`, check whether a release PR is open — and if one is, recreate it (close, delete branch, re-run the workflow).

with the one-line check to run:

```bash
gh pr list --state open --search "chore(release) in:title"
```

## No fence test

Deliberate: `workflow_dispatch` is a convenience trigger, not an invariant. Pinning it would add nothing a reader of the header does not get, and would only make the file harder to edit. The v0 fence continues to cover what *is* invariant in this workflow (the publish-job guard arms, the `if:` gate, `id-token: write`, the sha pin) and stays green — `release.yml` is one of its inputs, so the whole suite is the real check on this edit.

## Test plan

- `vp run check` — pass (rc=0).
- `vp run build` — pass (rc=0).
- `vp test run` — 252 files, 4634 tests, all pass; Type Errors: no errors. Includes the 7-case v0 fence, which reads this workflow.
- `vp run test:hooks` — 70 pass / 0 fail (rc=0).
