### PR TITLE
chore(hooks): refuse a PR-shaped Session-fit deferral, warn before an integ run on a stale base, and take a shell WORD for every flag value

### DIFF
--- a/.claude/hooks/_command-match.sh
+++ b/.claude/hooks/_command-match.sh
@@ -56,7 +56,89 @@ gate_segments_raw() {
     # `echo dont do it`), and treating it as one swallowed every command after it
     # — fail open. The pass is redone with that character literal
     # (go-to-k/cdkd#2130).
-    function flush_line(line,   i, n, c, out) {
+    # QUOTE- AND ESCAPE-AWARE. A naive depth count returns an EARLY closer for
+    # a `)` that is data rather than structure, and an early closer is worse
+    # than none: `return 0` falls back to the stack (the benign direction),
+    # while a wrong index truncates the body and resumes with `q` still `"`, so
+    # the REST of the real body is parsed as quoted prose and the verb inside it
+    # never starts a segment. Measured, `gate_matches ... GATE_RE_GIT_COMMIT`:
+    #
+    #   echo "$(echo <sq>)<sq> ; git commit -m x)"   was UNGATED
+    #   echo "$(echo \) ; git commit -m x)"          was UNGATED
+    #   echo "$(git commit -m x)"                    GATED  (control)
+    #
+    # where <sq> is a literal single quote, spelled out rather than written:
+    # this whole awk program is a SHELL single-quoted string, so one apostrophe
+    # in a comment ends it and hands the rest of the file to bash as code. That
+    # has now broken this file three times in one session.
+    #
+    # Unbalanced parens inside quotes are ordinary -- grep counting a paren, sed
+    # substituting one, awk -F with one -- so this is not a corner case.
+    function close_paren(line, from,   j, depth, c, iq, d) {
+      depth = 1; iq = ""
+      for (j = from; j <= length(line); j++) {
+        c = substr(line, j, 1)
+        # SINGLE quotes first, and BEFORE the backslash arm: inside them a
+        # backslash is LITERAL, so `\047a\\\047` closes at its second quote.
+        # Skipping the backslash there consumed the closer, left `iq` open, and
+        # the span never closed -- and in the QUOTED branch a `return 0` does
+        # NOT fall back harmlessly: `extra` is populated only when a closer is
+        # found, so the body was never scanned. Measured, that made
+        # `echo "$(printf \047a\\\047 ; git commit -m x)"` UNGATED.
+        # ... but an ANSI-C span is the OPPOSITE: in `$\047...\047` a backslash
+        # ESCAPES, so `\\\047` does NOT close it. Tracked as its own state
+        # rather than folded into the plain single-quote arm, which read the
+        # escaped quote as the closer, left `iq` open past the real one, and
+        # made the same shape ungated the other way round:
+        #   echo "$(printf $\047a\\\047b\047 ; git commit -m x)"   ungated
+        # This is the rule the `$GW` prelude in this same file already states.
+        #
+        # The sigil is found by scanning FORWARD from the `$`, never by looking
+        # BACK from the quote. A one-character look-back cannot tell a real
+        # ANSI-C sigil from a `$` that is ESCAPED, or that is the second half
+        # of `$$` (the PID) -- both are a literal dollar followed by a PLAIN
+        # single-quoted string, where a backslash-quote CLOSES. Reading those
+        # as ANSI-C held `iq` open past the real closer, `close_paren` returned
+        # 0, and in the double-quoted branch the body was never scanned as a
+        # command at all. Measured in cdkd by differential fuzz against real
+        # bash over 20,312 substitution bodies: the look-back spelling produced
+        # 15 fail-opens the revision before it did not have.
+        #
+        # Forward is correct BECAUSE of the arm order: an escaped `$` is eaten
+        # by the backslash arm below before its `$` is ever examined here, and
+        # `$$` steps over its own second character.
+        if (iq == "A") { if (c == "\\") { j++; continue }
+                         if (c == "\047") iq = ""; continue }
+        if (iq == "\047") { if (c == iq) iq = ""; continue }
+        if (c == "\\") { j++; continue }
+        if (iq != "") { if (c == iq) iq = ""; continue }
+        if (c == "$") { d = substr(line, j + 1, 1)
+                        if (d == "$") { j++; continue }
+                        if (d == "\047") { iq = "A"; j++; continue }
+                        continue }
+        if (c == "\"") { iq = c; continue }
+        if (c == "\047") { iq = "\047"; continue }
+
+        if (c == "(") depth++
+        else if (c == ")") { depth--; if (depth == 0) return j }
+      }
+      return 0
+    }
+    # The offset of the CLOSING backtick relative to `from`, or 0 when the span
+    # does not close. `index()` cannot be used: it takes the next backtick even
+    # when it is BACKSLASH-ESCAPED, which truncated the body the same way an
+    # early paren did -- `echo "\x60echo \\\x60 ; git commit -m x\x60"` was
+    # UNGATED. Returns the same 1-based offset `index()` did, so call sites are
+    # unchanged.
+    function close_backtick(s,   j, c) {
+      for (j = 1; j <= length(s); j++) {
+        c = substr(s, j, 1)
+        if (c == "\\") { j++; continue }
+        if (c == "\140") return j
+      }
+      return 0
+    }
+    function flush_line(line,   i, n, c, out, cp, bt) {
       out = ""; n = length(line)
       for (i = 1; i <= n; i++) {
         c = substr(line, i, 1)
@@ -88,6 +170,28 @@ gate_segments_raw() {
           # test review).
           if (c == "\\") { out = out c substr(line, i + 1, 1); i++; continue }
           if ((c == "\"" || c == "'"'"'") && c != ignore_q) { q = c; out = out c; continue }
+          # An ANSI-C span, the same state close_paren tracks. Without it this
+          # machine opens a PLAIN span on the quote and the escaped quote
+          # inside closes it early, so the rest of the body is read as code and
+          # a second substitution splits the line in the wrong place. Measured
+          # in cdkd against its real branch-gate: that shape passed a commit on
+          # main and a git checkout at rc=0, on main and on every revision of
+          # the branch that fixed close_paren alone. The two quote machines in
+          # this file must agree -- one of them being right is what let it
+          # survive the round that fixed the other.
+          #
+          # `$$` FIRST, as close_paren does it: the second dollar is the PID s,
+          # and what follows is a PLAIN span where the escaped quote CLOSES.
+          # Adding the ANSI-C arm without this step-over opens a span on
+          # `$$\047` that never closes, so the rest of the line -- separators
+          # included -- becomes data, and both the commit and the checkout gate
+          # walk through. Measured in cdkd, where the arm shipped without it for
+          # one round. Porting one arm of a pair is how the round before that
+          # arrived half-applied; diff the two machines arm by arm.
+          if (c == "$" && substr(line, i + 1, 1) == "$") { out = out c substr(line, i + 1, 1); i++; continue }
+          if (c == "$" && substr(line, i + 1, 1) == "\047" && ignore_q != "\047") {
+            q = "A"; out = out c substr(line, i + 1, 1); i++; continue
+          }
           # These three consume their `(` with `i++`, so it never reaches the
           # generic paren counter above. A NESTED substitution therefore closed
           # the OUTER one a paren early, which broke both ways:
@@ -121,17 +225,52 @@ gate_segments_raw() {
           out = out c
           continue
         }
-        if (c == "\\" && q == "\"") { out = out c substr(line, i + 1, 1); i++; continue }
-        if (c == q) { q = ""; out = out c; continue }
+        # A backslash ESCAPES in a double-quoted span and in an ANSI-C one; in
+        # a plain single-quoted span it is literal, which is why q == \047 is
+        # not in this test.
+        if (c == "\\" && (q == "\"" || q == "A")) { out = out c substr(line, i + 1, 1); i++; continue }
+        if (c == q || (q == "A" && c == "\047")) { q = ""; out = out c; continue }
         # A command substitution inside a DOUBLE-quoted span RUNS. Leaving it
         # quoted is what let the bypass above through. Inside a SINGLE-quoted
         # span it is literal, so nothing changes there -- that asymmetry is the
         # whole point, and it is why this branch tests q rather than assuming.
+        # DUAL-EMIT when the span CLOSES on this line: collapse it to the
+        # placeholder inline and queue the body as its own segment. The stack
+        # arms below still handle a span that runs past the newline.
+        #
+        # WHY, measured: pushing onto the stack emits a `\n`, which SPLITS the
+        # enclosing text. A body like
+        #
+        #   --body "Session-fit: next (not this session) -- the `x` fix needs
+        #           its own PR"
+        #
+        # became three segments, so `Session-fit:` and the PR-shaped clause
+        # landed in different ones and issue-deferral-criteria-gate returned 0
+        # where cdkd and cdk-real-drift both return 2. Backticks and `$( )` are
+        # ordinary in the bodies this flow writes, so that is a live bypass, not
+        # a corner. Collapsing keeps the enclosing text ONE segment while the
+        # body stays visible as a command in its own right -- the same trade
+        # cdkd makes (go-to-k/cdkd#2027 / go-to-k/cdkd#2339).
         if (q == "\"" && c == "$" && substr(line, i + 1, 1) == "(") {
+          cp = close_paren(line, i + 2)
+          if (cp > 0) {
+            extrabuf[++extran] = substr(line, i + 2, cp - i - 2)
+            out = out SEP_SUBST
+            i = cp
+            continue
+          }
           sdepth++; squote[sdepth] = q; stype[sdepth] = "("; sparen[sdepth] = 1
           q = ""; out = out "\n"; i++; continue
         }
         if (q == "\"" && c == "`") {
+          # Backticks do not nest, so the closer is simply the next one.
+          bt = close_backtick(substr(line, i + 1))
+          if (bt > 0) {
+            extrabuf[++extran] = substr(line, i + 1, bt - 1)
+            out = out SEP_SUBST
+            i = i + bt
+            continue
+          }
           sdepth++; squote[sdepth] = q; stype[sdepth] = "`"; sparen[sdepth] = 0
           q = ""; out = out "\n"; continue
         }
@@ -212,10 +351,35 @@ gate_segments_raw() {
       }
       open_span = q
     }
-    function run_pass(   i) {
+    function run_pass(   i, rounds, batch, bn, bi, blines) {
       q = ""; tag = ""; pending = ""; outn = 0; open_span = ""; sdepth = 0
+      extran = 0; delete extrabuf
       for (i = 1; i <= total; i++) emit(i)
       if (pending != "") outbuf[++outn] = flush_line(pending)
+      # Drain the substitution bodies queued by flush_line, so a command
+      # SUBSTITUTION is still scanned as a command in its own right. Bounded: a
+      # body can queue more (nested substitutions), so cap the rounds rather
+      # than trusting the input to terminate. Each body is run through
+      # flush_line so its OWN separators split it.
+      rounds = 0
+      while (extran > 0 && rounds < 8) {
+        bn = extran; batch = ""
+        for (bi = 1; bi <= bn; bi++) batch = batch extrabuf[bi] "\n"
+        extran = 0; delete extrabuf
+        q = ""
+        bi = split(batch, blines, "\n")
+        for (i = 1; i <= bi; i++) {
+          if (blines[i] == "") continue
+          outbuf[++outn] = flush_line(blines[i])
+        }
+        rounds++
+      }
+      # Hitting the cap DROPS the remaining bodies, i.e. stops scanning
+      # commands, so it is announced rather than swallowed -- a silent drop is
+      # the fail-open direction this file exists to avoid.
+      if (extran > 0) {
+        printf "gate_segments: substitution nesting deeper than 8; %d queued body/bodies were NOT scanned\n", extran > "/dev/stderr"
+      }
     }
     BEGIN { ignore_q = "" }
     { raw[NR] = $0; total = NR }
@@ -1327,4 +1491,309 @@ gate_target_dir() {
     break
   done < <(gate_segments "$cmd")
   printf '%s' "$target"
+}
+
+# ---------------------------------------------------------------------------
+# PORTED FROM cdkd (go-to-k/cdkd#2639, tip). Kept TEXTUALLY IDENTICAL to that
+# copy apart from path references and the per-repo consumer list above, so a
+# `diff` across the three repos is the review.
+#
+# The FIRST port of this block was one revision STALE and shipped two live
+# fail-opens cdkd had already fixed (a mid-word `$'...'` span, and every path
+# byte >= 0x80 turned into U+FFFD). It passed its own four-arm
+# `gate_perl_word_ok` because all four assertions were pure ASCII at word
+# position 0. That is why the probe now has SIX arms, two of them chosen to
+# fail exactly that stale copy -- verified: the stale block passes its own
+# probe and is rejected by this one.
+# ---------------------------------------------------------------------------
+# ── A shell WORD, for the gates that extract with PERL ─────────────────────
+#
+# `GATE_PATH_TOKEN` and `_GATE_WORD_CHAR` are bash EREs, usable only from
+# `[[ =~ ]]`. FOUR gates -- issue-deferral-criteria, issue-dup-check,
+# issue-classification-label and pr-body-item-number -- pull a `--body-file`
+# / `-F` path or an
+# inline `--body` value out of RAW command text with `perl -0777` instead,
+# because they need a GLOBAL scan over a multi-line slurp and `[[ =~ ]]` gives
+# neither. THIS LIST IS PER REPO: cdkd, which the class is ported from, has a
+# larger set (it also has gh-body-english, pr-body-item-number and
+# commit-prefix-scope). Derive it rather than trusting this sentence --
+# `grep -l GATE_PERL_WORD .claude/hooks/*-gate.sh` -- because an earlier
+# revision of this comment in cdkd said "three" while five files consumed it,
+# which is the same stale-sibling-note class the constant exists to end. Derive the list rather than trusting this
+# sentence -- `grep -l GATE_PERL_WORD .claude/hooks/*-gate.sh` -- because an earlier
+# revision of THIS comment said "three" while five files consumed it, which is
+# the same stale-sibling-note class the constant exists to end.
+# All of them spelled the value class `(["']?)([^"'\s]+)\1`, and that shape had
+# THREE MEASURED holes, all fail-OPEN (go-to-k/cdkd, 2026-09-05):
+#
+#   gh issue create --body-file "<dir with space>/x.md"
+#     The bare class cannot span the space, and with the optional quote group
+#     unset it cannot start on the quote either, so NOTHING is extracted and
+#     the gate judges an empty body. Measured: issue-deferral-criteria-gate
+#     rc=0 on a PR-shaped deferral where the unquoted spelling gave 2, and
+#     gh-body-english-gate rc=0 on a JAPANESE body where the unquoted spelling
+#     gave 2 -- the English-only rule was bypassable by putting the body file
+#     in a directory whose name contains a space.
+#
+#   gh api repos/O/R/issues -f body='<text>'
+#     gh's OWN documented spelling puts the quote INSIDE the value, after the
+#     `body=`. An alternation tried AFTER the literal `body=` falls through to
+#     `\S+` and captures `body='a`. Measured on issue-deferral-criteria-gate:
+#     rc=0, where `-f 'body=<text>'` (quote OUTSIDE, the only shape its suite
+#     covered) gave 2.
+#
+# So the value class is defined ONCE, here, rather than a fourth time in the
+# next hook that needs it. `GATE_PERL_WORD` is a perl PRELUDE, not a regex: a
+# caller prefixes it to its own program --
+#
+#   perl -0777 -ne "$GATE_PERL_WORD"'
+#     while (/--body-file[=\s]+($GW)/g) { print gate_unq($1), "\n"; }'
+#
+# -- and it defines two names:
+#
+#   $GW        ONE shell word that may EMBED quoted spans: the perl twin of
+#              `_GATE_WORD_CHAR`. `body='a b c'` is one word, `"/a b/x.md"` is
+#              one word, and a bare run still stops at whitespace.
+#   gate_unq   the shell's own unquoting of such a word, so a caller gets the
+#              string gh actually receives: spans unwrapped, and `\X` unescaped
+#              exactly where the shell would unescape it (inside a
+#              double-quoted span only for `\ " $` and a backtick; never inside
+#              a single-quoted one, which takes no escapes).
+#
+# UNBALANCED quotes are not a regression risk here: `$GW`'s bare alternative
+# excludes both quote characters, so a word like `/tmp/o'neill/x.md` stops at
+# the apostrophe -- which is exactly where the old class stopped too.
+#
+# A hook using this MUST also assert `GATE_PERL_WORD` is non-empty in its
+# library-load guard. Left undefined, `$GW` interpolates as the EMPTY string,
+# `($GW)` then matches empty at every position, and the extraction yields empty
+# values that every caller skips -- a silent fail-open, which is the exact
+# class this constant closes.
+#
+# The apostrophes below are spelled `\x27` -- a PERL escape, valid in a regex
+# and in a substitution alike -- because this is a bash SINGLE-QUOTED string
+# and a literal apostrophe would end it. The `'"'"'` idiom used elsewhere in
+# this file would work too, and is unreadable at this density.
+GATE_PERL_WORD='
+  # ANSI-C quoting is the FIRST alternative on purpose. `$` is an ordinary
+  # character to the bare class below, so without this arm `$\x27...\x27` was
+  # split into a bare `$` plus a plain single-quoted span -- which took the body
+  # LITERALLY, so `--body $\x27<CJK text>\x27` reached the English-only gate as
+  # ASCII -- a `$` followed by the same bytes read as literal characters -- and
+  # passed, while bash sent the DECODED text to GitHub. The characters are
+  # described rather than written here for the reason the gate itself enforces:
+  # this file lands in an OSS repository, and `non-english-text-gate` blocks the
+  # merge of any PR whose diff carries them, including in a comment explaining
+  # them. Its inner `\\.` also differs from the plain single-quote arm:
+  # inside `$\x27...\x27` a backslash ESCAPES, so `\\\x27` does not close it.
+  my $GW = qr/(?:\$\x27(?:[^\x27\\]|\\.)*\x27|"(?:[^"\\]|\\.)*"|\x27[^\x27]*\x27|\\.|[^\s"\x27;|&()<>\x60])+/;
+  # Append-as-BYTES normaliser. Perl strings carry an internal
+  # character-vs-bytes flag, and the callers of this prelude run under mixed
+  # `-C` settings: the path extraction has none, the non-English body scan uses
+  # `-CSD`, where the input is ALREADY decoded. Mixing the two in one result
+  # produces a string that is half characters and half bytes -- which is exactly
+  # how a literal accent beside an escape defeated the class test. Everything
+  # here is bytes; whoever needs characters decodes once, at its own call site.
+  sub gate_bytes {
+    my ($t) = @_;
+    utf8::encode($t) if utf8::is_utf8($t);
+    return $t;
+  }
+
+  # ANSI-C escape decoding, used only by the `$\x27...\x27` arm of gate_unq.
+  #
+  # EVERYTHING IS NORMALISED TO BYTES AND DECODED ONCE AT THE END, and each half
+  # of that is load-bearing:
+  #
+  #   bash itself is mixed -- `\xHH` and `\NNN` emit raw BYTES while `\uXXXX`
+  #   emits a CHARACTER -- so the only representation both agree on is the byte
+  #   string bash would actually pass. Hence `\u` is encoded rather than left
+  #   wide.
+  #
+  #   The LITERAL run has to be encoded too, and missing that was a live
+  #   BYPASS. The callers run under mixed `-C` settings: the path extraction has
+  #   none, the non-English body scan uses `-CSD`, where the input string is
+  #   ALREADY decoded. So a literal non-ASCII character sitting next to an
+  #   escape produced a string that was half characters and half bytes, the
+  #   closing `utf8::decode` refused it as invalid UTF-8, and the whole value
+  #   stayed Latin-1 -- which `NON_ENGLISH_RE` (CJK / Hangul) never matches.
+  #   Measured against the real hook:
+  #
+  #     --body $\x27\u65e5\u672c\u8a9e\x27         rc=2   blocked
+  #     --body $\x27<one accent>\u65e5\u672c\u8a9e\x27  rc=0   BYPASS
+  #     --body $\x27<one accent>\xe6\x97\xa5\x27        rc=0   BYPASS
+  #
+  #   Both bypasses publish Japanese, and the carrier is an ordinary Latin-1
+  #   accent that is not itself blocked, so nothing looks wrong.
+  #
+  #   `utf8::is_utf8` guards the encode: encoding unconditionally is correct for
+  #   the `-CSD` caller and DOUBLE-encodes for the byte-mode ones, which is the
+  #   same defect facing the other way.
+  #
+  # A value that is not valid UTF-8 once assembled is left exactly as built --
+  # utf8::decode returns false without modifying it, which is the right answer
+  # for a genuinely binary `\xNN` payload.
+  sub gate_ansi_c {
+    my ($v) = @_;
+    my %simple = ("a"=>"\a","b"=>"\b","e"=>"\e","E"=>"\e","f"=>"\f",
+                  "n"=>"\n","r"=>"\r","t"=>"\t","v"=>"\013",
+                  "\\"=>"\\","\x27"=>"\x27","\""=>"\"","?"=>"?");
+    # `\G` + `pos()`, never a destructive `s/^...//`. Each substitution copies
+    # the REMAINDER of the string, so a per-character loop over an n-character
+    # value is O(n^2): measured at 0.36 s for 5k escapes, 2.7 s for 20k and
+    # 14.5 s for 50k, against the 10 s PreToolUse timeout in
+    # .claude/settings.json -- and a timed-out hook is, for a gate, a SILENT
+    # PASS. Scanning leaves the string alone and is linear.
+    pos($v) = 0;
+    my $o = "";
+    my $n = length($v);
+    while (pos($v) < $n) {
+      # `& 255`: bash truncates an escape to a byte, so `\400` is NUL, not U+0100.
+      if    ($v =~ /\G\\x([0-9A-Fa-f]{1,2})/gc)  { $o .= chr(hex($1) & 255); }
+      elsif ($v =~ /\G\\([0-7]{1,3})/gc)         { $o .= chr(oct($1) & 255); }
+      elsif ($v =~ /\G\\u([0-9A-Fa-f]{1,4})/gc)  { $o .= gate_bytes(pack("U", hex($1))); }
+      elsif ($v =~ /\G\\U([0-9A-Fa-f]{1,8})/gc)  { $o .= gate_bytes(pack("U", hex($1))); }
+      elsif ($v =~ /\G\\c(.)/gcs)                { $o .= chr(ord(uc $1) & 255 ^ 64); }
+      elsif ($v =~ /\G\\(.)/gcs)                 { $o .= gate_bytes(exists $simple{$1} ? $simple{$1} : "\\" . $1); }
+      elsif ($v =~ /\G([^\\]+)/gcs)              { $o .= gate_bytes($1); }
+      elsif ($v =~ /\G(.)/gcs)                   { $o .= gate_bytes($1); }
+      else                                        { last; }
+    }
+    return $o;
+  }
+
+  # Byte string -> character string, lenient. The alternation is the standard
+  # UTF-8 well-formedness table (RFC 3629): no overlongs, no surrogates, no
+  # code point above U+10FFFF -- an over-permissive matcher here would decode a
+  # surrogate-encoded sequence into a character the class test then treats as
+  # ordinary text.
+  sub gate_utf8_lenient {
+    my ($b) = @_;
+    pos($b) = 0;
+    my $o = "";
+    my $n = length($b);
+    # `\G` + `pos()` for the same reason as gate_ansi_c: a destructive loop here
+    # is O(n^2) and the hook timeout is a silent pass.
+    while (pos($b) < $n) {
+      if ($b =~ /\G((?:[\x00-\x7F]|[\xC2-\xDF][\x80-\xBF]|\xE0[\xA0-\xBF][\x80-\xBF]|[\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}|\xED[\x80-\x9F][\x80-\xBF]|\xF0[\x90-\xBF][\x80-\xBF]{2}|[\xF1-\xF3][\x80-\xBF]{3}|\xF4[\x80-\x8F][\x80-\xBF]{2})+)/gcs) {
+        my $t = $1;
+        utf8::decode($t);
+        $o .= $t;
+      } elsif ($b =~ /\G./gcs) {
+        $o .= "\x{FFFD}";
+      } else {
+        last;
+      }
+    }
+    return $o;
+  }
+  sub gate_unq {
+    my ($t) = @_;
+    pos($t) = 0;
+    my $o = "";
+    my $n = length($t);
+    # `\G` + `pos()`, not `s/^...//`: see gate_ansi_c. A value made of many
+    # adjacent quoted chunks is a per-span loop, and the same O(n^2) applies.
+    while (pos($t) < $n) {
+      if ($t =~ /\G"((?:[^"\\]|\\.)*)"/gcs) {
+        my $s = $1; $s =~ s/\\([\\"\$`])/$1/gs; $o .= gate_bytes($s);
+      } elsif ($t =~ /\G\$\x27((?:[^\x27\\]|\\.)*)\x27/gcs) { $o .= gate_ansi_c($1);
+      } elsif ($t =~ /\G\x27([^\x27]*)\x27/gcs)             { $o .= gate_bytes($1);
+      } elsif ($t =~ /\G\\(.)/gcs)                          { $o .= gate_bytes($1);
+      # `\$(?!\x27)`: an ordinary `$` is legitimate text (`cost $5`,
+      # `hello$USER`) and must be consumed here, but a `$` that OPENS an ANSI-C
+      # span must be left for the arm above. Without the look-ahead this run ate
+      # the sigil greedily, so the ANSI-C arm only ever fired at word position 0
+      # -- one ASCII character before it defeated the whole decode, and
+      # `gh api -f body=$\x27...\x27` was bypassed UNCONDITIONALLY because
+      # `body=` is always such a prefix.
+      } elsif ($t =~ /\G((?:[^"\x27\\\$]|\$(?!\x27))+)/gcs) { $o .= gate_bytes($1);
+      } elsif ($t =~ /\G(.)/gcs)                            { $o .= gate_bytes($1);
+      } else { last; }
+    }
+    return $o;
+  }
+'
+
+# `GATE_PERL_WORD` is one shared literal that five blocking gates interpolate,
+# so its failure mode is the one this whole mechanism must not have: every
+# consumer runs `perl ... 2>/dev/null`, so a prelude that is PRESENT but does
+# not COMPILE produces no output, no stderr, and no exit-code change -- the
+# gates simply extract nothing and pass. Measured: a non-empty, non-compiling
+# prelude silently disarmed four gates at once (a Japanese body, a PR-shaped
+# deferral, an unlabelled `Severity: high`, and a bare `#4` all reached rc=0).
+#
+# `[ -n "$GATE_PERL_WORD" ]` cannot see that, so it is not the guard -- it is
+# only the cheap first half. This is the second half: run the prelude on a
+# known input and require the known answer. Call it AFTER a gate has armed, not
+# at library-load: the library is sourced by every hook on every Bash call,
+# while an armed gate is already about to fork perl anyway.
+#
+# Returns 0 when the prelude is usable, 1 otherwise. Callers must fail CLOSED.
+# Memoised fail-closed wrapper: probe once per process, at the first point a
+# gate is actually about to extract, then remember. `$1` is the gate's own name
+# so the refusal says which one refused.
+# RESET AT LOAD. `__GATE_PW_OK` is an ordinary shell variable, so without this
+# it is inheritable: `__GATE_PW_OK=1 gh issue create ...` made the probe report
+# a working prelude it never ran, and a Japanese body passed at rc=0 against a
+# deliberately broken library (measured). A guard whose whole job is to fail
+# closed on a tampered library must not be disable-able by one env var.
+__GATE_PW_OK=
+
+gate_perl_word_or_die() {
+  if [ "${__GATE_PW_OK:-}" != "1" ]; then
+    if gate_perl_word_ok; then
+      __GATE_PW_OK=1
+    else
+      echo "Blocked by $1: .claude/hooks/_command-match.sh defines GATE_PERL_WORD," >&2
+      echo "but running it does not return the expected value -- the prelude is missing," >&2
+      echo "outdated, or does not compile. Every extraction in this gate runs perl with" >&2
+      echo "stderr discarded, so a broken prelude would silently extract NOTHING and the" >&2
+      echo "gate would PASS whatever it was meant to refuse. Refusing instead." >&2
+      echo "Fix the library (or restore it from origin/main) and retry." >&2
+      return 1
+    fi
+  fi
+  return 0
+}
+
+gate_perl_word_ok() {
+  [ -n "${GATE_PERL_WORD:-}" ] || return 1
+  # FOUR dimensions, not one. The first cut asserted a single quoted-span pair,
+  # and a review measured two preludes that passed it while carrying a live
+  # bypass: a one-revision-STALE library (no ANSI-C arm -- which is exactly the
+  # state a sibling repo mid-port is in), and one hardcoded to the probe's own
+  # input. A guard that pins one dimension certifies one dimension.
+  #
+  # Each line below is a different arm of `$GW` / `gate_unq`, chosen because
+  # each was a measured fail-open in its own right:
+  #   1  a QUOTED span containing a space
+  #   2  a BACKSLASH-escaped space
+  #   3  an ANSI-C span, decoded rather than taken literally
+  #   4  the metacharacter STOP (the word must not swallow the `;`)
+  gate_pw_probe_() {
+    printf '%s' "$2" | perl -0777 -ne "$GATE_PERL_WORD"'
+      while (/--body-file[=\s]+($GW)/g) { print gate_unq($1) }' 2>/dev/null
+  }
+  [ "$(gate_pw_probe_ q 'x --body-file "/a b/p.md"')" = '/a b/p.md' ] || return 1
+  [ "$(gate_pw_probe_ b 'x --body-file /a\ b/p.md')"  = '/a b/p.md' ] || return 1
+  [ "$(gate_pw_probe_ a "x --body-file \$'/a\\'b/p.md' rest")" = "/a'b/p.md" ] || return 1
+  [ "$(gate_pw_probe_ m 'x --body-file /a/p.md; echo hi')" = '/a/p.md' ] || return 1
+  # 5  a MID-WORD ANSI-C span. Added after a review measured the four arms above
+  #    certifying a one-revision-STALE library -- the exact case the guard was
+  #    written for. The bare-run arm used to eat the `$` sigil greedily, so the
+  #    ANSI-C arm fired only at word position 0; every arm above sits at
+  #    position 0 and none of them could see it.
+  [ "$(gate_pw_probe_ w "x --body-file /a/b\$'\\x20'c.md")" = '/a/b c.md' ] || return 1
+  # 6  BYTE FIDELITY. `gate_unq` must return the byte string bash would pass;
+  #    decoding inside it corrupted every path carrying a byte >= 0x80 (measured
+  #    128 of 255) while leaving all five assertions above green, because each of
+  #    them is pure ASCII.
+  [ "$(gate_pw_probe_ y "x --body-file \$'/a/\\xc3\\xa9.md'")" = "$(printf '/a/\303\251.md')" ] || return 1
+  # 7  a SINGLE-quoted span containing a space. Arm 1 covers the double-quoted
+  #    one, and deleting the single-quote alternative from `$GW` left all six
+  #    arms above green while `--body-file '/a b/p.md'` extracted NOTHING --
+  #    the same stale-sibling fail-open shape, one quote character over.
+  [ "$(gate_pw_probe_ s "x --body-file '/a b/p.md'")" = '/a b/p.md' ] || return 1
+  return 0
 }

--- a/.claude/hooks/_command-match.test.sh
+++ b/.claude/hooks/_command-match.test.sh
@@ -1093,5 +1093,61 @@ if [ "$((pass + fail))" -lt "$CASE_FLOOR" ]; then
   fail=$((fail + 1))
   printf 'FAIL case floor: only %s cases ran, expected at least %s\n' "$((pass + fail))" "$CASE_FLOOR"
 fi
+# --- a mis-closed substitution span must not HIDE the verb inside it ---------
+#
+# `close_paren` / `close_backtick` decide where a `$( )` or backtick span ends.
+# An EARLY closer is worse than none: returning 0 falls back to the stack, which
+# is benign, but a wrong index truncates the body and resumes with the enclosing
+# quote still open, so the REST of the real body is parsed as quoted prose and
+# the verb inside it never starts a segment.
+#
+# All three shapes were UNGATED before the helpers learned about quotes and
+# backslashes, and all twelve hook suites stayed green throughout -- nothing
+# pinned a MIS-closed span, only balanced ones. Unbalanced parens inside quotes
+# are ordinary: grep counting a paren, sed substituting one, awk -F with one.
+want_match 0 'paren inside a quoted string in the body does not end the span' \
+  "$(printf 'echo "$(echo %s)%s ; git commit -m x)"' "'" "'")" "$C"
+want_match 0 'backslash-escaped paren does not end the span' \
+  'echo "$(echo \) ; git commit -m x)"' "$C"
+want_match 0 'backslash-escaped backtick does not end the span' \
+  'echo "`echo \` ; git commit -m x`"' "$C"
+# The control: a balanced span must still be seen, or the three above would be
+# satisfied by a matcher that matches everything.
+want_match 0 'a balanced substitution body is still seen' \
+  'echo "$(git commit -m x)"' "$C"
+# The negative twin: no verb in the body means no match, so the cases above are
+# not passing because the command matches regardless of the span.
+want_match 1 'a mis-closed span with NO verb in it does not match' \
+  "$(printf 'echo "$(echo %s)%s ; echo done)"' "'" "'")" "$C"
+# --- gate_perl_word_ok must reject a STALE prelude ---------------------------
+#
+# The guard exists to catch a library that is present but does not WORK, and the
+# case it is most likely to meet is a SIBLING REPO one revision behind -- this
+# prelude is copied between three repos on purpose. A four-dimension probe was
+# measured certifying exactly that: the pre-`ebf5ac39` prelude (no mid-word
+# ANSI-C arm, `gate_unq` decoding instead of returning bytes) passed every
+# assertion, because all four inputs were pure ASCII at word position 0.
+#
+# Each case deletes ONE dimension from the REAL prelude and requires a
+# rejection. A dimension whose deletion still passes is one the probe does not
+# actually certify. Driven from a single python block rather than per-case shell
+# arguments: the mutations are regex literals full of quotes and backslashes,
+# and threading them through shell quoting broke the file twice.
+__pr_out=$(python3 "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/testdata/probe-rejects.py" \
+             "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh" 2>&1)
+__pr_rc=$?
+printf '%s\n' "$__pr_out"
+__pr_ok=$(printf '%s\n' "$__pr_out" | grep -c '^OK   probe-rejects:')
+__pr_bad=$(printf '%s\n' "$__pr_out" | grep -c '^FAIL probe-rejects:')
+# The COUNT is asserted, not just the failures: a script that dies early prints
+# nothing and would otherwise read as six silent passes.
+if [ "$__pr_rc" != 0 ] || [ "$__pr_ok" -ne 7 ] || [ "$__pr_bad" -ne 0 ]; then
+  fail=$((fail + 1))
+  printf 'FAIL probe-rejects: expected 7 OK / 0 FAIL, got %s / %s (rc=%s)\n' "$__pr_ok" "$__pr_bad" "$__pr_rc"
+  fail_log+="FAIL probe-rejects: expected 7 OK / 0 FAIL, got $__pr_ok / $__pr_bad\n"
+else
+  pass=$((pass + __pr_ok))
+fi
+
 printf '\npass: %s  fail: %s\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/.claude/hooks/integ-stale-base-detector.sh
+++ b/.claude/hooks/integ-stale-base-detector.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# integ-stale-base-detector.sh — PreToolUse hook (matcher: Bash), NON-BLOCKING.
+#
+# Warns, before a Docker integ fixture is spent, that the branch is behind
+# `origin/main` — because a rebase after the run moves the merge base and can
+# stale the very `integ` marker the run was spent to earn.
+#
+# WHY THE WARNING IS ABOUT THE MERGE BASE AND NOT ABOUT BEING BEHIND
+#
+#   `.markgate.yml`'s `integ` gate is the repo's only `hash: diff` gate:
+#   the digest is THIS BRANCH'S DELTA against `merge-base(origin/main, HEAD)`
+#   restricted to `src/**` + `tests/integration/**`. A rebase moves that base,
+#   so the delta is recomputed — and it changes for exactly one population:
+#
+#     an in-scope file that BOTH `main` and this branch changed.
+#
+#   For a file only `main` touched, the branch's delta has no entry either way,
+#   which is the whole point of `hash: diff` (`.markgate.yml`: "a `main` merge /
+#   rebase that moves an in-scope file this branch did NOT touch leaves the
+#   marker fresh ... while a `main` change to a file this branch ALSO changed
+#   still stales it"). So this hook does not merely count what `main` brought:
+#   it INTERSECTS main's in-scope advance with this branch's own in-scope delta,
+#   and the two arms below give opposite advice on that intersection. A hook
+#   that shouted on every advance would be ignored within a week, and one that
+#   counted only main's side would shout on the common case.
+#
+#   That intersection is why this hook is NOT a copy of go-to-k/cdkd's, whose
+#   integ gates guard a hand-listed set of destroy / deploy-engine / analyzer
+#   paths and which counts main's side alone. Here the scope is two globs read
+#   off `.markgate.yml`, and `integ-stale-base-detector.test.sh` FAILS if that
+#   include list ever changes, so the regex below cannot silently drift from the
+#   gate it is describing.
+#
+# WHY HERE AND NOT AT `markgate set integ`
+#
+#   The obvious placement is next to the marker write, and it is the wrong one:
+#   by then the fixture run is already spent, so the warning can only tell you
+#   the money is gone. This hook fires on the fixture INVOCATION, which is the
+#   last moment a rebase is still free. `/run-integ` §5 is a Docker run whose
+#   first-ever pull of `public.ecr.aws/lambda/*` is ~600 MB and whose measured
+#   worst case (go-to-k/cdk-local#650) was a three-hour stall, so "one more run"
+#   is not a rounding error here.
+#
+# WHY NON-BLOCKING
+#
+#   A deliberate run on an old base is legitimate (bisecting a regression,
+#   reproducing an issue against a released tree), and a hard refusal there
+#   would cost more than the waste it prevents. This hook is a discipline aid,
+#   not a safety boundary — it exits 0 always, and its only effect is text on
+#   stderr. Compare `integ-gate.sh`, which DOES block: that one guards the
+#   merge, where being wrong is unrecoverable.
+#
+# WHAT IT DOES *NOT* ESCALATE
+#
+#   `.claude/skills/work-issues/references/verify.md` §8 already says to run the
+#   integ LAST and that "even a comment-only change to an in-scope file stales
+#   the marker", and §7 of `gates-and-pr.md` says to rebase when `main` advances
+#   and re-run the gates. Neither states the interaction: a REBASE, all by
+#   itself, can stale a marker that was earned by a run nobody re-ran. So unlike
+#   the sibling in go-to-k/cdkd (an escalation of a written-down-and-violated
+#   ordering rule), this hook fills a GAP in the written rules rather than
+#   enforcing one of them, and the message names the two files that come
+#   closest.
+#
+# NOISE CONTROL
+#
+#   Only fires for a command that actually RUNS an integ fixture. In this repo
+#   there is exactly ONE such shape — `bash tests/integration/<name>/verify.sh`
+#   (`/run-integ` §5) — because every fixture ships a `verify.sh`; re-derive
+#   with `for d in tests/integration/*/; do [ -f "$d/verify.sh" ] || echo "$d";
+#   done`, which printed only `_lib/` on 2026-09-05. That is the one place this
+#   hook is SIMPLER than cdkd's, which needs a second arm for the four broad-set
+#   fixtures that have no verify.sh. If a fixture ever ships without one, this
+#   arm goes silent for it: the re-derivation command above is the fence.
+#
+#   Recognition goes through the SHARED matcher (`_command-match.sh`), which is
+#   this repo's invariant for every hook wired to the `Bash` matcher and is
+#   enforced by `_command-match.test.sh`. It is also strictly better than the
+#   grep pair cdkd's copy carries: `gate_matches` anchors the regex at the start
+#   of each SEGMENT, so `cat .../verify.sh`, `git diff .../verify.sh` and
+#   `cd x && grep -n foo .../verify.sh` cannot match at all — no read-verb
+#   exclusion list is needed, and the one KNOWN false positive of the grep
+#   version (a fixture path inside an arbitrary quoted string) is gone too,
+#   because segments respect quoting.
+#
+#   `tests/integration/_lib/aws-orphan-sweep.sh` and the other `_lib` scripts
+#   are deliberately NOT matched: a sweep is what brackets the run, not the
+#   spend itself.
+
+set -u
+
+# Shared, segment-aware command matching. Sourcing it is the repo-wide
+# invariant for a hook on the `Bash` matcher (`_command-match.test.sh`).
+#
+# Unlike every GATE here, a missing library exits 0 rather than 2. Fail-CLOSED
+# is the right default for a hook whose job is to REFUSE; this one refuses
+# nothing, so "fail closed" would mean blocking an integ run the operator
+# deliberately started — the exact harm the non-blocking design exists to
+# avoid. The cost of the open direction is one missing nudge.
+_gate_lib="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_command-match.sh"
+[ -r "$_gate_lib" ] || exit 0
+# shellcheck source=/dev/null
+. "$_gate_lib" 2>/dev/null || exit 0
+declare -F gate_matches >/dev/null 2>&1 || exit 0
+
+input=$(cat 2>/dev/null || true)
+
+tool=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+[ "$tool" = "Bash" ] || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+[ -n "$cmd" ] || exit 0
+
+# The fixture-run shape, anchored per segment by `gate_matches`. `[^|;&]*`
+# rather than `.*` keeps the path from running past a chained command in the
+# same segment text.
+GATE_RE_INTEG_RUN='^(bash|sh)[[:space:]]+[^|;&]*verify\.sh([[:space:]]|$)'
+gate_matches "$cmd" "$GATE_RE_INTEG_RUN" || exit 0
+
+cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$cwd" ] || cwd=$PWD
+[ -d "$cwd" ] || exit 0
+
+# Opt-in: only in a repo that uses markgate, matching `issue-dup-check-gate.sh`'s
+# convention. Without markgate there is no `hash: diff` marker to stale, so the
+# warning would be noise.
+top=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$top" ] || exit 0
+[ -f "$top/.markgate.yml" ] || exit 0
+
+# NO `git fetch` here. A PreToolUse hook runs on every matching Bash call and
+# must stay fast and side-effect-free; a fetch would add network latency to the
+# critical path and mutate refs behind the user. The trade is that this reads
+# the LAST-FETCHED `origin/main`, so it under-reports when the local ref is
+# itself stale — under-reporting is the safe direction for a non-blocking nudge.
+git -C "$cwd" rev-parse --verify --quiet origin/main >/dev/null 2>&1 || exit 0
+
+behind=$(git -C "$cwd" rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+case "$behind" in ''|*[!0-9]*) exit 0 ;; esac
+[ "$behind" -gt 0 ] || exit 0
+
+branch=$(git -C "$cwd" branch --show-current 2>/dev/null || true)
+[ -n "$branch" ] || branch='(detached HEAD)'
+
+# The `integ` gate's include list, as an ERE. DERIVED from `.markgate.yml`'s
+# `integ:` block (`src/**` + `tests/integration/**`) and fenced against it by
+# `integ-stale-base-detector.test.sh`, which re-reads that block and fails when
+# it no longer holds exactly those two entries — a hand-copied scope that drifts
+# from the gate is a hook describing a gate that no longer exists.
+scope_re='^src/|^tests/integration/'
+
+# BOTH sides, both three-dot, and the difference between the two spellings is
+# load-bearing in each:
+#   main_files   -- what MAIN brought since the merge base (`HEAD...origin/main`).
+#                   Two dots would sweep in this lane's own commits and blame
+#                   them on main.
+#   branch_files -- what THIS BRANCH changed since the merge base
+#                   (`origin/main...HEAD`), which is the population `hash: diff`
+#                   actually digests.
+# The intersection is what a rebase can change; see the header.
+main_files=$(git -C "$cwd" diff --name-only HEAD...origin/main 2>/dev/null | grep -E "$scope_re" || true)
+branch_files=$(git -C "$cwd" diff --name-only origin/main...HEAD 2>/dev/null | grep -E "$scope_re" || true)
+
+overlap=0
+if [ -n "$main_files" ] && [ -n "$branch_files" ]; then
+  # `grep -Fx -f` and not a shell loop: an exact, whole-line set intersection,
+  # with the file lists as data rather than as patterns.
+  overlap=$(printf '%s\n' "$main_files" \
+    | grep -cFx -f <(printf '%s\n' "$branch_files") 2>/dev/null || true)
+fi
+case "$overlap" in ''|*[!0-9]*) overlap=0 ;; esac
+
+{
+  echo "NOTE integ-stale-base-detector: '$branch' is $behind commit(s) behind origin/main."
+  if [ "$overlap" -gt 0 ]; then
+    echo "  $overlap in-scope file(s) arriving with them are files THIS BRANCH also"
+    echo "  changed (src/** / tests/integration/**), so a rebase after this run WILL"
+    echo "  recompute this branch's delta against a moved merge base and stale the"
+    echo "  \`integ\` marker the run is about to earn — a second Docker fixture run."
+    echo "  Rebase FIRST (git fetch origin && git rebase origin/main), then run this once."
+  else
+    echo "  None of them overlap this branch's own in-scope changes, so the \`integ\`"
+    echo "  marker (hash: diff vs merge-base, see .markgate.yml) will probably survive"
+    echo "  a rebase — but the unit suite and the built dist/ are still from an older"
+    echo "  base."
+  fi
+  echo "  See .claude/skills/work-issues/references/verify.md section 8 and"
+  echo "  gates-and-pr.md section 7; confirm afterwards with"
+  echo "  \`mise exec -- markgate status integ\`."
+  echo "  Deliberately running against an older base (a bisect, a repro)? Ignore this."
+} >&2
+
+exit 0

--- a/.claude/hooks/integ-stale-base-detector.test.sh
+++ b/.claude/hooks/integ-stale-base-detector.test.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Smoke tests for integ-stale-base-detector.sh
+#
+# Run from anywhere:  bash .claude/hooks/integ-stale-base-detector.test.sh
+# `vp run test:hooks` globs `.claude/hooks/*.test.sh`, so this file is picked up
+# with no registration step.
+#
+# The hook is NON-BLOCKING by design (always exit 0), so the exit code carries
+# no signal at all and every assertion here is about the MESSAGE. That is the
+# opposite of the blocking gates' suites, and it is the whole risk of a warn
+# hook: an always-`exit 0` stub passes any suite that only checks exit codes.
+#
+# MUTATION-PROBED, measured 2026-09-05 against the 24 cases below under bash 3.2,
+# every mutation checked to have actually applied and every one restored:
+#
+#   `exit 0`, printing nothing            passed  8, FAILED 14  (every warn case)
+#   the ALARMING arm printed always       passed 18, FAILED  4  (every soft case)
+#   the SOFT arm printed always           passed 17, FAILED  5  (every alarming
+#                                                      case except the
+#                                                      "how far behind" line,
+#                                                      which both arms print --
+#                                                      which is why the two arms
+#                                                      are asserted separately)
+#   `main_files` 3-dot -> 2-dot           FAILED  2  -- the NO_OVERLAP and
+#                                                      LANE_ONLY soft cases: a
+#                                                      2-dot diff sweeps in the
+#                                                      LANE's own file and prints
+#                                                      the alarming arm
+#   `branch_files` 3-dot -> 2-dot         FAILED  2  -- the NO_OVERLAP and
+#                                                      MAIN_ONLY soft cases, the
+#                                                      mirror image
+#   `scope_re` -> `.` (match anything)    FAILED  1  -- exactly the
+#                                                      out-of-scope-overlap arm
+#                                                      case (its sibling asserts
+#                                                      the behind-count, which is
+#                                                      arm-independent)
+#   `^` dropped from GATE_RE_INTEG_RUN   FAILED  1  -- exactly the quoted-MENTION
+#                                                      case. It took a second
+#                                                      writing: the first spelling
+#                                                      ended the mention at the
+#                                                      closing quote, so the
+#                                                      regex's own trailing
+#                                                      `([[:space:]]|$)` refused
+#                                                      it either way and the case
+#                                                      was INERT against the
+#                                                      mutation it exists for
+#   `overlap=0` initialiser -> `$behind`  FAILED  3  -- exactly the three fixtures
+#                                                      where one side's in-scope
+#                                                      list is EMPTY, so the
+#                                                      recompute below never runs:
+#                                                      LANE_ONLY, MAIN_ONLY,
+#                                                      OOS_OVERLAP
+#
+# No direction passes vacuously. Asserted, in both directions:
+#   - WARNS when the branch is behind origin/main and a fixture is being run
+#   - names the OVERLAP (main's in-scope advance INTERSECTED with this branch's
+#     own in-scope delta) when there is one, and says the marker will probably
+#     survive when there is not -- the two arms give opposite advice, so
+#     conflating them would make the hook lie
+#   - SILENT when up to date, when the command only READS a verify.sh, when the
+#     repo never opted in, and for a non-Bash tool
+#   - the scope regex still matches `.markgate.yml`'s `integ` include list
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/integ-stale-base-detector.sh"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+pass=0
+fail=0
+
+TMPBASE=$(mktemp -d)
+trap 'rm -rf "$TMPBASE"' EXIT
+
+# See pr-body-item-number-gate.test.sh's header for the full derivation: the
+# hook's `#!/usr/bin/env bash` shebang resolves through PATH, so measuring the
+# SUBJECT under 3.2 needs a shim rather than just running this file under
+# /bin/bash. Defaulted rather than opt-in, because nothing sets `HOOK_BASH` in
+# `vp run test:hooks`.
+HOOK_BASH="${HOOK_BASH:-/bin/bash}"
+[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+if [ -n "${HOOK_BASH:-}" ]; then
+  HOOK_BASH_BIN="$(command -v "$HOOK_BASH" 2>/dev/null || printf '%s' "$HOOK_BASH")"
+  case "$HOOK_BASH_BIN" in /*) ;; *) HOOK_BASH_BIN="$PWD/$HOOK_BASH_BIN" ;; esac
+  HOOK_BASH_SHIM="$TMPBASE/bash32-shim"
+  mkdir -p "$HOOK_BASH_SHIM"
+  ln -sf "$HOOK_BASH_BIN" "$HOOK_BASH_SHIM/bash"
+  PATH="$HOOK_BASH_SHIM:$PATH"
+  export PATH
+fi
+printf 'hook interpreter: %s (bash %s)\n' \
+  "$(command -v bash)" "$(bash -c 'echo "$BASH_VERSION"')"
+
+# Without `jq` the hook reads an EMPTY command and every WARN case would go
+# silent, i.e. pass vacuously in the SILENT direction and fail loudly in the
+# other -- refuse to run rather than report over that.
+for tool in jq git; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "FATAL: $tool is required; without it cases would not measure the hook." >&2
+    exit 1
+  }
+done
+
+run_hook() { "$HOOK_BASH" "$HOOK"; }
+
+# Fixture trees. Real git repos, not mocks: what the hook reads is exactly
+# `git rev-list --count`, `git diff --name-only` and `git branch --show-current`,
+# so a mock would test the mock.
+#
+#   $OVERLAP       -- main and the lane both changed the SAME in-scope file
+#   $NO_OVERLAP    -- both changed in-scope files, but DIFFERENT ones
+#   $LANE_ONLY     -- the lane changed an in-scope file, main advanced docs-only
+#   $MAIN_ONLY     -- main changed an in-scope file, the lane changed docs only
+#   $INTEG_OVERLAP -- the overlap is under `tests/integration/**`, the include's
+#                     second glob
+#   $OOS_OVERLAP   -- main and the lane changed the same OUT-of-scope file
+#   $UPTODATE      -- HEAD == origin/main
+#   $NOOPTIN       -- behind and overlapping, but no .markgate.yml
+OVERLAP="$TMPBASE/overlap"
+NO_OVERLAP="$TMPBASE/no-overlap"
+LANE_ONLY="$TMPBASE/lane-only"
+MAIN_ONLY="$TMPBASE/main-only"
+INTEG_OVERLAP="$TMPBASE/integ-overlap"
+OOS_OVERLAP="$TMPBASE/oos-overlap"
+UPTODATE="$TMPBASE/uptodate"
+NOOPTIN="$TMPBASE/no-optin"
+
+# build_repo <dir> <optin:yes|no> <main-file|-> <lane-file|->
+# Leaves refs/remotes/origin/main at the tip of `main` (with <main-file>
+# changed, if given) and HEAD on branch `lane`, forked at the base commit and
+# carrying <lane-file> (if given). Both files are written with DIFFERENT content
+# on each side when they are the same path, which is what makes the overlap real
+# rather than nominal.
+build_repo() {
+  local d="$1" optin="$2" main_file="$3" lane_file="$4"
+  mkdir -p "$d"
+  git -C "$d" init -q -b main 2>/dev/null
+  git -C "$d" config user.email t@t
+  git -C "$d" config user.name t
+  [ "$optin" = yes ] && printf 'gates: {}\n' > "$d/.markgate.yml"
+  mkdir -p "$d/tests/integration/local-demo"
+  printf '#!/bin/sh\n' > "$d/tests/integration/local-demo/verify.sh"
+  mkdir -p "$d/src"
+  printf 'base\n' > "$d/src/shared.ts"
+  printf 'base\n' > "$d/base.txt"
+  git -C "$d" add -A >/dev/null
+  git -C "$d" commit -qm base
+  git -C "$d" branch -f lane HEAD
+  if [ "$main_file" != "-" ]; then
+    mkdir -p "$d/$(dirname "$main_file")"
+    printf 'from main\n' > "$d/$main_file"
+    git -C "$d" add -A >/dev/null
+    git -C "$d" commit -qm "main advance"
+  fi
+  git -C "$d" update-ref refs/remotes/origin/main HEAD
+  git -C "$d" checkout -q lane
+  if [ "$lane_file" != "-" ]; then
+    mkdir -p "$d/$(dirname "$lane_file")"
+    printf 'from the lane\n' > "$d/$lane_file"
+    git -C "$d" add -A >/dev/null
+    git -C "$d" commit -qm "lane change"
+  fi
+}
+
+build_repo "$OVERLAP"       yes src/shared.ts                          src/shared.ts
+build_repo "$NO_OVERLAP"    yes src/other.ts                           src/lane.ts
+build_repo "$LANE_ONLY"     yes docs/only.md                           src/lane.ts
+build_repo "$MAIN_ONLY"     yes src/other.ts                           docs/lane.md
+build_repo "$INTEG_OVERLAP" yes tests/integration/local-demo/verify.sh tests/integration/local-demo/verify.sh
+build_repo "$OOS_OVERLAP"   yes .claude/rules/hooks.md                 .claude/rules/hooks.md
+build_repo "$UPTODATE"      yes -                                      -
+build_repo "$NOOPTIN"       no  src/shared.ts                          src/shared.ts
+
+RUN_CMD='bash tests/integration/local-demo/verify.sh'
+# The shape `/run-integ` section 5 actually prescribes: backgrounded with the
+# output REDIRECTED to a log (never piped through tee).
+RUN_CMD_LOG='bash tests/integration/local-demo/verify.sh > /tmp/integ-local-demo.log 2>&1'
+
+# warns <name> <command> <cwd> <substring stderr must carry>
+warns() {
+  local name="$1" command="$2" cwd="$3" needle="$4"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | run_hook 2>&1) && rc=0 || rc=$?
+  # Exit 0 is asserted too: a warn hook that ever blocked would stop an integ
+  # the operator deliberately started, which is the failure mode the
+  # non-blocking design exists to avoid.
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -qF "$needle"; then
+    printf 'OK   %-62s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL %s (exit %s, expected 0 carrying %s)\n' "$name" "$rc" "$needle"
+    printf '%s\n' "$out" | sed 's/^/       /' | head -8
+    fail=$((fail + 1))
+  fi
+}
+
+# silent <name> <command> <cwd>
+silent() {
+  local name="$1" command="$2" cwd="$3"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | run_hook 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    printf 'OK   %-62s\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL %s (exit %s, expected 0 and NO output)\n' "$name" "$rc"
+    printf '%s\n' "$out" | sed 's/^/       /' | head -8
+    fail=$((fail + 1))
+  fi
+}
+
+echo "== the ALARMING arm: main's advance overlaps this branch's own delta ======="
+warns 'overlap: reports how far behind'        "$RUN_CMD" "$OVERLAP" '1 commit(s) behind origin/main'
+warns 'overlap: names the overlapping count'   "$RUN_CMD" "$OVERLAP" '1 in-scope file(s) arriving with them are files THIS BRANCH also'
+warns 'overlap: says rebase first'             "$RUN_CMD" "$OVERLAP" 'Rebase FIRST'
+warns 'overlap: names the marker at risk'      "$RUN_CMD" "$OVERLAP" '`integ` marker'
+warns 'the redirected /run-integ spelling arms it' "$RUN_CMD_LOG" "$OVERLAP" 'Rebase FIRST'
+# The include's SECOND glob. Covering only `src/**` would leave every
+# fixture-only branch -- the ones most likely to be running an integ -- unwarned.
+warns 'overlap under tests/integration/**'     "$RUN_CMD" "$INTEG_OVERLAP" 'Rebase FIRST'
+
+echo "== the SOFT arm: behind, but the marker will probably survive =============="
+# The two arms must give OPPOSITE advice. A hook that printed the alarming arm
+# unconditionally would be ignored within a week.
+warns 'disjoint in-scope changes: soft arm'    "$RUN_CMD" "$NO_OVERLAP" 'None of them overlap'
+warns 'disjoint in-scope changes: still reports being behind' \
+  "$RUN_CMD" "$NO_OVERLAP" 'behind origin/main'
+# 3-dot vs 2-dot, main's side: main advanced DOCS-only while the lane carries
+# its own in-scope commit. A 2-dot `git diff HEAD..origin/main` sweeps the
+# lane's own file in and prints the alarming arm for nothing.
+warns "lane has its own in-scope commit: judges MAIN's advance, not the lane's" \
+  "$RUN_CMD" "$LANE_ONLY" 'None of them overlap'
+# 3-dot vs 2-dot, the branch's side: main changed an in-scope file the lane
+# never touched. A 2-dot `git diff origin/main..HEAD` reports main's own file as
+# part of the branch's delta and manufactures an overlap.
+warns "main changed a file this branch never touched: soft arm" \
+  "$RUN_CMD" "$MAIN_ONLY" 'None of them overlap'
+# The scope filter itself: a shared edit to a file OUTSIDE `src/**` /
+# `tests/integration/**` cannot stale the `integ` marker.
+warns 'out-of-scope overlap does not raise the alarm' \
+  "$RUN_CMD" "$OOS_OVERLAP" 'None of them overlap'
+warns 'out-of-scope overlap still reports being behind' \
+  "$RUN_CMD" "$OOS_OVERLAP" 'behind origin/main'
+
+echo "== both arms point at the local rules ====================================="
+warns 'alarming arm cites verify.md section 8' "$RUN_CMD" "$OVERLAP"    'verify.md section 8'
+warns 'soft arm cites markgate status integ'   "$RUN_CMD" "$NO_OVERLAP" 'markgate status integ'
+
+echo "== SILENT ================================================================="
+silent 'up to date: silent'                      "$RUN_CMD" "$UPTODATE"
+silent 'not opted in (no .markgate.yml): silent' "$RUN_CMD" "$NOOPTIN"
+# Reading a fixture is not running one. Without this the hook fires on every
+# grep of the integ tree, which is how a warn hook trains people to ignore it.
+silent 'grep of a verify.sh: silent' 'grep -n cdkl tests/integration/local-demo/verify.sh' "$OVERLAP"
+silent 'cat of a verify.sh after a cd: silent'   'cd x && cat tests/integration/local-demo/verify.sh' "$OVERLAP"
+silent 'the AWS orphan sweep is not a fixture run' \
+  'bash tests/integration/_lib/aws-orphan-sweep.sh local-demo' "$OVERLAP"
+silent 'unrelated command: silent'               'git status --porcelain' "$OVERLAP"
+# The two cases that fence the SEGMENT-ANCHORED recognition, which is what
+# this port has and cdkd's grep-pair copy does not. A quoted MENTION of the
+# invocation is the false positive that copy documents as known and accepts;
+# here it must be silent, and dropping the `^` from `GATE_RE_INTEG_RUN`
+# reddens exactly this case.
+silent 'a quoted MENTION of the invocation: silent' \
+  'echo "then run: bash tests/integration/local-demo/verify.sh in the lane"' "$OVERLAP"
+silent 'git diff of a verify.sh: silent' \
+  'git diff tests/integration/local-demo/verify.sh' "$OVERLAP"
+
+# Non-Bash tool: the hook must not read tool_input.command from a Write.
+nonbash_check() {
+  local out rc
+  out=$(jq -n '{tool_name:"Write", tool_input:{file_path:"/x/verify.sh"}, cwd:"/tmp"}' \
+    | run_hook 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ] && [ -z "$out" ]; then
+    printf 'OK   %-62s\n' "non-Bash tool: silent"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL non-Bash tool: silent (exit %s, output %s)\n' "$rc" "$out"
+    fail=$((fail + 1))
+  fi
+}
+nonbash_check
+
+echo "== the scope regex still describes the gate it warns about ================="
+# The hook's `scope_re` is a hand-written ERE for `.markgate.yml`'s `integ`
+# include list. A hand copy of a config is exactly what goes stale unnoticed
+# (the class `tests/unit/gates/markgate-include-globs.test.ts` exists for), so
+# this reads the include block back and fails when it no longer holds exactly
+# the two globs the regex encodes. Deliberately an EQUALITY check: a new entry
+# means the regex is now incomplete, and a removed one means it over-warns.
+scope_fence() {
+  local yml="$REPO_ROOT/.markgate.yml" globs
+  if [ ! -r "$yml" ]; then
+    printf 'FAIL .markgate.yml not readable at %s\n' "$yml"
+    fail=$((fail + 1))
+    return
+  fi
+  # The `integ:` gate block, then its `include:` list. `awk` rather than a YAML
+  # parser: the hook suites run with no node/pnpm environment.
+  globs=$(awk '
+    /^  integ:/            { in_gate = 1; next }
+    in_gate && /^  [a-z]/  { in_gate = 0 }
+    in_gate && /^    include:/ { in_inc = 1; next }
+    in_inc && /^    [a-z]/ { in_inc = 0 }
+    in_inc && /^      - / {
+      line = $0
+      sub(/^      - /, "", line)
+      gsub(/"/, "", line)
+      print line
+    }
+  ' "$yml" | sort | tr '\n' ' ')
+  if [ "$globs" = "src/** tests/integration/** " ]; then
+    printf 'OK   %-62s\n' "scope_re matches .markgate.yml's integ include list"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL .markgate.yml integ include is now [%s]; re-derive scope_re in %s\n' \
+      "$globs" "$(basename "$HOOK")"
+    fail=$((fail + 1))
+  fi
+}
+scope_fence
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/issue-classification-label-gate.sh
+++ b/.claude/hooks/issue-classification-label-gate.sh
@@ -215,10 +215,29 @@ $cmd"
   # exited 0 on a body stating `Severity: high` with no label. Sibling
   # issue-dup-check-gate.sh already carries the same three arms. `body=@` is
   # matched FIRST so an `-F body=@path` is not also read as a bare `-F path`.
-  done < <(printf '%s' "$seg" | perl -0777 -ne '
-      while (/(?:--field|--raw-field|-F)[=\s]+(["\x27]?)body=\@([^"\x27\s]+)\1/g) { print "$2\n"; }
-      while (/--body-file[=\s]+(["\x27]?)([^"\x27\s]+)\1/g) { print "$2\n"; }
-      while (/(?:^|\s)-F[=\s]+(["\x27]?)([^"\x27\s=]+)\1(?=\s|$)/g) { print "$2\n"; }
+  done < <(printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
+      # The value class is `$GW` from the SHARED `GATE_PERL_WORD` prelude in
+      # _command-match.sh, not a local `(["\x27]?)([^"\x27\s]+)\1`. That local
+      # shape ENUMERATES where a quote may sit instead of taking one shell WORD,
+      # and it could not span a QUOTED PATH CONTAINING A SPACE, a
+      # BACKSLASH-ESCAPED one, or the GLUED `-F<path>` gh accepts -- each
+      # measured here as a FAIL-OPEN before this change (rc=0 where the plain
+      # spelling gave 2). Ported from go-to-k/cdkd#2639; the full per-shape
+      # table lives in the header of that constant, in _command-match.sh.
+      # (No apostrophe anywhere in this comment: the whole perl program is a
+      # SHELL single-quoted string, so one would end it and hand the rest to
+      # bash as code.)
+      while (/(?:--field|--raw-field|-F)[=\s]*($GW)/g) {
+        my $v = gate_unq($1);
+        next unless $v =~ s/^body=\@//;
+        print "$v\n";
+      }
+      while (/--body-file[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+      while (/(?:^|\s)-F[=\s]*($GW)(?=[\s;&|)]|$)/g) {
+        my $v = gate_unq($1);
+        next if $v =~ /^\w+=/;
+        print "$v\n";
+      }
     ' 2>/dev/null)
 
   if [ -n "$out" ]; then
@@ -280,6 +299,18 @@ has_label() {
 
 offending_seg=""
 missing=""
+# `GATE_PERL_WORD` is one shared literal that several BLOCKING gates
+# interpolate, and every extraction runs `perl ... 2>/dev/null`. A prelude
+# that is present but does NOT COMPILE therefore produces no output, no
+# stderr and no exit-code change -- the gate extracts nothing and PASSES
+# what it exists to refuse. Measured in cdkd: one broken literal disarmed
+# four gates at once, with zero stderr. A non-empty test cannot see that,
+# so probe it FUNCTIONALLY, once, after arming, and at TOP LEVEL -- the
+# extraction helpers run inside `$( )`, where `exit 2` ends only the
+# substitution subshell (measured: an in-function guard PRINTED its
+# refusal and the hook still returned 0).
+gate_perl_word_or_die issue-classification-label-gate || exit 2
+
 while IFS= read -r seg; do
   is_edit=0
   if gate_matches "$seg" "$GATE_RE_GH_ISSUE_EDIT"; then

--- a/.claude/hooks/issue-classification-label-gate.sh
+++ b/.claude/hooks/issue-classification-label-gate.sh
@@ -245,12 +245,18 @@ $cmd"
     return 0
   fi
 
-  out=$(printf '%s' "$seg" | perl -0777 -ne '
-    while (/(?:^|\s)--body[=\s]+("(?:[^"\\]|\\.)*"|\x27[^\x27]*\x27|\S+)/g) {
-      my $v = $1;
-      $v =~ s/^["\x27]//; $v =~ s/["\x27]$//;
-      print "$v\n";
-    }' 2>/dev/null)
+  # `$GW` + `gate_unq`, like the file scan above -- this arm was left on the
+  # retired class when the rest of this function was converted, which is a
+  # half-applied refactor rather than a decision. The old class ENUMERATES
+  # where a quote may sit, so it could not see an ANSI-C value: measured,
+  # `--body $\x27Severity: high\x27` extracted nothing and the issue filed with
+  # no `severity:*` label (rc=0), while the plain-quoted spelling gave rc=2.
+  # `-b` is gh`s documented short `--body` and was missing for the same reason.
+  #
+  # NOTE no apostrophes below -- the perl body is a single-quoted SHELL string.
+  out=$(printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
+    while (/(?:^|\s)--body[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+    while (/(?:^|\s)-b[=\s]*($GW)/g) { print gate_unq($1), "\n"; }' 2>/dev/null)
   if [ -n "$out" ]; then
     printf '%s' "$out"
     return 0

--- a/.claude/hooks/issue-classification-label-gate.test.sh
+++ b/.claude/hooks/issue-classification-label-gate.test.sh
@@ -334,6 +334,55 @@ out=$(printf '%s' "$payload" | "$HOOK" 2>&1) && rc=0 || rc=$?
 if [ "${rc:-0}" -eq 0 ]; then echo "PASS: non-Bash tool passes (exit 0)"; PASS=$((PASS + 1))
 else echo "FAIL: non-Bash tool passes (exit ${rc:-0})"; FAIL=$((FAIL + 1)); fi
 
+# --- the shared GATE_PERL_WORD value class, and its guard --------------------
+# Ported with the class from go-to-k/cdkd#2639. Three spellings were LIVE
+# fail-opens here before the port, each measured rc=0 where the plain path gave
+# 2: a quoted path containing a SPACE, a BACKSLASH-escaped one, and the GLUED
+# `-F<path>` gh accepts. They are cases rather than a note because a value class
+# that enumerates quote POSITIONS grows a new hole every time gh accepts another
+# spelling.
+GWDIR="$TMPROOT/gw dir"
+mkdir -p "$GWDIR"
+printf 'Severity: high -- users lose data\nEffort: small (S)\n' > "$GWDIR/sev.md"
+run "spaced --body-file path, unlabelled Severity, blocks" \
+  "gh issue create -t x --body-file \"$GWDIR/sev.md\"" "$TMPROOT" 2
+run "spaced --body-file path, backslash-escaped, blocks" \
+  "gh issue create -t x --body-file ${GWDIR// /\\ }/sev.md" "$TMPROOT" 2
+run "glued -F<spaced path>, unlabelled Severity, blocks" \
+  "gh issue create -t x -F\"$GWDIR/sev.md\"" "$TMPROOT" 2
+
+# The guard. `[ -n "$GATE_PERL_WORD" ]` cannot see a prelude that is present but
+# does not COMPILE, and every extraction runs perl with stderr discarded -- so
+# the gate would extract nothing and PASS. The payload is one this gate NORMALLY
+# PASSES, so exit 2 can only come from the guard. The second case is the
+# ENVIRONMENT half: the memo is an ordinary shell variable, so without a reset
+# at library load `__GATE_PW_OK=1` made the probe report a prelude it never ran.
+GWBROKEN="$TMPROOT/brokenlib"
+mkdir -p "$GWBROKEN"
+cp "$HOOK" "$GWBROKEN/"
+sed "s|^  my \$GW = qr/.*|  my \$GW = qr/(((unclosed/;|" \
+  "$(dirname "$HOOK")/_command-match.sh" > "$GWBROKEN/_command-match.sh"
+if grep -q 'unclosed' "$GWBROKEN/_command-match.sh" \
+   && ! grep -q 'my \$GW = qr/(?:' "$GWBROKEN/_command-match.sh"; then
+  for gw_env in "" "__GATE_PW_OK=1"; do
+    gw_rc=0
+    jq -n --arg c "gh issue create -t x --body nothing classified here --label severity:high" --arg d "$TMPROOT" \
+      '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}' \
+      | env $gw_env "$GWBROKEN/$(basename "$HOOK")" >/dev/null 2>&1 || gw_rc=$?
+    if [ "$gw_rc" = "2" ]; then
+      PASS=$((PASS + 1))
+      echo "PASS: a non-compiling GATE_PERL_WORD fails CLOSED (env='$gw_env')"
+    else
+      FAIL=$((FAIL + 1))
+      echo "FAIL: a non-compiling GATE_PERL_WORD returned $gw_rc with env='$gw_env', expected 2"
+    fi
+  done
+else
+  # A probe that silently does not run is the failure mode this file is about.
+  FAIL=$((FAIL + 1))
+  echo "FAIL: could not stage a broken GATE_PERL_WORD (sed anchor drifted)"
+fi
+
 echo ""
 echo "Pass: $PASS  Fail: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.claude/hooks/issue-classification-label-gate.test.sh
+++ b/.claude/hooks/issue-classification-label-gate.test.sh
@@ -155,6 +155,21 @@ run_msg "create: no labels at all" \
 run_msg "create: severity labelled, effort missing" \
   "gh issue create -t x --body-file $BODY_BOTH --label severity:high" \
   "$TMPROOT" 2 "effort:large"
+# The inline arm was left on the retired quote-POSITION class when the rest of
+# this function moved to `$GW`, so an ANSI-C `--body` value was extracted as
+# NOTHING and the issue filed unlabelled. Measured in this repo: rc=0 before,
+# rc=2 after; the plain-quoted spelling of the same body was rc=2 throughout.
+#
+# ONE field, deliberately. With two, the whole-segment fallback at the end of
+# `segment_body_text` finds the OTHER field in the raw command text and the
+# case passes with the arm deleted -- vacuous. (The same fallback is why the
+# `-b` arm added alongside is measured-neutral here: rc=2 with and without it.
+# It stays for parity with the other gates, not as a fix, and no case claims
+# otherwise.)
+run_msg "create: ANSI-C --body value, unlabelled" \
+  "gh issue create -t x --body \$'Severity: high'" \
+  "$TMPROOT" 2 "severity:high"
+
 run_msg "create: label DISAGREES with the body" \
   "gh issue create -t x --body-file $BODY_BOTH --label severity:low --label effort:large" \
   "$TMPROOT" 2 "severity:high"

--- a/.claude/hooks/issue-deferral-criteria-gate.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.sh
@@ -1,0 +1,717 @@
+#!/usr/bin/env bash
+# issue-deferral-criteria-gate.sh — block `gh issue create` when the body's
+# `Session-fit: next` line defers the work for a PR-SHAPED reason.
+#
+# WHY
+#
+# `Session-fit` answers ONE question: do I finish this in THIS session? The
+# field reference is `.claude/rules/session-report.md`, and none of the
+# criteria there is about the pull request -- splitting work across several PRs
+# is normal, needs no permission and costs no session. `/work-issues` §5
+# (`.claude/skills/work-issues/references/implement.md`) says so in as many
+# words:
+#
+#   **"It needs its own PR" is NOT a `next` reason** -- it is a `now` item that
+#   gets its own PR; the bar is the SESSION, not the diff. Writing
+#   "independent review surface" on a `Session-fit` line is the
+#   classify-by-MEANS error arriving through the PR boundary
+#
+# That bullet carries its own violation log: a hook missing from one sibling
+# filed `next` on exactly that wording on 2026-09-01, re-classified `now` on
+# the maintainer's challenge and shipped in the same session -- and the port
+# then found four more defects a fresh session would not have looked for.
+# go-to-k/cdkd repeated the class three times in one session on 2026-09-04
+# (go-to-k/cdkd#2587 / go-to-k/cdkd#2588 / go-to-k/cdkd#2590, all three
+# re-classified `now` and finished that same day). `/work-issues` §10-b is
+# explicit about what happens to a rule that is written down and violated
+# anyway: it escalates to a MECHANISM. This is that mechanism.
+#
+# WHAT IT ASKS FOR, AND WHAT IT DELIBERATELY DOES NOT
+#
+# It does NOT ask for a ritual. A gate demanding the body carry a "criteria
+# audit" line is satisfiable by boilerplate, and a gate a sentence can satisfy
+# measures typing rather than thinking. This one refuses the specific defect
+# instead: a `next` line whose REASON is PR-SHAPED. Everything else passes
+# untouched, including every legitimate `next` this repo documents --
+#
+#   Session-fit: next (not this session) -- a NEW integ fixture must be written
+#   Session-fit: next (not this session) -- blocked on an upstream fix landing
+#   Session-fit: next (not this session) -- verified by `/run-integ
+#     local-start-api-watch` on an arm64 host, which a fresh session has
+#
+# and it never argues with a `Session-fit: now`, whatever that line says.
+#
+# It is also NOT a filing threshold: nothing here makes a finding harder to
+# write down (an unfiled finding is strictly worse than a filed one). It
+# changes one word in one line, or -- the outcome it actually steers toward --
+# it makes you notice that the item is a `now`.
+#
+# WHY `unreviewable` IS IN THE VOCABULARY, AND WHY TWO RULES MOVED TO MEET IT
+#
+# The first cut of this port DROPPED the word (go-to-k/cdkd's copy carries it),
+# because two passages here read as sanctioning a review-SIZE deferral:
+# implement.md §5's "a sweep that would make the PR unreviewable is a genuine
+# `next`", and .claude/rules/session-report.md's Calibration paragraph naming
+# "review of a larger diff, which grows superlinearly" among the things to
+# "defer on". A gate must not contradict its host repo's rules, so the word was
+# left out and the divergence was fenced by two suite cases.
+#
+# REVERSED 2026-09-05, in the commit that carries this line. cdkd hit the
+# identical tension and resolved it the OTHER way (go-to-k/cdkd#2619): the gate
+# keeps `unreviewable` and the DOC is reworded, because review size is the
+# SIGNAL you notice, not the criterion. Underneath it is verification the
+# residue needs and this lane is not already paying -- which the `next` criteria
+# list already contains. Both passages were rewritten alongside: §5's bullet now
+# reads "a sweep whose residue carries its own verification is a genuine `next`"
+# (the umbrella, the named sites and both drift tripwires kept verbatim), and
+# Calibration now says review cost argues for SPLITTING the PR and belongs under
+# `Effort`, not for ending the session. Three repos running one skill must not
+# answer this differently: a divergence here is not local colour, it is one rule
+# giving two answers, which is the defect this gate exists for.
+#
+# MEASURED, not argued (2026-09-05, `gh issue list --state all --limit 300`,
+# 206 bodies, of which 74 carry a `Session-fit: next` FIELD LINE -- the anchored
+# predicate this gate reads; state the predicate or the number cannot be
+# reproduced, and here a bare `grep -i 'Session-fit: next'` happens to agree at
+# 74):
+#
+#   vocabulary without `unreviewable`   fires on 10 of the 74 (14%)
+#   this vocabulary (with it)           fires on 16 of the 74 (22%)
+#
+# The 10 are PR-SPLIT deferrals ("it wants its own PR and its own review", "must
+# not share the mirror-split PR", "on an independent review surface"). The 6
+# added are sweeps: go-to-k/cdk-local#569 (~54 fixtures), go-to-k/cdk-local#585
+# (a repo-wide segmentation change), go-to-k/cdk-local#591 (30 fixtures),
+# go-to-k/cdk-local#654 (20 fixtures), go-to-k/cdk-local#655 (a subsystem
+# bundled into a 15-file PR already at the 3-axis tier) and
+# go-to-k/cdk-local#665 (a fifth probe value on a three-round diff). Refusing
+# those 6 is the INTENT rather than collateral: each named review size where it
+# owed the claim underneath, and several already named the next session's
+# verification command -- so a re-filing states the real criterion and passes.
+#
+# WHAT IS AND IS NOT GATED
+#
+#   gated:      gh issue create   -- the site where a deferral is FIRST decided
+#               gh api repos/<o>/<r>/issues -- the same mint through REST
+#   not gated:  gh issue edit     -- re-classification is the outcome this gate
+#               gh issue comment     wants; taxing it would penalise the fix
+#
+# Same split, and the same reasoning, as issue-dup-check-gate.sh.
+#
+# KNOWN LIMITS, all measured rather than assumed:
+#
+#   - A body passed INLINE as one physical line has no line structure, so the
+#     reason runs to the end of that line and a PR-shaped phrase belonging to a
+#     later field is read as part of it. That is the over-approximating
+#     direction (a loud, clearable block), and the file-borne shape this repo
+#     mandates for issue bodies does not have it.
+#   - A one-call body written to an EXISTING path by something other than a
+#     heredoc (`printf > f`, `python3 -c ... > f`) cannot be extracted from the
+#     command text, so the scan falls back to what is on disk -- the PREVIOUS
+#     body. The heredoc shape, which is the one this repo mandates, is CLOSED
+#     (see `segment_body_text` arm 1); this remainder is the same limit
+#     pr-body-item-number-gate.sh carries and names.
+#   - The vocabulary is a closed list, so a reworded PR-shaped reason passes.
+#     Deliberate: see the note on PR_SHAPE_RE.
+#   - A PR-shaped reason quoted INLINE, in running prose, to argue against it
+#     still needs the bypass. A quote inside a ``` fence does not: fenced
+#     blocks are stripped before the scan.
+#
+# ESCAPE HATCH: CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1, honored from the hook's own
+# process env AND from a leading assignment AT THE START of the command text.
+# An agent's Bash call cannot populate a PreToolUse hook's environment -- the
+# hook is spawned with the session's env -- so a text channel is the only one a
+# refusal can honestly advertise (the go-to-k/cdkd#2368 lesson, where an
+# advertised remediation silently did nothing). It is anchored at offset 0 of
+# the command rather than at any command position, and that is a DELIBERATE
+# narrowing: this repo's `_command-match.sh` has no `strip_noncommand_spans`,
+# so a mid-command scan could not tell an assignment from the same text quoted
+# inside a body, and a bypass that a body can spell is not a bypass. Offset 0
+# cannot be inside a quoted span. `cd <repo> && CDKL_...=1 gh issue create` is
+# therefore NOT a bypass -- put the assignment first, which is the spelling the
+# refusal prints. The hatch exists for the case this gate cannot see: a body
+# quoting someone else's PR-shaped reasoning in order to argue against it, and
+# only for the INLINE quote. The commonest shape of that body, a ``` fenced
+# exhibit, needs no bypass (see `scan_text`): a body should not have to disarm
+# a gate to talk about the rule the gate enforces.
+
+set -u
+
+__hook_dir="${BASH_SOURCE[0]%/*}"
+# `%/*` leaves the string unchanged when the path has no slash (invoked as
+# `bash issue-deferral-criteria-gate.sh` from inside the hooks dir).
+[ "$__hook_dir" = "${BASH_SOURCE[0]}" ] && __hook_dir="."
+# The shared matcher lives at `_command-match.sh` here and at
+# `lib/command-match.sh` in go-to-k/cdkd. Try both rather than forking the
+# file: the two spellings are the ONLY difference between the copies, and a
+# fork is how they drift. FAIL CLOSED -- a gate that cannot evaluate the
+# command must not wave it through; `|| exit 0` here is what silently disabled
+# ten sibling gates (go-to-k/cdkd#2130 review).
+# shellcheck source=_command-match.sh
+if ! . "$__hook_dir/_command-match.sh" 2>/dev/null \
+  && ! . "$__hook_dir/lib/command-match.sh" 2>/dev/null; then
+  echo "Blocked: the shared command matcher (_command-match.sh or" >&2
+  echo "lib/command-match.sh) is missing or unloadable, so" >&2
+  echo "issue-deferral-criteria-gate cannot evaluate the command." >&2
+  echo "Restore the file; do not work around the gate." >&2
+  exit 2
+fi
+# A matcher that loaded but predates the constants this gate needs is the same
+# hazard one step later. `declare -F` also catches a partial source.
+if ! declare -F gate_matches >/dev/null 2>&1 \
+  || ! declare -F gate_segments >/dev/null 2>&1 \
+  || [ -z "${GATE_RE_GH_ISSUE_CREATE:-}" ]; then
+  echo "Blocked: the shared command matcher loaded but is missing gate_matches," >&2
+  echo "gate_segments or GATE_RE_GH_ISSUE_CREATE, so" >&2
+  echo "issue-deferral-criteria-gate cannot evaluate the command." >&2
+  exit 2
+fi
+
+input=$(cat 2>/dev/null || true)
+tool_name=$(printf '%s' "$input" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+[ "$tool_name" = "Bash" ] || exit 0
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // ""' 2>/dev/null || echo "")
+hook_cwd=$(printf '%s' "$input" | jq -r '.cwd // ""' 2>/dev/null || echo "")
+[ -n "$cmd" ] || exit 0
+
+[ "${CDKL_SKIP_DEFERRAL_CRITERIA_GATE:-}" = "1" ] && exit 0
+# The text channel, anchored at offset 0 -- see the ESCAPE HATCH note above for
+# why it is not a general command-position scan.
+case "$cmd" in
+  CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1[[:space:]]*) exit 0 ;;
+esac
+
+# Command-position matching, so a body or comment that merely QUOTES
+# `gh issue create` does not arm the gate (.claude/rules/hooks.md). The verb
+# that matched is kept, because `gate_target_dir` below has to read the SAME
+# segment this gate is judging.
+gate_re=""
+for gate_candidate in "$GATE_RE_GH_ISSUE_CREATE" "${GATE_RE_GH_API_ISSUE_CREATE:-}"; do
+  [ -n "$gate_candidate" ] || continue
+  if gate_matches "$cmd" "$gate_candidate"; then
+    gate_re="$gate_candidate"
+    break
+  fi
+done
+[ -n "$gate_re" ] || exit 0
+
+# --- resolve the target directory ONCE --------------------------------------
+# Both the opt-in check and the relative `--body-file` resolution need the same
+# directory and must agree. `gate_target_dir` is this repo's shared resolver: a
+# `-C <path>` inside the MATCHED segment wins, else the last `cd <path>` before
+# it, else the payload cwd. Using it rather than a hand-rolled scan is what
+# keeps `gh -C "/a b" issue create` and the
+# `gh issue list --search x && cd <repo> && gh issue create` chain (the shape
+# `/work-issues` §5 prescribes) resolving to the right tree.
+target_dir="${hook_cwd:-$PWD}"
+if declare -F gate_target_dir >/dev/null 2>&1; then
+  _resolved=$(gate_target_dir "$cmd" "$target_dir" "$gate_re" 2>/dev/null || true)
+  [ -n "$_resolved" ] && target_dir="$_resolved"
+fi
+
+# --- repo opt-in ------------------------------------------------------------
+# A session rooted here regularly files issues in unrelated personal repos,
+# where this repo's `Session-fit` vocabulary does not exist and a refusal is
+# pure friction. So the gate fires only in a repo that opts in by carrying
+# `.markgate.yml` at its root, matching issue-dup-check-gate.sh. The CWD's repo
+# decides, not any `-R <owner/repo>`: `-R` names where the issue LANDS, the cwd
+# names whose policy the session is operating under -- and the cross-repo
+# mirror flow (`/work-issues` §10-c) files into a sibling from here, which is
+# exactly a filing this repo wants classified.
+optin_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)
+[ -n "$optin_top" ] || exit 0
+[ -f "$optin_top/.markgate.yml" ] || exit 0
+
+# --- the PR-shaped reason vocabulary ----------------------------------------
+# Deliberately a SHORT closed list of the spellings implement.md §5 names as
+# errors, not an attempt to enumerate every way a person could say "PR". The
+# threat model is an agent reaching for the cheap justification it has seen
+# before, not one evading a regex: someone who rewords the reason to dodge this
+# has had to read the criteria to do it, which is the entire ask. `unreviewable`
+# IS in the list, matching the sibling gates -- see the header for the
+# 2026-09-05 reversal and the rule rewrites that came with it.
+#
+# `prs?` is bounded by `([^[:alnum:]]|$)` rather than `\b` -- `\b` is a GNU
+# extension that BSD regcomp does not carry, so on macOS it would match nothing
+# and the gate would be inert.
+PR_SHAPE_RE='(own|separate)[[:space:]]+prs?([^[:alnum:]]|$)'
+PR_SHAPE_RE="$PR_SHAPE_RE"'|shar(e|es|ing)[[:space:]]+((a|an|the|its|their)[[:space:]]+)?prs?([^[:alnum:]]|$)'
+PR_SHAPE_RE="$PR_SHAPE_RE"'|(independent|separate)[[:space:]]+review[[:space:]]+surface'
+PR_SHAPE_RE="$PR_SHAPE_RE"'|unreviewable'
+PR_SHAPE_RE="$PR_SHAPE_RE"'|own[[:space:]]+review([^[:alnum:]]|$)'
+
+OFFENDING_REASON=""
+
+pr_shaped() { # <reason text> -> 0 when it is PR-shaped, and records it
+  [[ $1 =~ $PR_SHAPE_RE ]] || return 1
+  OFFENDING_REASON=$(printf '%s' "$1" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  return 0
+}
+
+# Scan a body for a `Session-fit: next` line whose reason is PR-shaped.
+#
+# The reason continues onto WRAPPED lines, and that is not a refinement: an
+# issue body written to 76 columns puts "needs its own PR" on the line AFTER
+# `Session-fit: next (not this session) -- this touches a different subsystem
+# and`, and a line-only scan would read the first half and pass. A continuation
+# ends at a blank line, at the next `Key:` field (`Severity:` / `Effort:` /
+# `Estimate:` / `Dup-check:` / `Notes:`, list-prefixed or not), at a LIST ITEM,
+# or at a markdown heading -- so a wrapped reason is read whole while the
+# SIBLING fields, which are nobody's reason, are not folded in.
+#
+# The LIST-ITEM boundary is not decoration either. This repo's own report
+# template puts the four fields under a `- TODO #<N>` bullet as nested bullets,
+# so a body reading
+#
+#   Session-fit: next (not this session) -- blocked on an upstream fix
+#   - the sibling cleanup would need its own PR, so it is filed separately
+#
+# folded the bullet into the reason and refused a deferral whose stated reason
+# is a documented criterion. A bullet starts a new block in markdown exactly
+# like a blank line or a heading does; it is a boundary for the same reason.
+#
+# FENCED CODE BLOCKS are removed before the scan (the same allow-list
+# pr-body-item-number-gate.sh applies, and for the same reason). A body arguing
+# ABOUT this rule quotes the refused line to do it, and quoting it inside a
+# ```text fence is how a markdown body says "this is an exhibit, not an
+# assertion". Without the strip, the FIRST `Session-fit:` match wins and
+# `break`s, so a body whose own classification is `Session-fit: now` is refused
+# over the exhibit above it -- and the advertised remedy (the bypass variable)
+# is exactly what a body of that shape should not have to reach for.
+#
+# A `**Session-fit:**` / `**Session-fit**:` spelling is read like the bare one:
+# .claude/rules/session-report.md bolds every field name in its prose, so the
+# spelling is one copy-paste away.
+#
+# `nocasematch` is enabled for the duration of this function and restored on the
+# way out rather than set once at the top of the file, and that scoping is
+# load-bearing: the shared matcher's `gate_matches` is a `[[ =~ ]]` too, so a
+# file-wide `nocasematch` would silently widen EVERY gate verb this hook matches
+# (`GH ISSUE CREATE` would arm it). It is used instead of a `[Ss]`-class regex
+# or a `tr` pass because the reason has to be REPORTED BACK in its original
+# casing, and lowercasing to match would mean carrying two copies of every line.
+scan_text() { # <body text> -> 0 when the body carries a PR-shaped deferral
+  local text="$1" line rest active=0 reason="" rc=1 nocase_was=0 fence=0 fence_mark=""
+  # A fence line is `` ``` `` or `~~~`, indented or not. The CONTENT of the
+  # block is invisible to the scan; the fence line itself also closes an open
+  # continuation, because a fenced block starts a new markdown block exactly
+  # like a heading does.
+  # A fence OPENS only when its own closer appears later, and closes only on the
+  # SAME marker. Both halves are load-bearing: latching on any opener with no
+  # look-ahead makes an UNCLOSED fence blank every remaining line (rc=0 where
+  # the pre-fence hook said 2), and ignoring the marker type lets a ``` line
+  # inside a ~~~ block close it early. This is the exact class
+  # .claude/rules/hooks.md documents for heredoc openers -- "latching onto any
+  # <<WORD blanks every remaining line, fail open" -- so the look-ahead is
+  # copied from that solution rather than re-derived.
+  local fence_open_re='^[[:space:]]*(```|~~~)'
+  # `[*_]*` on both sides of the colon accepts `**Severity:**` and
+  # `**Severity**:`. Keeping the two boundary tests in sync with the key
+  # spelling `session_fit_re` accepts is load-bearing: a body that bolds one
+  # field bolds them all, so a bold-blind boundary would fold the whole field
+  # block into the reason.
+  local key_re='^[[:space:]]*([-*+>][[:space:]]+)?[*_]*[A-Za-z][A-Za-z_-]*[*_]*:'
+  local item_re='^[[:space:]]*([-*+]|[0-9]+[.)])[[:space:]]+'
+  local session_fit_re='session-fit[*_]*:[*_]*(.*)$'
+  case "$(shopt -p nocasematch)" in *-s*) nocase_was=1 ;; esac
+  shopt -s nocasematch
+  # Buffered into an array rather than streamed, because the opener has to look
+  # AHEAD for its own closer. Built with a read loop, not `mapfile` -- the hook
+  # suites run under macOS bash 3.2 (`HOOK_BASH`), where `mapfile` does not
+  # exist and would be a runtime error, which for a gate is a silent pass.
+  local -a lines=()
+  local n=0
+  while IFS= read -r line; do
+    lines[$n]="$line"
+    n=$((n + 1))
+  done <<EOF
+$text
+EOF
+  local i=0 j
+  while [ "$i" -lt "$n" ]; do
+    line="${lines[$i]}"
+    i=$((i + 1))
+    if [[ $line =~ $fence_open_re ]]; then
+      local mark="${BASH_REMATCH[1]}" closes=0
+      if [ "$fence" = "1" ]; then
+        # Close only on the marker that opened it.
+        if [ "$mark" = "$fence_mark" ]; then fence=0; fence_mark=""; fi
+        continue
+      fi
+      # Open only if this same marker recurs LATER; a stray fence line must not
+      # swallow the rest of the body.
+      j=$i
+      while [ "$j" -lt "$n" ]; do
+        case "${lines[$j]}" in
+          *"$mark"*)
+            if [[ ${lines[$j]} =~ ^[[:space:]]*"$mark" ]]; then closes=1; break; fi
+            ;;
+        esac
+        j=$((j + 1))
+      done
+      if [ "$closes" = "1" ]; then
+        fence=1
+        fence_mark="$mark"
+        if [ "$active" = "1" ]; then
+          active=0
+          if pr_shaped "$reason"; then rc=0; break; fi
+        fi
+        continue
+      fi
+      # Not a real fence -- fall through and treat it as ordinary text.
+    fi
+    if [ "$fence" = "1" ]; then
+      continue
+    fi
+    if [ "$active" = "1" ]; then
+      if [[ $line =~ ^[[:space:]]*$ ]] \
+        || [[ $line =~ $key_re ]] \
+        || [[ $line =~ $item_re ]] \
+        || [[ $line =~ ^[[:space:]]*\# ]]; then
+        active=0
+        if pr_shaped "$reason"; then rc=0; break; fi
+      else
+        reason="$reason $line"
+      fi
+    fi
+    if [[ $line =~ $session_fit_re ]]; then
+      # A second `Session-fit:` closes whatever the first one opened.
+      if [ "$active" = "1" ]; then
+        if pr_shaped "$reason"; then rc=0; break; fi
+      fi
+      rest="${BASH_REMATCH[1]}"
+      # ONLY `next` is gated. `now` is never refused, whatever its reason says
+      # -- an agent talking itself INTO finishing the work needs no supervision.
+      # A line stating neither token (an old packed body, a `Session-fit` in
+      # prose) is not a deferral decision this gate can read, so it passes.
+      if [[ $rest =~ ^[[:space:]]*next([^[:alpha:]]|$) ]]; then
+        reason="$rest"
+        active=1
+      else
+        active=0
+        reason=""
+      fi
+    fi
+  done
+  if [ "$rc" != "0" ] && [ "$active" = "1" ]; then
+    pr_shaped "$reason" && rc=0
+  fi
+  [ "$nocase_was" = "1" ] || shopt -u nocasematch
+  return "$rc"
+}
+
+# --- reading the body the command is about to WRITE -------------------------
+# These three are this repo's own extraction, lifted from
+# pr-body-item-number-gate.sh (go-to-k/cdk-local#637), whose comments carry the
+# full derivation; the subtleties are restated here only where this gate would
+# break without them.
+#
+# `cmd_appends_path` and `cmd_rewrites_path` answer DIFFERENT questions and must
+# not be collapsed: `>>` / `tee -a` APPEND, so what is on disk is the FIRST HALF
+# of the body being submitted and still has to be scanned; only `>` / `tee`
+# supersede it.
+cmd_rewrites_path() { # <path as the command spells it>
+  CMD="$cmd" TARGET="$1" perl -0777 -e '
+    my $c = $ENV{CMD};
+    my $t = quotemeta($ENV{TARGET});
+    # (?<!>) keeps `>>f` out of the `>f` arm while leaving `1>f` / `2>f` in it.
+    # The trailing class covers the TIGHT spellings -- `>f<<EOF`, `>f;`, `>f&&`
+    # -- which a `(?:\s|$)` terminator misses, and `>f<<EOF` is the very shape
+    # this exists for.
+    exit 0 if $c =~ /(?<!>)>\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    exit 0 if $c =~ /\btee\b(?!\s+-a\b)(?:\s+-[^a\s-][^\s]*)*\s+(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    exit 1;
+  ' 2>/dev/null
+}
+
+cmd_appends_path() { # <path as the command spells it>
+  CMD="$cmd" TARGET="$1" perl -0777 -e '
+    my $c = $ENV{CMD};
+    my $t = quotemeta($ENV{TARGET});
+    exit 0 if $c =~ />>\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    exit 0 if $c =~ /\btee\b(?:\s+-[^\s]*)*\s+-a\b(?:\s+-[^\s]*)*\s+(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+    exit 1;
+  ' 2>/dev/null
+}
+
+# EVERY heredoc body that writes the path, in order. Both orders
+# (`cat > f <<EOF` and `cat <<EOF > f`), quoted and unquoted delimiters, and
+# `<<-`, whose terminator may be indented by TABS only -- stripping all leading
+# whitespace makes an indented `  EOF` INSIDE the body end the extraction early,
+# so everything after it goes unscanned while bash still submits it. The STATUS,
+# not the output, reports whether a heredoc was found: an empty heredoc body is
+# legal and prints nothing.
+heredoc_bodies_for() { # <path as the command spells it>
+  CMD="$cmd" TARGET="$1" perl -0777 -e '
+    my $c = $ENV{CMD};
+    my $t = quotemeta($ENV{TARGET});
+    my @lines = split /\n/, $c, -1;
+    my @out;
+    my $found = 0;
+    for (my $i = 0; $i <= $#lines; $i++) {
+      my $l = $lines[$i];
+      next unless $l =~ /(?:>>?|\btee\b(?:\s+-[^\s]*)*)\s*(["\x27]?)$t\1(?:[\s;&|)<]|$)/;
+      next unless $l =~ /(<<-?)\s*(["\x27]?)([A-Za-z_][A-Za-z0-9_]*)\2/;
+      my $dash  = ($1 eq "<<-");
+      my $delim = $3;
+      $found = 1;
+      my $j = $i + 1;
+      while ($j <= $#lines) {
+        my $probe = $lines[$j];
+        $probe =~ s/^\t+// if $dash;
+        last if $probe eq $delim;
+        push @out, $lines[$j];
+        $j++;
+      }
+      # Resume AFTER this body and do NOT stop at the first: one path can be
+      # written by more than one heredoc in one command.
+      $i = $j;
+    }
+    print join("\n", @out), "\n" if @out;
+    exit($found ? 0 : 1);
+  ' 2>/dev/null
+}
+
+# Each matcher is offered BOTH spellings of the path -- the one the command
+# writes and the one it hands to gh -- because they need not be the same string
+# (`cat > /abs/b.md ... --body-file b.md`), and either half alone leaves that
+# shape unscanned: the write-detection matches against the RAW COMMAND TEXT, so
+# handed only the resolved absolute path it matches nothing whenever the command
+# writes a RELATIVE or `~/` path. The short-circuit on equality saves a perl
+# spawn on the common absolute spelling.
+cmd_rewrites_either() { # <raw spelling> <resolved path>
+  cmd_rewrites_path "$1" && return 0
+  [ "$1" = "$2" ] && return 1
+  cmd_rewrites_path "$2"
+}
+cmd_appends_either() { # <raw spelling> <resolved path>
+  cmd_appends_path "$1" && return 0
+  [ "$1" = "$2" ] && return 1
+  cmd_appends_path "$2"
+}
+heredoc_bodies_either() { # <raw spelling> <resolved path>
+  heredoc_bodies_for "$1" && return 0
+  [ "$1" = "$2" ] && return 1
+  heredoc_bodies_for "$2"
+}
+
+# The BODY text of ONE segment, in descending order of specificity:
+#
+#   1. the HEREDOC BODY that this command writes to the named `--body-file`,
+#      when it writes one -- this is the arm that closes the fail-open
+#   2. the contents of the file at that path, unless arm 1 fired AND the command
+#      REWRITES the path (an APPEND leaves the existing content as the first
+#      half of the submitted body)
+#   3. the WHOLE command, when such a path was named, cannot be read, and no
+#      heredoc writes it -- a `printf > f` body, or an unresolvable `$VAR` path
+#   4. the inline `--body` value, plus the `-f`/`--field` `body=` forms the REST
+#      mint uses, quote-aware so a multi-word body stays one value
+#
+# ARM 1 IS NOT AN OPTIMISATION. The hook runs BEFORE the command, so in the
+# one-call `heredoc -> file -> --body-file` shape this repo MANDATES, the path
+# either does not exist yet or still holds what a PREVIOUS call left there. A
+# file-first read judges that previous body, so a stale-but-clean file makes the
+# gate INERT against the body actually being submitted -- the go-to-k/cdk-local#637
+# window, closed here at the outset rather than after a measurement.
+#
+# There is deliberately NO last-resort "scan the whole segment" arm, which is
+# where this diverges from issue-classification-label-gate.sh. That gate must
+# find a value SOMEWHERE or its labels mean nothing; this one objects to content
+# it FINDS, so a fallback that folds `--title` and `--label` text in can only
+# manufacture false blocks -- a title reading `Session-fit: next handling for its
+# own PR` is a title about the rule, not a deferral. pr-body-item-number-gate.sh
+# reached the same verdict from its own measurement.
+segment_body_text() { # <segment>
+  local seg="$1" f f_raw out="" hd have_hd
+  while IFS= read -r f_raw; do
+    [ -n "$f_raw" ] || continue
+    # An unexpanded `$VAR` or a substitution cannot be resolved from command
+    # TEXT. Treat it like an unreadable path and fall back to the whole command
+    # rather than refusing: unlike dup-check, this gate demands nothing be
+    # PRESENT, so "cannot read" is not evidence of a violation.
+    case "$f_raw" in
+      *'$'*|*'`'*) out="$out
+$cmd"; continue ;;
+    esac
+    # BOTH spellings are kept. `f` is the path to READ; `f_raw` is the path as
+    # the command SPELLS it.
+    #
+    # A literal `~` in the command string is text, not something to expand -- a
+    # real tilde would already have been expanded by the shell before gh ran.
+    # shellcheck disable=SC2088
+    f="$f_raw"
+    case "$f" in
+      /*) ;;
+      "~/"*) f="${HOME:-/nonexistent}/${f#\~/}" ;;
+      *) f="$target_dir/$f" ;;
+    esac
+    hd=""
+    have_hd=0
+    if [ ! -r "$f" ] || cmd_rewrites_either "$f_raw" "$f" || cmd_appends_either "$f_raw" "$f"; then
+      hd=$(heredoc_bodies_either "$f_raw" "$f") && have_hd=1
+    fi
+    if [ "$have_hd" = "1" ]; then
+      out="$out
+$hd"
+      # Only a REWRITE supersedes what is on disk. After an append the file is
+      # still the first half of the submitted body.
+      if cmd_rewrites_either "$f_raw" "$f"; then
+        continue
+      fi
+    fi
+    if [ -r "$f" ]; then
+      out="$out
+$(cat "$f" 2>/dev/null || true)"
+    elif [ "$have_hd" != "1" ]; then
+      out="$out
+$cmd"
+    fi
+  # `body=@` is matched FIRST so an `-F body=@path` is not also read as a bare
+  # `-F path`. The bare `-F <path>` arm is not optional: `-F` is gh's short
+  # `--body-file`.
+  done < <(printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
+      # The value class is `$GW` from the SHARED `GATE_PERL_WORD` prelude in
+      # _command-match.sh, not a local `(["\x27]?)([^"\x27\s]+)\1`. That local
+      # shape ENUMERATES where a quote may sit instead of taking one shell WORD,
+      # and it could not span a QUOTED PATH CONTAINING A SPACE, a
+      # BACKSLASH-ESCAPED one, or the GLUED `-F<path>` gh accepts -- each
+      # measured here as a FAIL-OPEN before this change (rc=0 where the plain
+      # spelling gave 2). Ported from go-to-k/cdkd#2639; the full per-shape
+      # table lives in the header of that constant, in _command-match.sh.
+      # (No apostrophe anywhere in this comment: the whole perl program is a
+      # SHELL single-quoted string, so one would end it and hand the rest to
+      # bash as code.)
+      while (/(?:--field|--raw-field|-F)[=\s]*($GW)/g) {
+        my $v = gate_unq($1);
+        next unless $v =~ s/^body=\@//;
+        print "$v\n";
+      }
+      while (/--body-file[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+      while (/(?:^|\s)-F[=\s]*($GW)(?=[\s;&|)]|$)/g) {
+        my $v = gate_unq($1);
+        next if $v =~ /^\w+=/;
+        print "$v\n";
+      }
+    ' 2>/dev/null)
+
+  if [ -n "$out" ]; then
+    printf '%s' "$out"
+    return 0
+  fi
+
+  # `$GW` + `gate_unq`, not a three-alternative class with the quotes STRIPPED
+  # from the ends afterwards. Stripping is not unquoting: it cannot span
+  # adjacent chunks, it cannot see a backslash escape, and it cannot handle a
+  # quote INSIDE the value -- which is gh`s own documented spelling for a field:
+  #
+  #     -f `body=<text>`   quote OUTSIDE   rc=2   correct
+  #     -f body=`<text>`   quote INSIDE    rc=0   FAIL-OPEN
+  #
+  # The `body=` prefix has to be stripped AFTER unquoting for the same reason:
+  # in the quote-inside spelling the prefix sits outside the quotes, so a
+  # strip-then-unquote order never finds it. Measured on this repo before the
+  # change; the quote-inside form is the one gh documents.
+  printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
+    while (/(?:^|\s)--body[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+    while (/(?:^|\s)(?:-f|--field|--raw-field)[=\s]*($GW)/g) {
+      my $v = gate_unq($1);
+      next unless $v =~ s/^body=//;
+      next if $v =~ /^\@/;
+      print "$v\n";
+    }' 2>/dev/null
+}
+
+# EVERY scan is scoped to the SEGMENT that is the `gh issue create`, never to
+# the whole command, and the scoping is load-bearing in BOTH directions here.
+# `-F` is `git commit`'s flag as well as gh's short `--body-file`, so an
+# unscoped extraction reads the COMMIT MESSAGE -- and commit messages quote the
+# lines they describe (the commit introducing this gate quotes a PR-shaped
+# `Session-fit: next` line as the thing it refuses). Unscoped, that commit's own
+# `git commit -F <msg> && gh issue create --body-file <clean>` would have been
+# refused over text that is not the issue body at all.
+offending_seg=""
+# `GATE_PERL_WORD` is one shared literal that several BLOCKING gates
+# interpolate, and every extraction runs `perl ... 2>/dev/null`. A prelude
+# that is present but does NOT COMPILE therefore produces no output, no
+# stderr and no exit-code change -- the gate extracts nothing and PASSES
+# what it exists to refuse. Measured in cdkd: one broken literal disarmed
+# four gates at once, with zero stderr. A non-empty test cannot see that,
+# so probe it FUNCTIONALLY, once, after arming, and at TOP LEVEL -- the
+# extraction helpers run inside `$( )`, where `exit 2` ends only the
+# substitution subshell (measured: an in-function guard PRINTED its
+# refusal and the hook still returned 0).
+gate_perl_word_or_die issue-deferral-criteria-gate || exit 2
+
+while IFS= read -r seg; do
+  if ! gate_matches "$seg" "$GATE_RE_GH_ISSUE_CREATE"; then
+    if [ -z "${GATE_RE_GH_API_ISSUE_CREATE:-}" ] \
+      || ! gate_matches "$seg" "$GATE_RE_GH_API_ISSUE_CREATE"; then
+      continue
+    fi
+  fi
+  body_text=$(segment_body_text "$seg")
+  [ -n "$body_text" ] || continue
+  if scan_text "$body_text"; then
+    offending_seg="$seg"
+    break
+  fi
+done < <(gate_segments "$cmd")
+
+[ -n "$offending_seg" ] || exit 0
+
+{
+  echo "Blocked by issue-deferral-criteria-gate: this \`gh issue create\` body"
+  echo "defers the work with a PR-SHAPED reason:"
+  echo ""
+  echo "  Session-fit: ${OFFENDING_REASON}"
+  echo ""
+  echo "PR shape is not a \`Session-fit\` criterion. From"
+  echo "\`.claude/skills/work-issues/references/implement.md\` section 5:"
+  echo ""
+  echo "  \"'It needs its own PR' is NOT a \`next\` reason -- it is a \`now\`"
+  echo "   item that gets its own PR; the bar is the SESSION, not the diff."
+  echo "   Writing 'independent review surface' on a \`Session-fit\` line is"
+  echo "   the classify-by-MEANS error arriving through the PR boundary.\""
+  echo ""
+  echo "What this repo DOES accept for a \`next\`, per"
+  echo "\`.claude/rules/session-report.md\` and implement.md section 5:"
+  echo ""
+  echo "  - you can NAME the concrete command the next session will run to"
+  echo "    verify the fix, and a FRESH session plainly has it (an existing"
+  echo "    \`local-*\` fixture needing only Docker, a \`vp test run <path>\""
+  echo "    assertion, an ordinary \`gh\` query) -- and RUNNING an existing"
+  echo "    integ is never a deferral reason (median 85 s over 268 rows)"
+  echo "  - what the Calibration paragraph calls genuinely expensive: WRITING"
+  echo "    a new fixture, an integ that FAILS, or a verifier bound to a host"
+  echo "    / account this session cannot reach"
+  echo "  - external input: an upstream fix, a maintainer decision, a quota"
+  echo "  - a SWEEP whose RESIDUE carries its own verification -- file an"
+  echo "    umbrella naming every site, and say which sites this lane DID"
+  echo "    close (implement.md section 5). State it in the CRITERIA's terms:"
+  echo "    review size is the signal you noticed, and \`unreviewable\` is"
+  echo "    refused here for that reason -- name the verification the residue"
+  echo "    needs and this lane is not already paying, or it is a \`now\`."
+  echo ""
+  echo "And nothing is a \`next\` inside a cross-repo scope the user framed as"
+  echo "one session. If none of the above fires, this is a \`now\`: ask what the"
+  echo "next session would have to RE-DERIVE -- a probe, a measurement, a shape"
+  echo "just proved correct in a sibling repo does not survive in an issue body."
+  echo ""
+  echo "Two ways out, both of which leave the gate doing its job:"
+  echo ""
+  echo "  - re-classify: \`Session-fit: now (do it in this session)\` -- and do"
+  echo "    it in this session, splitting the PR if the diff wants splitting"
+  echo "  - re-state the real reason, if one of the criteria above genuinely"
+  echo "    fires, and NAME the next session's verification command beside it"
+  echo ""
+  echo "Deliberate exception (a body QUOTING PR-shaped reasoning INLINE, in"
+  echo "prose, in order to argue against it -- a quote inside a \`\`\` fenced"
+  echo "block needs no bypass; fenced blocks are not scanned). The assignment"
+  echo "must come FIRST in the command, before any \`cd\`:"
+  echo ""
+  echo "  CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1 gh issue create ..."
+  echo ""
+  echo "Rules: .claude/rules/session-report.md (the four TODO fields);"
+  echo "/work-issues section 5 (\"'It needs its own PR' is NOT a \`next\` reason\")."
+} >&2
+exit 2

--- a/.claude/hooks/issue-deferral-criteria-gate.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.sh
@@ -310,7 +310,12 @@ scan_text() { # <body text> -> 0 when the body carries a PR-shaped deferral
   # spelling `session_fit_re` accepts is load-bearing: a body that bolds one
   # field bolds them all, so a bold-blind boundary would fold the whole field
   # block into the reason.
-  local key_re='^[[:space:]]*([-*+>][[:space:]]+)?[*_]*[A-Za-z][A-Za-z_-]*[*_]*:'
+  # The NAMED sibling fields, not any `word:`. A generic key pattern also
+  # matches a URL scheme, so a reason wrapping onto a line that begins with
+  # `https://...` ended there and the PR-shaped half was never scanned
+  # (measured rc=0; the same body with `issue 700` in place of the URL gave 2).
+  # This is what the comment above already claimed the boundary was.
+  local key_re='^[[:space:]]*([-*+>][[:space:]]+)?[*_]*(Session-fit|Severity|Effort|Estimate|Notes|Dup-check)[*_]*:'
   local item_re='^[[:space:]]*([-*+]|[0-9]+[.)])[[:space:]]+'
   local session_fit_re='session-fit[*_]*:[*_]*(.*)$'
   case "$(shopt -p nocasematch)" in *-s*) nocase_was=1 ;; esac
@@ -384,7 +389,10 @@ EOF
       # -- an agent talking itself INTO finishing the work needs no supervision.
       # A line stating neither token (an old packed body, a `Session-fit` in
       # prose) is not a deferral decision this gate can read, so it passes.
-      if [[ $rest =~ ^[[:space:]]*next([^[:alpha:]]|$) ]]; then
+      # The KEY already accepts `**Session-fit:**`, so the VALUE must accept
+      # `**next**` too -- bolding both halves is the natural markdown, and it
+      # slipped through (measured rc=0).
+      if [[ $rest =~ ^[[:space:]]*[*_]*next([^[:alpha:]]|$) ]]; then
         reason="$rest"
         active=1
       else
@@ -521,6 +529,74 @@ heredoc_bodies_either() { # <raw spelling> <resolved path>
 # manufacture false blocks -- a title reading `Session-fit: next handling for its
 # own PR` is a title about the rule, not a deferral. pr-body-item-number-gate.sh
 # reached the same verdict from its own measurement.
+# `gate_segments` emits ONE LINE PER SEGMENT, so a newline inside a quoted
+# inline body arrives here as a SPACE (measured: `A: one\n  B: two` comes back
+# as `A: one   B: two`; only the newline is rewritten, every other byte
+# survives). `scan_text` is LINE-STRUCTURED -- the reason ends at the next
+# `Key:` field, a list item, a heading or a blank line -- so a flattened body
+# has exactly one line, every terminator is unreachable, and the whole body
+# reads as ONE reason. That is a FALSE BLOCK on a legitimate filing, and the
+# body it refuses is the one this repo tells you to write:
+#
+#   Session-fit: next (not this session) -- the integ fixture does not exist yet
+#   Effort: large (L) -- a behavior change needing its own PR plus review
+#
+# Two separate fields, the second quoted from `.claude/rules/session-report.md`
+# and from this gate`s own refusal text. Flattened, `Effort:` no longer
+# terminates the reason and the gate refuses it (measured rc=2; the same body
+# through `--body-file` gives 0).
+#
+# The fix restores the LINE STRUCTURE without widening the scan: the SEGMENT
+# still decides which command this is and which value is its body, and the raw
+# command is consulted only to look that value back up. A raw value is
+# accepted only when collapsing its newlines to spaces reproduces the extracted
+# one byte for byte, so nothing outside the segment can be substituted in.
+#
+# NOTE the env var is assigned on the PERL invocation, not before `printf`: a
+# `VAR=x printf ... | perl` assignment applies to printf, and perl then reads an
+# EMPTY value and silently restores nothing.
+# `gh api ... --input <file>`: the REST mint`s body lives in a JSON payload on
+# disk, which is a body CHANNEL none of the `--body-file` / `-F` / `-f body=`
+# arms above recognises. Extract `.body` from it. Failure at any step (no
+# `--input`, unreadable path, not JSON, no `body` key) prints nothing, which
+# the caller treats as "channel not recognised" and passes -- this gate demands
+# nothing be PRESENT, so "cannot read" is never evidence of a violation.
+input_body_text() { # <segment>
+  local f
+  f=$(printf '%s' "$1" | perl -0777 -ne "$GATE_PERL_WORD"'
+    while (/(?:^|\s)--input[=\s]+($GW)/g) { print gate_unq($1), "\n"; last; }
+  ' 2>/dev/null)
+  [ -n "$f" ] || return 0
+  [ -r "$f" ] || return 0
+  jq -r '.body // empty' "$f" 2>/dev/null || true
+}
+
+restore_inline_newlines() { # <extracted body values, one per line>
+  local restored
+  restored=$(printf '%s' "$cmd" | GATE_COLLAPSED="$1" perl -0777 -ne "$GATE_PERL_WORD"'
+    my %raw;
+    my $keep = sub {
+      my ($v) = @_;
+      return unless $v =~ /\n/;
+      (my $c = $v) =~ s/\n/ /g;
+      $raw{$c} = $v unless exists $raw{$c};
+    };
+    while (/(?:^|\s)(?:--body|-b)[=\s]*($GW)/g) { $keep->(gate_unq($1)); }
+    while (/(?:^|\s)(?:-f|--field|--raw-field)[=\s]*($GW)/g) {
+      my $v = gate_unq($1);
+      next unless $v =~ s/^body=//;
+      next if $v =~ /^\@/;
+      $keep->($v);
+    }
+    for my $l (split /\n/, $ENV{GATE_COLLAPSED}, -1) {
+      print exists $raw{$l} ? $raw{$l} : $l, "\n";
+    }
+  ' 2>/dev/null)
+  # Fail SAFE, not open: if perl produced nothing the caller keeps the
+  # flattened text it already had, which is the pre-fix behaviour.
+  if [ -n "$restored" ]; then printf '%s' "$restored"; else printf '%s' "$1"; fi
+}
+
 segment_body_text() { # <segment>
   local seg="$1" f f_raw out="" hd have_hd
   while IFS= read -r f_raw; do
@@ -529,9 +605,16 @@ segment_body_text() { # <segment>
     # TEXT. Treat it like an unreadable path and fall back to the whole command
     # rather than refusing: unlike dup-check, this gate demands nothing be
     # PRESENT, so "cannot read" is not evidence of a violation.
+    # `$seg`, NOT `$cmd`. Falling back to the WHOLE command re-opens exactly
+    # what the segment scoping below exists to close: a `git commit -m` whose
+    # message QUOTES a PR-shaped line -- routine in this repo, the commit that
+    # introduced this gate does it -- was read as the issue body and refused.
+    # Measured: `git commit -m "<...Session-fit: next -- it needs its own
+    # PR>" && gh issue create -t t --body-file "$BODY"` gave rc=2 with `$cmd`
+    # and rc=0 with `$seg`.
     case "$f_raw" in
       *'$'*|*'`'*) out="$out
-$cmd"; continue ;;
+$seg"; continue ;;
     esac
     # BOTH spellings are kept. `f` is the path to READ; `f_raw` is the path as
     # the command SPELLS it.
@@ -563,8 +646,9 @@ $hd"
       out="$out
 $(cat "$f" 2>/dev/null || true)"
     elif [ "$have_hd" != "1" ]; then
+      # `$seg` for the same reason as the unresolvable-path arm above.
       out="$out
-$cmd"
+$seg"
     fi
   # `body=@` is matched FIRST so an `-F body=@path` is not also read as a bare
   # `-F path`. The bare `-F <path>` arm is not optional: `-F` is gh's short
@@ -612,7 +696,17 @@ $cmd"
   # strip-then-unquote order never finds it. Measured on this repo before the
   # change; the quote-inside form is the one gh documents.
   printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
+    # `-b` is the documented short spelling of `--body` in gh, and this scan is
+    # already scoped to the `gh issue create` SEGMENT, so it cannot collide with
+    # a `-b` belonging to some other command. Without it the gate was INERT on
+    # that spelling: measured, the same PR-shaped reason gave rc=0 through `-b`
+    # and rc=2 through `--body`. The sibling dup-check gate already had the arm,
+    # so this was a port miss rather than a decision.
+    #
+    # NOTE no apostrophes in this perl body -- it is a single-quoted shell
+    # string, and one apostrophe in a comment ends it.
     while (/(?:^|\s)--body[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+    while (/(?:^|\s)-b[=\s]*($GW)/g) { print gate_unq($1), "\n"; }
     while (/(?:^|\s)(?:-f|--field|--raw-field)[=\s]*($GW)/g) {
       my $v = gate_unq($1);
       next unless $v =~ s/^body=//;
@@ -650,7 +744,21 @@ while IFS= read -r seg; do
     fi
   fi
   body_text=$(segment_body_text "$seg")
+  # An extraction that comes back EMPTY is not evidence of a clean body -- it
+  # means no arm recognised the body CHANNEL. `--input <file>` is one: the REST
+  # mint (`gh api repos/o/r/issues`) that `GATE_RE_API_MINT` already arms on
+  # carries its whole payload as JSON on disk, and no arm above reads it.
+  # Measured: `gh api repos/o/r/issues -f title=t --input p.json` with a
+  # PR-shaped `Session-fit: next` in `p.json` filed at rc=0.
+  #
+  # Read `.body` out of it, with the same "cannot read is not evidence" rule as
+  # the `--body-file` arms: an unreadable or non-JSON file leaves `body_text`
+  # empty and the segment passes.
+  if [ -z "$body_text" ]; then
+    body_text=$(input_body_text "$seg")
+  fi
   [ -n "$body_text" ] || continue
+  body_text=$(restore_inline_newlines "$body_text")
   if scan_text "$body_text"; then
     offending_seg="$seg"
     break

--- a/.claude/hooks/issue-deferral-criteria-gate.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.sh
@@ -234,8 +234,13 @@ optin_top=$(git -C "$target_dir" rev-parse --show-toplevel 2>/dev/null || true)
 # `prs?` is bounded by `([^[:alnum:]]|$)` rather than `\b` -- `\b` is a GNU
 # extension that BSD regcomp does not carry, so on macOS it would match nothing
 # and the gate would be inert.
-PR_SHAPE_RE='(own|separate)[[:space:]]+prs?([^[:alnum:]]|$)'
-PR_SHAPE_RE="$PR_SHAPE_RE"'|shar(e|es|ing)[[:space:]]+((a|an|the|its|their)[[:space:]]+)?prs?([^[:alnum:]]|$)'
+# `PR` and `pull request` are the SAME term, and so is a hyphen in place of the
+# space -- these are SPELLINGS of one noun, not the "third spelling in a third
+# round" the note below refuses to chase (which is about reasoning that never
+# names a PR at all). Measured before this alternation: `its own pull request`
+# and `its own-PR` both filed at rc=0 while `its own PR` gave 2.
+PR_SHAPE_RE='(own|separate)[[:space:]-]+(prs?|pull[[:space:]-]+requests?)([^[:alnum:]]|$)'
+PR_SHAPE_RE="$PR_SHAPE_RE"'|shar(e|es|ing)[[:space:]]+((a|an|the|its|their)[[:space:]]+)?(prs?|pull[[:space:]-]+requests?)([^[:alnum:]]|$)'
 PR_SHAPE_RE="$PR_SHAPE_RE"'|(independent|separate)[[:space:]]+review[[:space:]]+surface'
 PR_SHAPE_RE="$PR_SHAPE_RE"'|unreviewable'
 PR_SHAPE_RE="$PR_SHAPE_RE"'|own[[:space:]]+review([^[:alnum:]]|$)'
@@ -323,8 +328,12 @@ scan_text() { # <body text> -> 0 when the body carries a PR-shaped deferral
   #                      from the `Notes:` that passes.
   #
   # So the colon must not be followed by `//`. bash regexes are ERE with no
-  # look-ahead, hence `:([^/]|$)` rather than `:(?!//)`.
-  local key_re='^[[:space:]]*([-*+>][[:space:]]+)?[*_]*[A-Za-z][A-Za-z_-]*[*_]*:([^/]|$)'
+  # look-ahead, hence the explicit alternation. `/[^/]` is load-bearing: a bare
+  # `:([^/]|$)` also excepts every `Key:/value` line, so a continuation reading
+  # `Repro:/tmp/x it needs its own PR` folded into the reason and REFUSED a
+  # legitimate `next` (measured rc=2; the `- Key:/x` list form survived only
+  # because `item_re` caught it first, which is an accident, not coverage).
+  local key_re='^[[:space:]]*([-*+>][[:space:]]+)?[*_]*[A-Za-z][A-Za-z_-]*[*_]*:([^/]|/[^/]|$)'
   local item_re='^[[:space:]]*([-*+]|[0-9]+[.)])[[:space:]]+'
   local session_fit_re='session-fit[*_]*:[*_]*(.*)$'
   case "$(shopt -p nocasematch)" in *-s*) nocase_was=1 ;; esac
@@ -519,8 +528,17 @@ heredoc_bodies_either() { # <raw spelling> <resolved path>
 #   2. the contents of the file at that path, unless arm 1 fired AND the command
 #      REWRITES the path (an APPEND leaves the existing content as the first
 #      half of the submitted body)
-#   3. the WHOLE command, when such a path was named, cannot be read, and no
-#      heredoc writes it -- a `printf > f` body, or an unresolvable `$VAR` path
+#   3. this SEGMENT plus every OTHER segment that WRITES the path, when such a
+#      path was named, cannot be read, and no heredoc writes it -- a
+#      `printf > f` body, or an unresolvable `$VAR` path. Not the whole
+#      command: that refuses a filing whose sibling `git commit -m` message
+#      merely QUOTES a PR-shaped line, and it does so even when a writer is
+#      present, so "is there a writer" is the wrong question and "WHICH segment
+#      is the writer" is the right one. NOTE this arm carries the writer`s
+#      COMMAND TEXT, not its output -- a `printf`-written body is only seen
+#      because the text appears in the command, so a writer over a READABLE
+#      file is not consulted at all (arm 2 wins, and arm 1 covers heredocs
+#      only).
 #   4. the inline `--body` value, plus the `-f`/`--field` `body=` forms the REST
 #      mint uses, quote-aware so a multi-word body stays one value
 #
@@ -582,12 +600,22 @@ heredoc_bodies_either() { # <raw spelling> <resolved path>
 # passes -- this gate demands nothing be PRESENT, so "cannot read" is never
 # evidence of a violation.
 input_body_text() { # <segment>
-  local seg="$1" f_raw f hd
+  local seg="$1" f_raw f hd have_hd
   f_raw=$(printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
     if (/(?:^|\s)--input[=\s]+($GW)/) { print gate_unq($1), "\n"; }
   ' 2>/dev/null)
   [ -n "$f_raw" ] || return 0
-  case "$f_raw" in *'$'*|*'`'*) return 0 ;; esac
+  # A `$VAR` path cannot be resolved to disk -- but a heredoc in THIS command is
+  # keyed on the RAW spelling and needs no resolution, and writing the payload
+  # with a heredoc in the same call is the documented recipe. Measured before
+  # this arm: `cat > "$P" <<JSON ... JSON && gh api ... --input "$P"` filed at
+  # rc=0 while the `--body-file` twin gave 2.
+  case "$f_raw" in
+    *'$'*|*'`'*)
+      hd=$(heredoc_bodies_either "$f_raw" "$f_raw") || hd=""
+      [ -n "$hd" ] && printf '%s' "$hd" | jq -r '.body // empty' 2>/dev/null
+      return 0 ;;
+  esac
   # shellcheck disable=SC2088
   f="$f_raw"
   case "$f" in
@@ -595,35 +623,52 @@ input_body_text() { # <segment>
     "~/"*) f="${HOME:-/nonexistent}/${f#\~/}" ;;
     *) f="$target_dir/$f" ;;
   esac
+  # The STATUS, not the OUTPUT. An empty heredoc body is legal, and reading
+  # emptiness as "no heredoc" falls through to the STALE file on disk -- so
+  # `cat > p.json <<JSON` with an empty body judged the PREVIOUS payload
+  # (measured rc=2 where the `--body-file` twin gives 0).
+  have_hd=0
   if [ ! -r "$f" ] || cmd_rewrites_either "$f_raw" "$f" || cmd_appends_either "$f_raw" "$f"; then
-    hd=$(heredoc_bodies_either "$f_raw" "$f") || hd=""
-    if [ -n "$hd" ]; then
-      printf '%s' "$hd" | jq -r '.body // empty' 2>/dev/null || true
-      return 0
-    fi
+    hd=$(heredoc_bodies_either "$f_raw" "$f") && have_hd=1
+  fi
+  if [ "$have_hd" = "1" ]; then
+    printf '%s' "$hd" | jq -r '.body // empty' 2>/dev/null || true
+    return 0
   fi
   [ -r "$f" ] || return 0
   jq -r '.body // empty' "$f" 2>/dev/null || true
 }
 
-# Restore the line structure `gate_segments` flattened, for the ONE value the
-# caller already extracted from this segment.
+# Restore the line structure `gate_segments` flattened, for the values the
+# caller extracted from THIS segment.
 #
-# It is a LOOKUP, not a re-extraction: a raw value is used only when collapsing
-# its newlines to spaces reproduces the extracted line byte for byte, so the
-# characters never change and only newline POSITIONS move -- which loosens the
-# reason boundary, never tightens it.
+# The lookup is scoped to the segment's own bytes, and the segmenter makes that
+# exact rather than approximate: it rewrites a newline to a SPACE and leaves
+# every other byte alone, so collapsing the whole command the same way produces
+# a string of identical LENGTH in which the segment appears verbatim. Its byte
+# offset there is its byte offset in the raw command, and the raw slice is that
+# offset plus the segment's length.
 #
-# KNOWN BOUND, measured rather than claimed: the lookup table is built from the
-# whole raw command, so a value in ANOTHER segment whose collapsed form is
-# byte-identical to this one wins the lookup. Two `gh issue create` calls in
-# one chain can be crafted that way. It is fail-OPEN only (a restored value has
-# MORE terminators than the flat one, so the reason gets shorter, never
-# longer), and scoping it properly needs a raw-slice-per-segment API the
-# segmenter does not expose -- tracked separately rather than hidden here.
-restore_inline_newlines() { # <extracted body values, one per line> <raw command>
-  local values="$1" raw="$2" restored
-  restored=$(printf '%s' "$raw" | GATE_COLLAPSED="$values" perl -0777 -ne "$GATE_PERL_WORD"'
+# Scoping matters because an unscoped table decides this segment's verdict from
+# ANOTHER segment's text: a `gh issue comment --body` whose collapsed form
+# equals the create's body handed the create its own newline placement, and the
+# create alone reached the opposite verdict. Not a bounded fail-open either --
+# added line structure can expose a LATER `Session-fit:` that the flat line hid,
+# because `scan_text` reads the first match per line.
+#
+# Restoration is not a safety direction, it is ACCURACY: the gate should judge
+# the body gh will send. A value the slice does not contain is left flat.
+restore_inline_newlines() { # <extracted values, one per line> <raw command> <segment>
+  local values="$1" raw="$2" seg="$3" restored
+  restored=$(GATE_RAW="$raw" GATE_SEG="$seg" GATE_COLLAPSED="$values" perl -e "$GATE_PERL_WORD"'
+    my $raw = $ENV{GATE_RAW};
+    my $seg = $ENV{GATE_SEG};
+    (my $flat = $raw) =~ s/\n/ /g;
+    my $off = index($flat, $seg);
+    # No slice means the segment did not come from this command text (a caller
+    # passing something else, or a segmenter that rewrote more than newlines).
+    # Print the input unchanged rather than guess.
+    my $slice = $off < 0 ? "" : substr($raw, $off, length($seg));
     my %raw;
     my $keep = sub {
       my ($v) = @_;
@@ -631,12 +676,20 @@ restore_inline_newlines() { # <extracted body values, one per line> <raw command
       (my $c = $v) =~ s/\n/ /g;
       $raw{$c} = $v unless exists $raw{$c};
     };
-    while (/(?:^|\s)(?:--body|-b)[=\s]+($GW)/g) { $keep->(gate_unq($1)); }
-    while (/(?:^|\s)(?:-f|--field|--raw-field)[=\s]*($GW)/g) {
-      my $v = gate_unq($1);
-      next unless $v =~ s/^body=//;
-      next if $v =~ /^\@/;
-      $keep->($v);
+    # MIRROR the extractor exactly: `--body` needs a separator, `-b` does not.
+    # Demanding one for both false-blocks the GLUED `-b<multi-line body>` -- it
+    # is extracted flattened and then never restored, which is precisely the
+    # defect this function exists to prevent (measured rc=2 on a legitimate
+    # two-field body).
+    for ($slice) {
+      while (/(?:^|\s)--body[=\s]+($GW)/g) { $keep->(gate_unq($1)); }
+      while (/(?:^|\s)-b[=\s]*($GW)/g)     { $keep->(gate_unq($1)); }
+      while (/(?:^|\s)(?:-f|--field|--raw-field)[=\s]*($GW)/g) {
+        my $v = gate_unq($1);
+        next unless $v =~ s/^body=//;
+        next if $v =~ /^\@/;
+        $keep->($v);
+      }
     }
     for my $l (split /\n/, $ENV{GATE_COLLAPSED}, -1) {
       print exists $raw{$l} ? $raw{$l} : $l, "\n";
@@ -647,6 +700,38 @@ restore_inline_newlines() { # <extracted body values, one per line> <raw command
   if [ -n "$restored" ]; then printf '%s' "$restored"; else printf '%s' "$values"; fi
 }
 
+# The body-file fallback text: the `gh` SEGMENT, plus every OTHER segment that
+# WRITES the path -- never the whole command.
+#
+# Three shapes, and only this rule gets all three right. Measured, each on a
+# body whose PR-shaped text is in the place named:
+#
+#   `$seg` only    lost the writer: `printf <PR-shaped> > b.md && gh issue
+#                  create --body-file b.md` (b.md unreadable) went 2 -> 0.
+#   `$cmd` whole   refused a filing whose sibling `git commit -m` message
+#                  merely QUOTES a PR-shaped line: 0 -> 2.
+#   `$cmd` when a  still refuses it the moment BOTH exist in one chain --
+#   writer exists  `git commit -m <PR-shaped> && printf <clean> > b.md &&
+#                  gh issue create --body-file b.md` gave 2.
+#
+# So the question is not "is there a writer somewhere" but "WHICH segment is
+# the writer", and the segmenter already answers it. `cmd_writes` reads the
+# global `$cmd`, so each segment is tested with that global rebound inside a
+# SUBSHELL -- rebinding it in place would corrupt every later scan.
+fallback_body_text() { # <raw spelling> <resolved path> <gh segment>
+  local f_raw="$1" f="$2" seg="$3" s out
+  out="$seg"
+  while IFS= read -r s; do
+    [ -n "$s" ] || continue
+    [ "$s" = "$seg" ] && continue
+    if ( cmd="$s"; cmd_rewrites_either "$f_raw" "$f" || cmd_appends_either "$f_raw" "$f" ); then
+      out="$out
+$s"
+    fi
+  done < <(gate_segments "$cmd")
+  printf '%s' "$out"
+}
+
 segment_body_text() { # <segment>
   local seg="$1" f f_raw out="" hd have_hd
   while IFS= read -r f_raw; do
@@ -655,25 +740,14 @@ segment_body_text() { # <segment>
     # TEXT. Treat it like an unreadable path and fall back to the whole command
     # rather than refusing: unlike dup-check, this gate demands nothing be
     # PRESENT, so "cannot read" is not evidence of a violation.
-    # `$seg` unless the command WRITES this path, in which case `$cmd`. Both
-    # halves are measured, and they pull opposite ways:
-    #
-    #   `$cmd` always   a `git commit -m` message QUOTING a PR-shaped line --
-    #                   routine here; the commit introducing this gate does it
-    #                   -- was read as the issue body and REFUSED (rc=2).
-    #   `$seg` always   `printf <PR-shaped> > b.md && gh issue create
-    #                   --body-file b.md` with `b.md` unreadable lost the
-    #                   writer, which lives in ANOTHER segment (rc=2 -> 0).
-    #
-    # The writer is exactly what tells them apart, and the write
-    # predicates already answer it against the RAW command text -- so it answers for an
-    # unexpanded `$VAR` path too, which is the arm below.
+    # An unexpanded `$VAR` or a substitution cannot be resolved from command
+    # TEXT. Treat it like an unreadable path and fall back rather than refuse:
+    # unlike dup-check, this gate demands nothing be PRESENT, so "cannot read"
+    # is not evidence of a violation. Both spellings passed to the writer probe
+    # are the RAW one -- there is no resolved path here, which is the point.
     case "$f_raw" in
-      *'$'*|*'`'*)
-        if cmd_rewrites_either "$f_raw" "$f_raw" || cmd_appends_either "$f_raw" "$f_raw"; then out="$out
-$cmd"; else out="$out
-$seg"; fi
-        continue ;;
+      *'$'*|*'`'*) out="$out
+$(fallback_body_text "$f_raw" "$f_raw" "$seg")"; continue ;;
     esac
     # BOTH spellings are kept. `f` is the path to READ; `f_raw` is the path as
     # the command SPELLS it.
@@ -705,16 +779,9 @@ $hd"
       out="$out
 $(cat "$f" 2>/dev/null || true)"
     elif [ "$have_hd" != "1" ]; then
-      # Same split as the unresolvable-path arm above: the writer of an
-      # unreadable body file lives in another segment, everything else does
-      # not.
-      if cmd_rewrites_either "$f_raw" "$f" || cmd_appends_either "$f_raw" "$f"; then
-        out="$out
-$cmd"
-      else
-        out="$out
-$seg"
-      fi
+      # Same rule as the unresolvable-path arm above.
+      out="$out
+$(fallback_body_text "$f_raw" "$f" "$seg")"
     fi
   # `body=@` is matched FIRST so an `-F body=@path` is not also read as a bare
   # `-F path`. The bare `-F <path>` arm is not optional: `-F` is gh's short
@@ -824,7 +891,7 @@ while IFS= read -r seg; do
     body_text=$(input_body_text "$seg")
   fi
   [ -n "$body_text" ] || continue
-  body_text=$(restore_inline_newlines "$body_text" "$cmd")
+  body_text=$(restore_inline_newlines "$body_text" "$cmd" "$seg")
   if scan_text "$body_text"; then
     offending_seg="$seg"
     break

--- a/.claude/hooks/issue-deferral-criteria-gate.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.sh
@@ -658,13 +658,26 @@ input_body_text() { # <segment>
 #
 # Restoration is not a safety direction, it is ACCURACY: the gate should judge
 # the body gh will send. A value the slice does not contain is left flat.
-restore_inline_newlines() { # <extracted values, one per line> <raw command> <segment>
+restore_inline_newlines() { # <values> <raw command> <segment> <1-based ordinal of this segment among identical ones>
   local values="$1" raw="$2" seg="$3" restored
-  restored=$(GATE_RAW="$raw" GATE_SEG="$seg" GATE_COLLAPSED="$values" perl -e "$GATE_PERL_WORD"'
+  restored=$(GATE_RAW="$raw" GATE_SEG="$seg" GATE_SEG_ORD="$4" GATE_COLLAPSED="$values" perl -e "$GATE_PERL_WORD"'
     my $raw = $ENV{GATE_RAW};
     my $seg = $ENV{GATE_SEG};
     (my $flat = $raw) =~ s/\n/ /g;
-    my $off = index($flat, $seg);
+    # The ORDINAL, not the first hit. `index` alone hands the SECOND of two
+    # segments that collapse to identical text the FIRST one`s raw slice, and a
+    # flat PR-shaped filing then passes on the newline placement of its twin
+    # (measured rc=0 for `gh issue create --body "<two lines>" && gh issue
+    # create --body "<the same text on one line>"`, where the second command
+    # ALONE gives 2). Segments arrive in order, so the caller`s count of how
+    # many identical ones it has already passed selects the right occurrence.
+    my $ord = ($ENV{GATE_SEG_ORD} || 1) + 0;
+    my ($off, $pos) = (-1, 0);
+    for (my $i = 0; $i < $ord; $i++) {
+      $off = index($flat, $seg, $pos);
+      last if $off < 0;
+      $pos = $off + 1;
+    }
     # No slice means the segment did not come from this command text (a caller
     # passing something else, or a segmenter that rewrote more than newlines).
     # Print the input unchanged rather than guess.
@@ -718,17 +731,34 @@ restore_inline_newlines() { # <extracted values, one per line> <raw command> <se
 # the writer", and the segmenter already answers it. `cmd_writes` reads the
 # global `$cmd`, so each segment is tested with that global rebound inside a
 # SUBSHELL -- rebinding it in place would corrupt every later scan.
+# `$all_segments` is the segment list computed ONCE by the caller, not a fresh
+# `gate_segments "$cmd"` here: this runs per unreadable path per gh segment, and
+# re-splitting the whole command each time is quadratic. Measured before the
+# hoist, on N chained `gh issue create --body-file missing$i.md`: 3.4 s at N=20
+# and 12.6 s at N=40, past the PreToolUse timeout -- which is a SILENT PASS, so
+# the cost is a correctness bug, not a slow gate.
 fallback_body_text() { # <raw spelling> <resolved path> <gh segment>
   local f_raw="$1" f="$2" seg="$3" s out
   out="$seg"
   while IFS= read -r s; do
     [ -n "$s" ] || continue
     [ "$s" = "$seg" ] && continue
+    # A writer is a redirect or a `tee`, so a segment with neither cannot be
+    # one -- and this test is a shell string match, while the probe below forks
+    # perl twice. Without it the walk forked 2N times per unreadable path per
+    # gh segment: 40 chained `--body-file missing$i.md` took 10-19 s across the
+    # three repos, past the PreToolUse timeout, which is a SILENT PASS.
+    case "$s" in
+      *'>'*|*tee*) ;;
+      *) continue ;;
+    esac
     if ( cmd="$s"; cmd_rewrites_either "$f_raw" "$f" || cmd_appends_either "$f_raw" "$f" ); then
       out="$out
 $s"
     fi
-  done < <(gate_segments "$cmd")
+  done <<EOF
+$all_segments
+EOF
   printf '%s' "$out"
 }
 
@@ -869,7 +899,23 @@ offending_seg=""
 # refusal and the hook still returned 0).
 gate_perl_word_or_die issue-deferral-criteria-gate || exit 2
 
+# ONCE. `gate_segments` is an awk pass over the whole command, and the fallback
+# below needs the same list per unreadable path -- recomputing it there was
+# quadratic and crossed the PreToolUse timeout, which is a SILENT PASS.
+all_segments=$(gate_segments "$cmd")
+# How many segments IDENTICAL to the current one have already been seen. The
+# restore lookup selects the raw slice by this ordinal, because two segments
+# can collapse to the same text and `index` would hand the second the first
+# one`s slice. `grep -c` exits 1 on zero matches, so `|| true` and then a
+# default -- never `|| echo 0`, which prints a count AND appends a second one.
+seen_segments=""
+
 while IFS= read -r seg; do
+  seg_ord=$(printf '%s\n' "$seen_segments" | grep -Fxc -- "$seg" 2>/dev/null || true)
+  [ -n "$seg_ord" ] || seg_ord=0
+  seg_ord=$((seg_ord + 1))
+  seen_segments="$seen_segments
+$seg"
   if ! gate_matches "$seg" "$GATE_RE_GH_ISSUE_CREATE"; then
     if [ -z "${GATE_RE_GH_API_ISSUE_CREATE:-}" ] \
       || ! gate_matches "$seg" "$GATE_RE_GH_API_ISSUE_CREATE"; then
@@ -891,12 +937,14 @@ while IFS= read -r seg; do
     body_text=$(input_body_text "$seg")
   fi
   [ -n "$body_text" ] || continue
-  body_text=$(restore_inline_newlines "$body_text" "$cmd" "$seg")
+  body_text=$(restore_inline_newlines "$body_text" "$cmd" "$seg" "$seg_ord")
   if scan_text "$body_text"; then
     offending_seg="$seg"
     break
   fi
-done < <(gate_segments "$cmd")
+done <<EOF
+$all_segments
+EOF
 
 [ -n "$offending_seg" ] || exit 0
 

--- a/.claude/hooks/issue-deferral-criteria-gate.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.sh
@@ -310,12 +310,21 @@ scan_text() { # <body text> -> 0 when the body carries a PR-shaped deferral
   # spelling `session_fit_re` accepts is load-bearing: a body that bolds one
   # field bolds them all, so a bold-blind boundary would fold the whole field
   # block into the reason.
-  # The NAMED sibling fields, not any `word:`. A generic key pattern also
-  # matches a URL scheme, so a reason wrapping onto a line that begins with
-  # `https://...` ended there and the PR-shaped half was never scanned
-  # (measured rc=0; the same body with `issue 700` in place of the URL gave 2).
-  # This is what the comment above already claimed the boundary was.
-  local key_re='^[[:space:]]*([-*+>][[:space:]]+)?[*_]*(Session-fit|Severity|Effort|Estimate|Notes|Dup-check)[*_]*:'
+  # Any `Key:` line ends the reason, EXCEPT a URL scheme. Two measured
+  # defects pull against each other here and only this shape answers both:
+  #
+  #   any `word:`        a reason wrapping onto a line that begins with
+  #                      `https://...` ended there, and the PR-shaped half was
+  #                      never scanned (rc=0; the same body with `issue 700` in
+  #                      place of the URL gave 2).
+  #   the NAMED fields   every OTHER single-word field line then folds INTO the
+  #                      reason: `Note:` (singular) and `Repro:` both turned a
+  #                      legitimate `next` into a refusal, one character away
+  #                      from the `Notes:` that passes.
+  #
+  # So the colon must not be followed by `//`. bash regexes are ERE with no
+  # look-ahead, hence `:([^/]|$)` rather than `:(?!//)`.
+  local key_re='^[[:space:]]*([-*+>][[:space:]]+)?[*_]*[A-Za-z][A-Za-z_-]*[*_]*:([^/]|$)'
   local item_re='^[[:space:]]*([-*+]|[0-9]+[.)])[[:space:]]+'
   local session_fit_re='session-fit[*_]*:[*_]*(.*)$'
   case "$(shopt -p nocasematch)" in *-s*) nocase_was=1 ;; esac
@@ -557,23 +566,64 @@ heredoc_bodies_either() { # <raw spelling> <resolved path>
 # EMPTY value and silently restores nothing.
 # `gh api ... --input <file>`: the REST mint`s body lives in a JSON payload on
 # disk, which is a body CHANNEL none of the `--body-file` / `-F` / `-f body=`
-# arms above recognises. Extract `.body` from it. Failure at any step (no
-# `--input`, unreadable path, not JSON, no `body` key) prints nothing, which
-# the caller treats as "channel not recognised" and passes -- this gate demands
-# nothing be PRESENT, so "cannot read" is never evidence of a violation.
+# arms above recognises. Extract `.body` from it.
+#
+# The path goes through the SAME resolution as the `--body-file` arms, and for
+# the same reasons: a relative path is joined to the resolved cwd, a literal
+# `~/` is expanded, and a payload the command WRITES in this very call is read
+# out of its heredoc rather than off disk (writing the payload with a heredoc
+# in the same command is this repo`s own documented filing recipe). Resolving
+# only absolute, already-existing paths closed the narrowest third of the hole:
+# measured, `--input rel.json` and a `cat > x.json <<JSON` payload both filed a
+# PR-shaped `next` at rc=0 while the `--body-file` twin of each gave rc=2.
+#
+# Failure at any step (no `--input`, unreadable path, not JSON, no `body` key)
+# prints nothing, which the caller treats as "channel not recognised" and
+# passes -- this gate demands nothing be PRESENT, so "cannot read" is never
+# evidence of a violation.
 input_body_text() { # <segment>
-  local f
-  f=$(printf '%s' "$1" | perl -0777 -ne "$GATE_PERL_WORD"'
-    while (/(?:^|\s)--input[=\s]+($GW)/g) { print gate_unq($1), "\n"; last; }
+  local seg="$1" f_raw f hd
+  f_raw=$(printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
+    if (/(?:^|\s)--input[=\s]+($GW)/) { print gate_unq($1), "\n"; }
   ' 2>/dev/null)
-  [ -n "$f" ] || return 0
+  [ -n "$f_raw" ] || return 0
+  case "$f_raw" in *'$'*|*'`'*) return 0 ;; esac
+  # shellcheck disable=SC2088
+  f="$f_raw"
+  case "$f" in
+    /*) ;;
+    "~/"*) f="${HOME:-/nonexistent}/${f#\~/}" ;;
+    *) f="$target_dir/$f" ;;
+  esac
+  if [ ! -r "$f" ] || cmd_rewrites_either "$f_raw" "$f" || cmd_appends_either "$f_raw" "$f"; then
+    hd=$(heredoc_bodies_either "$f_raw" "$f") || hd=""
+    if [ -n "$hd" ]; then
+      printf '%s' "$hd" | jq -r '.body // empty' 2>/dev/null || true
+      return 0
+    fi
+  fi
   [ -r "$f" ] || return 0
   jq -r '.body // empty' "$f" 2>/dev/null || true
 }
 
-restore_inline_newlines() { # <extracted body values, one per line>
-  local restored
-  restored=$(printf '%s' "$cmd" | GATE_COLLAPSED="$1" perl -0777 -ne "$GATE_PERL_WORD"'
+# Restore the line structure `gate_segments` flattened, for the ONE value the
+# caller already extracted from this segment.
+#
+# It is a LOOKUP, not a re-extraction: a raw value is used only when collapsing
+# its newlines to spaces reproduces the extracted line byte for byte, so the
+# characters never change and only newline POSITIONS move -- which loosens the
+# reason boundary, never tightens it.
+#
+# KNOWN BOUND, measured rather than claimed: the lookup table is built from the
+# whole raw command, so a value in ANOTHER segment whose collapsed form is
+# byte-identical to this one wins the lookup. Two `gh issue create` calls in
+# one chain can be crafted that way. It is fail-OPEN only (a restored value has
+# MORE terminators than the flat one, so the reason gets shorter, never
+# longer), and scoping it properly needs a raw-slice-per-segment API the
+# segmenter does not expose -- tracked separately rather than hidden here.
+restore_inline_newlines() { # <extracted body values, one per line> <raw command>
+  local values="$1" raw="$2" restored
+  restored=$(printf '%s' "$raw" | GATE_COLLAPSED="$values" perl -0777 -ne "$GATE_PERL_WORD"'
     my %raw;
     my $keep = sub {
       my ($v) = @_;
@@ -581,7 +631,7 @@ restore_inline_newlines() { # <extracted body values, one per line>
       (my $c = $v) =~ s/\n/ /g;
       $raw{$c} = $v unless exists $raw{$c};
     };
-    while (/(?:^|\s)(?:--body|-b)[=\s]*($GW)/g) { $keep->(gate_unq($1)); }
+    while (/(?:^|\s)(?:--body|-b)[=\s]+($GW)/g) { $keep->(gate_unq($1)); }
     while (/(?:^|\s)(?:-f|--field|--raw-field)[=\s]*($GW)/g) {
       my $v = gate_unq($1);
       next unless $v =~ s/^body=//;
@@ -594,7 +644,7 @@ restore_inline_newlines() { # <extracted body values, one per line>
   ' 2>/dev/null)
   # Fail SAFE, not open: if perl produced nothing the caller keeps the
   # flattened text it already had, which is the pre-fix behaviour.
-  if [ -n "$restored" ]; then printf '%s' "$restored"; else printf '%s' "$1"; fi
+  if [ -n "$restored" ]; then printf '%s' "$restored"; else printf '%s' "$values"; fi
 }
 
 segment_body_text() { # <segment>
@@ -605,16 +655,25 @@ segment_body_text() { # <segment>
     # TEXT. Treat it like an unreadable path and fall back to the whole command
     # rather than refusing: unlike dup-check, this gate demands nothing be
     # PRESENT, so "cannot read" is not evidence of a violation.
-    # `$seg`, NOT `$cmd`. Falling back to the WHOLE command re-opens exactly
-    # what the segment scoping below exists to close: a `git commit -m` whose
-    # message QUOTES a PR-shaped line -- routine in this repo, the commit that
-    # introduced this gate does it -- was read as the issue body and refused.
-    # Measured: `git commit -m "<...Session-fit: next -- it needs its own
-    # PR>" && gh issue create -t t --body-file "$BODY"` gave rc=2 with `$cmd`
-    # and rc=0 with `$seg`.
+    # `$seg` unless the command WRITES this path, in which case `$cmd`. Both
+    # halves are measured, and they pull opposite ways:
+    #
+    #   `$cmd` always   a `git commit -m` message QUOTING a PR-shaped line --
+    #                   routine here; the commit introducing this gate does it
+    #                   -- was read as the issue body and REFUSED (rc=2).
+    #   `$seg` always   `printf <PR-shaped> > b.md && gh issue create
+    #                   --body-file b.md` with `b.md` unreadable lost the
+    #                   writer, which lives in ANOTHER segment (rc=2 -> 0).
+    #
+    # The writer is exactly what tells them apart, and the write
+    # predicates already answer it against the RAW command text -- so it answers for an
+    # unexpanded `$VAR` path too, which is the arm below.
     case "$f_raw" in
-      *'$'*|*'`'*) out="$out
-$seg"; continue ;;
+      *'$'*|*'`'*)
+        if cmd_rewrites_either "$f_raw" "$f_raw" || cmd_appends_either "$f_raw" "$f_raw"; then out="$out
+$cmd"; else out="$out
+$seg"; fi
+        continue ;;
     esac
     # BOTH spellings are kept. `f` is the path to READ; `f_raw` is the path as
     # the command SPELLS it.
@@ -646,9 +705,16 @@ $hd"
       out="$out
 $(cat "$f" 2>/dev/null || true)"
     elif [ "$have_hd" != "1" ]; then
-      # `$seg` for the same reason as the unresolvable-path arm above.
-      out="$out
+      # Same split as the unresolvable-path arm above: the writer of an
+      # unreadable body file lives in another segment, everything else does
+      # not.
+      if cmd_rewrites_either "$f_raw" "$f" || cmd_appends_either "$f_raw" "$f"; then
+        out="$out
+$cmd"
+      else
+        out="$out
 $seg"
+      fi
     fi
   # `body=@` is matched FIRST so an `-F body=@path` is not also read as a bare
   # `-F path`. The bare `-F <path>` arm is not optional: `-F` is gh's short
@@ -758,7 +824,7 @@ while IFS= read -r seg; do
     body_text=$(input_body_text "$seg")
   fi
   [ -n "$body_text" ] || continue
-  body_text=$(restore_inline_newlines "$body_text")
+  body_text=$(restore_inline_newlines "$body_text" "$cmd")
   if scan_text "$body_text"; then
     offending_seg="$seg"
     break

--- a/.claude/hooks/issue-deferral-criteria-gate.test.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.test.sh
@@ -1,0 +1,764 @@
+#!/usr/bin/env bash
+# Smoke tests for issue-deferral-criteria-gate.sh
+#
+# Run from anywhere:  bash .claude/hooks/issue-deferral-criteria-gate.test.sh
+# `vp run test:hooks` globs `.claude/hooks/*.test.sh`, so this file is picked up
+# with no registration step.
+#
+# The gate blocks `gh issue create` when the body's `Session-fit: next` line
+# defers the work for a PR-SHAPED reason ("needs its own PR", "a separate PR",
+# "independent review surface", "its own review surface"). Asserts, in both
+# directions:
+#
+#   - BLOCK for every PR-shaped spelling in the vocabulary, inline and
+#     file-borne
+#   - BLOCK for `unreviewable` too, wrapped as well as inline. The port first
+#     dropped that word because implement.md section 5 and
+#     .claude/rules/session-report.md's Calibration paragraph both blessed a
+#     review-SIZE deferral; both were reworded on 2026-09-05 (matching
+#     go-to-k/cdkd#2619) so that review size is the SIGNAL and the criterion is
+#     the verification the residue needs. These two cases are the fence against
+#     the word drifting back OUT of the vocabulary.
+#   - PASS for the same sweep re-stated in the criteria's terms — the umbrella
+#     filing the reworded section 5 asks for. The pair is what makes the block
+#     above a rewording tax rather than a filing threshold: an N-sites sweep is
+#     still deferrable, it just has to say WHY in a term `Session-fit` owns.
+#   - PASS  for every LEGITIMATE `next` reason, including one that mentions a
+#     PR without being PR-SHAPED (an upstream PR is external input, which IS a
+#     criterion) — the gate keys on the reasoning, not on the token `PR`
+#   - PASS  for `Session-fit: now`, whatever its reason says, and for a body
+#     with no `Session-fit` line at all: this gate has exactly one job and the
+#     two sibling issue gates own filing hygiene
+#   - PASS  for `gh issue edit` / `gh issue comment` carrying the same text —
+#     re-classification is the outcome the gate steers toward
+#   - PASS  outside an opted-in repo
+#   - correct in BOTH directions on the `git commit -F <msg> && gh issue create
+#     --body-file <body>` shape: `-F` is `git commit`'s flag as well as gh's
+#     short `--body-file`, so an unscoped extraction reads the COMMIT MESSAGE
+#     and manufactures a FALSE BLOCK from a neighbouring segment
+#   - BLOCK on the one-call `heredoc -> file -> --body-file` shape when the path
+#     ALREADY EXISTS (the go-to-k/cdk-local#637 window): a stale-but-clean file
+#     makes a file-first gate judge the PREVIOUS body and pass, which is the
+#     dangerous direction — a run that looks like a working gate
+#   - PASS for a body ARGUING about this rule that quotes the refused line
+#     inside a fenced code block, while the same quote UNFENCED still blocks
+#   - BLOCK on a `**Session-fit:**` / `**Session-fit**:` bolded key
+#   - PASS for a legitimate reason followed by a list item (this repo's own
+#     report template nests the four fields as bullets)
+#
+# MUTATION-PROBED rather than asserted, re-measured 2026-09-05 over the 87
+# cases below, under bash 3.2 (the harness default). A tally says how many
+# cases ran, not what any of them fences, so each fence was broken in the real
+# hook and the survivors counted:
+#
+#   always-`exit 0` stub                     fails 50   (nothing passes vacuously)
+#   always-`exit 2` stub                     fails 43   (nor does anything block
+#                                                        vacuously)
+#   `next` polarity test -> `if true`        fails  2   -- exactly the two
+#                                                        `Session-fit: now` cases
+#   continuation boundary -> `if false`      fails  4   -- the sibling field-line
+#                                                        case plus the bold-key,
+#                                                        bullet and numbered-item
+#                                                        cases: the boundary is
+#                                                        load-bearing, not
+#                                                        decoration
+#   segment scoping reverted (scan `$cmd`)   fails  4   -- both neighbouring-
+#                                                        segment cases, plus the
+#                                                        subshell and command-
+#                                                        substitution spellings
+#   fence strip -> never matches             fails  2   -- exactly the two
+#                                                        fenced-exhibit cases
+#   bolded-key accept reverted               fails  2   -- exactly the two bold
+#                                                        spellings
+#   list-item boundary -> never matches      fails  2   -- exactly the bullet and
+#                                                        numbered-item cases
+#   heredoc arm 1 removed (file-first)       fails  3   -- the fail-open case, its
+#                                                        false-block complement,
+#                                                        and the relative spelling
+#   `cmd_rewrites_either` -> `return 0`      fails  1   -- exactly the APPEND case,
+#                                                        so "an append is not a
+#                                                        rewrite" is fenced apart
+#                                                        from "the command writes"
+#   raw path spelling dropped                fails  1   -- exactly the relative
+#                                                        case, so offering BOTH
+#                                                        spellings to the matchers
+#                                                        is fenced
+#   `unreviewable` dropped from PR_SHAPE_RE  fails  2   -- exactly the two sweep
+#                                                        cases, so the word is
+#                                                        FENCED into the list
+#                                                        rather than merely
+#                                                        commented into it
+#
+# Keep these numbers current when cases are added — a stale count in a comment
+# that exists to prove non-vacuity is itself the thing it warns about.
+
+set -u
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/issue-deferral-criteria-gate.sh"
+pass=0
+fail=0
+
+TMPBASE=$(mktemp -d)
+trap 'rm -rf "$TMPBASE"' EXIT
+
+# bash 3.2 is NOT exercised on the HOOK by running THIS FILE under /bin/bash.
+# The hook's shebang is `#!/usr/bin/env bash`, which resolves through PATH and
+# finds whatever bash is first there -- Homebrew 5.x on a dev Mac -- so
+# `/bin/bash <suite>` would measure the SUITE under 3.2 and the SUBJECT under
+# 5.x. `HOOK_BASH` puts a `bash` shim first on PATH so the shebang, the explicit
+# `bash "$HOOK"` calls, and any `bash` the hook itself spawns all follow the
+# harness. DEFAULTED to `/bin/bash` (3.2 on macOS) rather than left opt-in,
+# matching `pr-body-item-number-gate.test.sh` and `gate-command-recognition.test.sh`
+# in this repo: nothing sets `HOOK_BASH` in `vp run test:hooks`, so an opt-in
+# fence measures 5.x in CI forever. Override with
+# `HOOK_BASH=/opt/homebrew/bin/bash bash <this file>` to take the 5.x tally.
+# It matters here specifically: this hook uses `shopt -s nocasematch`, `[[ =~ ]]`
+# with variable regexes, an array built by a read loop (NOT `mapfile`, which
+# does not exist in 3.2) and process substitution.
+HOOK_BASH="${HOOK_BASH:-/bin/bash}"
+[ -x "$HOOK_BASH" ] || HOOK_BASH="$(command -v bash)"
+if [ -n "${HOOK_BASH:-}" ]; then
+  # Resolved to an ABSOLUTE path first: `HOOK_BASH=bash` would otherwise make
+  # `ln -sf bash <shim>/bash` a symlink pointing at ITSELF, and every hook
+  # invocation would die on ELOOP -- a suite-wide red with a cause nowhere near
+  # the hook.
+  HOOK_BASH_BIN="$(command -v "$HOOK_BASH" 2>/dev/null || printf '%s' "$HOOK_BASH")"
+  case "$HOOK_BASH_BIN" in /*) ;; *) HOOK_BASH_BIN="$PWD/$HOOK_BASH_BIN" ;; esac
+  HOOK_BASH_SHIM="$TMPBASE/bash32-shim"
+  mkdir -p "$HOOK_BASH_SHIM"
+  ln -sf "$HOOK_BASH_BIN" "$HOOK_BASH_SHIM/bash"
+  PATH="$HOOK_BASH_SHIM:$PATH"
+  export PATH
+fi
+# PRINTED, not merely honoured: a suite that does not say which interpreter it
+# measured cannot be read as evidence about either one.
+printf 'hook interpreter: %s (bash %s)\n' \
+  "$(command -v bash)" "$(bash -c 'echo "$BASH_VERSION"')"
+
+# `jq` must exist for the hook to parse the payload. Without it the hook reads
+# an EMPTY command and every BLOCK case would pass vacuously, so refuse to run
+# rather than report a green suite over nothing. `perl` is what the heredoc
+# extraction runs on; `git` is what the repo opt-in reads.
+for tool in jq perl git; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "FATAL: $tool is required; without it cases would pass vacuously." >&2
+    exit 1
+  }
+done
+
+invoke_hook() { # <hook path>; reads stdin
+  "$HOOK_BASH" "$1"
+}
+invoke_hook_env() { # <VAR=value> <hook path>; reads stdin
+  env "$1" "$HOOK_BASH" "$2"
+}
+
+# Two fixture trees, because the gate is repo-opt-in:
+#   $OPTIN   -- a git repo carrying `.markgate.yml`, so the gate fires
+#   $NOOPTIN -- a git repo without it, so the gate must stay silent
+# Real repos rather than mocks: the opt-in decision is exactly what
+# `git rev-parse --show-toplevel` reports, so mocking it would test nothing.
+OPTIN="$TMPBASE/optin"
+NOOPTIN="$TMPBASE/no-optin"
+for d in "$OPTIN" "$NOOPTIN"; do
+  mkdir -p "$d"
+  git -C "$d" init -q 2>/dev/null
+done
+printf 'gates: {}\n' > "$OPTIN/.markgate.yml"
+
+# run <name> <command> <cwd> <expected-exit>
+run() {
+  local name="$1" command="$2" cwd="$3" expect="$4"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | invoke_hook "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ]; then
+    printf 'OK   %-62s (exit %s)\n' "$name" "$rc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL %s (exit %s, expected %s)\n' "$name" "$rc" "$expect"
+    printf '%s\n' "$out" | sed 's/^/       /' | head -5
+    fail=$((fail + 1))
+  fi
+}
+
+# run_msg <name> <command> <cwd> <expected-exit> <substring the stderr carries>
+# The refusal QUOTES the offending line back, and that is the half a bare exit
+# code cannot see: a gate that blocks while naming the wrong line teaches the
+# reader to distrust it.
+run_msg() {
+  local name="$1" command="$2" cwd="$3" expect="$4" needle="$5"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | invoke_hook "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ] && printf '%s' "$out" | grep -qF "$needle"; then
+    printf 'OK   %-62s (message matched)\n' "$name"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL %s (exit %s, expected %s carrying %s)\n' "$name" "$rc" "$expect" "$needle"
+    printf '%s\n' "$out" | sed 's/^/       /' | head -6
+    fail=$((fail + 1))
+  fi
+}
+
+# run_env <name> <VAR=value> <command> <cwd> <expected-exit>
+run_env() {
+  local name="$1" env_assign="$2" command="$3" cwd="$4" expect="$5"
+  local payload out rc
+  payload=$(jq -n --arg c "$command" --arg d "$cwd" \
+    '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}')
+  out=$(printf '%s' "$payload" | invoke_hook_env "$env_assign" "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq "$expect" ]; then
+    printf 'OK   %-62s (exit %s)\n' "$name" "$rc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL %s (exit %s, expected %s)\n' "$name" "$rc" "$expect"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- fixtures ---------------------------------------------------------------
+# Every body carries the full four-field block, because that is the shape a real
+# filing has: a fixture holding only the `Session-fit` line would not exercise
+# the continuation boundary at all, and the boundary is what keeps `Severity:`
+# from being read as part of the reason.
+mkbody() { # <path> <session-fit line>
+  {
+    printf 'The ALB router drops a nested condition on reload.\n\n'
+    printf '%s\n' "$2"
+    printf 'Severity: medium -- the condition is silently not applied\n'
+    printf 'Effort: small (S) -- edit plus unit tests\n'
+    printf 'Estimate: ~30 min -- the unit fixture already exists\n'
+    printf 'Dup-check: searched open issues for `nested condition` -- none covers it\n'
+  } > "$1"
+}
+
+OWNPR="$OPTIN/own-pr.md"
+SEPPR="$OPTIN/separate-pr.md"
+SURFACE="$OPTIN/surface.md"
+SEPSURFACE="$OPTIN/sep-surface.md"
+SHAREPR="$OPTIN/share-pr.md"
+OWNREVIEW="$OPTIN/own-review.md"
+FIXTURE="$OPTIN/fixture.md"
+UPSTREAM="$OPTIN/upstream.md"
+NAMEDCMD="$OPTIN/named-cmd.md"
+NOWPR="$OPTIN/now-pr.md"
+NOFIT="$OPTIN/no-fit.md"
+WRAPPED="$OPTIN/wrapped.md"
+SIBLING="$OPTIN/sibling.md"
+CAPS="$OPTIN/caps.md"
+SWEEP="$OPTIN/sweep.md"
+SWEEPWRAP="$OPTIN/sweep-wrapped.md"
+SWEEPOK="$OPTIN/sweep-restated.md"
+
+mkbody "$OWNPR"     'Session-fit: next (not this session) -- this needs its own PR'
+mkbody "$SEPPR"     'Session-fit: next (not this session) -- a separate PR, so the diff stays small'
+mkbody "$SURFACE"   'Session-fit: next (not this session) -- an independent review surface'
+mkbody "$SEPSURFACE" 'Session-fit: next (not this session) -- a separate review surface from this lane'
+mkbody "$SHAREPR"   'Session-fit: next (not this session) -- a schema bump must not share a PR with a fix'
+# The literal 2026-09-02 spelling implement.md section 5 records as the error.
+mkbody "$OWNREVIEW" 'Session-fit: next (not this session) -- a behaviour change across three repos with its own review surface'
+# The legitimate criteria, in this repo's own vocabulary.
+mkbody "$FIXTURE"   'Session-fit: next (not this session) -- a NEW integ fixture must be written'
+# A `next` whose reason MENTIONS a PR without being PR-SHAPED: an upstream PR is
+# external input, which IS a criterion. This is the control that keeps the
+# vocabulary closed -- widen the regex to any mention of `PR` and this fails.
+mkbody "$UPSTREAM"  'Session-fit: next (not this session) -- blocked on upstream PR aws/aws-cdk#123 landing'
+# The honest use of `next` implement.md section 5 describes: NAME the command.
+mkbody "$NAMEDCMD"  'Session-fit: next (not this session) -- verified by /run-integ local-start-alb-watch on an arm64 host, which a fresh session has'
+# `now` is never argued with, whatever the reason says.
+mkbody "$NOWPR"     'Session-fit: now (do it in this session) -- it lands in files this session has open; it will get its own PR'
+mkbody "$CAPS"      'SESSION-FIT: NEXT (NOT THIS SESSION) -- IT NEEDS ITS OWN PR'
+# The sweep deferral, spelled the way implement.md section 5 USED to print it.
+# Refused since 2026-09-05: review size is the signal, not the criterion, and a
+# body reaching for `unreviewable` has skipped saying what verification the
+# residue needs. The word being live here is what keeps this gate answering the
+# same way as its two sibling repos.
+mkbody "$SWEEP"     'Session-fit: next (not this session) -- a sweep of all 14 sites would make the PR unreviewable; umbrella filed'
+# The SAME sweep, re-stated in the criteria's terms -- the umbrella filing the
+# reworded section 5 asks for. Without this case the block above would read as a
+# filing threshold; with it, it reads as the rewording tax it is.
+mkbody "$SWEEPOK"   'Session-fit: next (not this session) -- the residue is 13 more fixtures, each needing a Docker run this lane is not paying for; umbrella filed naming every site'
+
+# No `Session-fit` line at all: other gates own filing hygiene, this one has
+# exactly one job.
+{
+  printf 'The ALB router drops a nested condition on reload.\n\n'
+  printf 'Fixing it needs its own PR because the diff touches two subsystems.\n'
+} > "$NOFIT"
+# The reason WRAPS. A 76-column issue body routinely puts the PR-shaped half on
+# the following line, and a line-only scan reads the first half and passes.
+{
+  printf 'The ALB router drops a nested condition on reload.\n\n'
+  printf 'Session-fit: next (not this session) -- this touches a different\n'
+  printf 'subsystem entirely and so needs its own PR\n'
+  printf 'Severity: low -- internal tidiness\n'
+} > "$WRAPPED"
+# The same, wrapped: `unreviewable` may arrive on a continuation line, which a
+# line-only scan would read past -- the refusal has to survive the wrap exactly
+# as the PR-SPLIT spellings do.
+{
+  printf 'Fourteen call sites share one wrong assumption.\n\n'
+  printf 'Session-fit: next (not this session) -- sweeping every site would\n'
+  printf 'make the PR unreviewable, so the umbrella lists them\n'
+  printf 'Severity: low -- internal tidiness\n'
+} > "$SWEEPWRAP"
+# The complement of the WRAPPED case: the PR-shaped words sit on a SIBLING FIELD
+# line, which is nobody's `Session-fit` reason. Folding the following lines in
+# unconditionally turns this into a false block.
+{
+  printf 'The ALB router drops a nested condition on reload.\n\n'
+  printf 'Session-fit: next (not this session) -- a NEW integ fixture must be written\n'
+  printf 'Notes: it will land as its own PR once the fixture exists\n'
+} > "$SIBLING"
+
+# --- fence / bold / list-item fixtures --------------------------------------
+# A body ARGUING ABOUT this rule quotes the refused line to do it, inside a
+# ```text fence, and classifies ITSELF `now`. Without the fence strip the first
+# `Session-fit:` match wins and `break`s, so the exhibit is read as the body's
+# own decision and the filing is refused -- with a remedy (the bypass) that a
+# body of this shape should never have to reach for.
+FENCED="$OPTIN/fenced.md"
+{
+  printf 'The deferral gate should not need a bypass to be discussed.\n\n'
+  printf 'The line it refuses looks like:\n\n'
+  printf '```text\n'
+  printf 'Session-fit: next (not this session) -- this needs its own PR\n'
+  printf '```\n\n'
+  printf 'Session-fit: now (do it in this session) -- the evidence exists only here\n'
+  printf 'Severity: medium -- the rule is unenforced until this lands\n'
+} > "$FENCED"
+# The control that keeps the strip honest: the SAME quotation in running prose,
+# unfenced, is indistinguishable from an assertion and still blocks (the inline
+# quote is what the bypass is for).
+UNFENCED="$OPTIN/unfenced.md"
+{
+  printf 'The deferral gate should not need a bypass to be discussed.\n\n'
+  printf 'The line it refuses looks like:\n\n'
+  printf 'Session-fit: next (not this session) -- this needs its own PR\n\n'
+  printf 'Session-fit: now (do it in this session) -- the evidence exists only here\n'
+} > "$UNFENCED"
+# An UNCLOSED fence must NOT swallow the rest of the body. Latching on any
+# opener with no look-ahead is the exact class .claude/rules/hooks.md documents
+# for heredoc openers ("blanks every remaining line, fail open").
+UNCLOSED_FENCE="$OPTIN/unclosed-fence.md"
+{
+  printf 'Dup-check: searched.\n\n'
+  printf '```text\n'
+  printf 'a fence nobody closed\n\n'
+  printf 'Session-fit: next (not this session) -- this needs its own PR\n'
+  printf 'Severity: low -- probe\n'
+} > "$UNCLOSED_FENCE"
+# A ``` line INSIDE a ~~~ block must not close it, and the ~~~ block must not
+# stay open past its own closer.
+MIXED_FENCE="$OPTIN/mixed-fence.md"
+{
+  printf 'Dup-check: searched.\n\n'
+  printf '~~~text\n'
+  printf 'an inner ``` line\n'
+  printf '~~~\n\n'
+  printf 'Session-fit: next (not this session) -- this needs its own PR\n'
+  printf 'Severity: low -- probe\n'
+} > "$MIXED_FENCE"
+# A ~~~ fence is a fence too.
+FENCED_TILDE="$OPTIN/fenced-tilde.md"
+{
+  printf 'Quoting the refused line:\n\n'
+  printf '~~~\n'
+  printf 'Session-fit: next (not this session) -- this needs its own PR\n'
+  printf '~~~\n\n'
+  printf 'Session-fit: now (do it in this session) -- it lands in open files\n'
+} > "$FENCED_TILDE"
+
+# A BOLDED key. .claude/rules/session-report.md bolds every field name, so
+# the bolded spelling is one copy-paste away -- and `rest` would otherwise
+# become `** next (not this session) ...`, which the `^[[:space:]]*next`
+# polarity test rejects, passing a PR-shaped deferral in silence. Both markdown
+# spellings, because they put the asterisks on opposite sides of the colon.
+BOLDFIT="$OPTIN/bold-fit.md"
+{
+  printf 'The ALB router drops a nested condition on reload.\n\n'
+  printf '**Session-fit:** next (not this session) -- this needs its own PR\n'
+  printf '**Severity:** medium -- the condition is silently not applied\n'
+} > "$BOLDFIT"
+BOLDFIT2="$OPTIN/bold-fit-2.md"
+{
+  printf 'The ALB router drops a nested condition on reload.\n\n'
+  printf '**Session-fit**: next (not this session) -- it deserves its own review\n'
+} > "$BOLDFIT2"
+# The control: a bolded key with a LEGITIMATE reason must still pass. Without
+# the matching `[*_]*` in the continuation boundary, `**Severity:**` stops
+# looking like a field line and the sibling text folds into the reason.
+BOLDOK="$OPTIN/bold-ok.md"
+{
+  printf 'The ALB router drops a nested condition on reload.\n\n'
+  printf '**Session-fit:** next (not this session) -- a NEW integ fixture must be written\n'
+  printf '**Severity:** low -- internal tidiness\n'
+  printf '**Notes:** it will land as its own PR once the fixture exists\n'
+} > "$BOLDOK"
+
+# A legitimate reason followed by a BULLET -- the shape this repo's own report
+# template produces, where the four fields are nested bullets under a
+# `- TODO #<N>` item.
+BULLET="$OPTIN/bullet.md"
+{
+  printf 'The deploy path cannot be exercised without the upstream fix.\n\n'
+  printf 'Session-fit: next (not this session) -- blocked on an upstream fix landing\n'
+  printf -- '- the sibling cleanup would need its own PR, so it is filed separately\n'
+  printf 'Severity: low -- nothing regresses meanwhile\n'
+} > "$BULLET"
+# The control: the boundary must not become a blanket amnesty. PR-shaped text on
+# the `Session-fit` line itself still blocks, bullet or no bullet.
+BULLETBAD="$OPTIN/bullet-bad.md"
+{
+  printf 'Session-fit: next (not this session) -- this needs its own PR\n'
+  printf -- '- an unrelated follow-up bullet\n'
+} > "$BULLETBAD"
+# Numbered list items are list items too.
+NUMLIST="$OPTIN/numlist.md"
+{
+  printf 'Session-fit: next (not this session) -- blocked on an upstream fix landing\n'
+  printf '1. the sibling cleanup would need its own PR\n'
+} > "$NUMLIST"
+
+# A commit message that QUOTES a PR-shaped deferral -- the realistic shape,
+# since the commit introducing this gate has to describe what it refuses.
+COMMITMSG="$TMPBASE/commit-msg.txt"
+{
+  printf 'chore(hooks): refuse PR-shaped Session-fit deferrals\n\n'
+  printf 'The line this gate refuses looks like:\n\n'
+  printf 'Session-fit: next (not this session) -- this needs its own PR\n'
+} > "$COMMITMSG"
+CLEANMSG="$TMPBASE/clean-msg.txt"
+printf 'chore(hooks): add a gate\n' > "$CLEANMSG"
+
+echo "== BLOCK: every PR-shaped spelling ========================================="
+run "inline --body: its own PR"        "gh issue create --title t --body 'Bug. Session-fit: next -- this needs its own PR'" "$OPTIN" 2
+run "body-file: its own PR"            "gh issue create --title t --body-file $OWNPR"      "$OPTIN" 2
+run "body-file: separate PR"           "gh issue create --title t --body-file $SEPPR"      "$OPTIN" 2
+run "body-file: independent review surface" "gh issue create --body-file $SURFACE"         "$OPTIN" 2
+run "body-file: separate review surface"    "gh issue create --body-file $SEPSURFACE"      "$OPTIN" 2
+run "body-file: must not share a PR"   "gh issue create --body-file $SHAREPR"              "$OPTIN" 2
+run "body-file: its own review surface (the 2026-09-02 spelling)" \
+  "gh issue create --body-file $OWNREVIEW"                                                 "$OPTIN" 2
+run "inline --body: sharing a PR"      "gh issue create --body 'Session-fit: next -- sharing a PR with the fix would hide it'" "$OPTIN" 2
+run "matching is case-insensitive"     "gh issue create --body-file $CAPS"                 "$OPTIN" 2
+run "the reason may WRAP onto the next line" "gh issue create --body-file $WRAPPED"        "$OPTIN" 2
+run "body-file: an unreviewable SWEEP"      "gh issue create --body-file $SWEEP"            "$OPTIN" 2
+run "the same word across a WRAPPED reason" "gh issue create --body-file $SWEEPWRAP"        "$OPTIN" 2
+
+echo "== PASS: every legitimate deferral ========================================="
+run "the sweep RE-STATED in the criteria's terms" "gh issue create --body-file $SWEEPOK"    "$OPTIN" 0
+run "a NEW integ fixture must be written" "gh issue create --body-file $FIXTURE"            "$OPTIN" 0
+run "external input: an upstream PR"      "gh issue create --body-file $UPSTREAM"           "$OPTIN" 0
+run "the honest next: names the command"  "gh issue create --body-file $NAMEDCMD"           "$OPTIN" 0
+run "Session-fit: now mentioning its own PR" "gh issue create --body-file $NOWPR"           "$OPTIN" 0
+run "inline now mentioning its own PR"    "gh issue create --body 'Session-fit: now -- and it gets its own PR'" "$OPTIN" 0
+run "no Session-fit line at all"          "gh issue create --body-file $NOFIT"              "$OPTIN" 0
+run "inline body, no Session-fit line"    "gh issue create --body 'Needs its own PR, obviously.'" "$OPTIN" 0
+run "PR words on a SIBLING field line"    "gh issue create --body-file $SIBLING"            "$OPTIN" 0
+
+echo "== verbs deliberately NOT gated ==========================================="
+# Re-classifying an already-filed issue is the outcome this gate steers toward,
+# so the verbs that do it must never be taxed.
+run "gh issue edit passes"        "gh issue edit 12 --body-file $OWNPR"      "$OPTIN" 0
+run "gh issue comment passes"     "gh issue comment 12 --body-file $OWNPR"   "$OPTIN" 0
+run "gh pr create passes"         "gh pr create --body-file $OWNPR"          "$OPTIN" 0
+run "gh issue list passes"        "gh issue list --state open --search foo"  "$OPTIN" 0
+
+echo "== the REST mint =========================================================="
+run "gh api issues POST, PR-shaped" "gh api repos/go-to-k/cdk-local/issues -f title=t -f 'body=Session-fit: next -- needs its own PR'" "$OPTIN" 2
+run "gh api issues POST, legitimate" "gh api repos/go-to-k/cdk-local/issues -f title=t -f 'body=Session-fit: next -- a NEW integ fixture must be written'" "$OPTIN" 0
+run "gh api comments is not a mint"  "gh api repos/go-to-k/cdk-local/issues/5/comments -f 'body=Session-fit: next -- own PR'" "$OPTIN" 0
+
+echo "== spellings a line-start-anchored matcher would leak ======================"
+run "chained after && blocks"      "git push && gh issue create --body-file $OWNPR"   "$OPTIN" 2
+run "chained after ; blocks"       "echo done; gh issue create --body-file $OWNPR"    "$OPTIN" 2
+run "subshell blocks"              "(gh issue create --body-file $OWNPR)"             "$OPTIN" 2
+run "command substitution blocks"  "URL=\$(gh issue create --body-file $OWNPR)"       "$OPTIN" 2
+run "gh -R <repo> issue create blocks" "gh -R go-to-k/cdk-local issue create --body-file $OWNPR" "$OPTIN" 2
+
+echo "== the scans are scoped to the gh SEGMENT ================================="
+# `-F` is `git commit`'s flag as well as gh's short `--body-file`, so an
+# unscoped extraction reads the COMMIT MESSAGE. Both orderings, and both
+# directions, because scoping only "after the verb" fixes just one of them.
+run "PR-shaped text in a NEIGHBOURING segment passes" \
+  "git commit -F $COMMITMSG && gh issue create --body-file $FIXTURE" "$OPTIN" 0
+run "neighbouring segment, gh first, passes" \
+  "gh issue create --body-file $FIXTURE && git commit -F $COMMITMSG" "$OPTIN" 0
+# The other direction: a clean neighbour must not shadow the real body.
+run "clean commit -F before a PR-shaped body still blocks" \
+  "git commit -F $CLEANMSG && gh issue create --body-file $OWNPR" "$OPTIN" 2
+run "clean commit -F after a PR-shaped body still blocks" \
+  "gh issue create --body-file $OWNPR && git commit -F $CLEANMSG" "$OPTIN" 2
+
+echo "== repo opt-in scope ======================================================"
+cp "$OWNPR" "$NOOPTIN/own-pr.md"
+run "no .markgate.yml: not gated"     "gh issue create --body-file $NOOPTIN/own-pr.md" "$NOOPTIN" 0
+run "outside any git repo: not gated" "gh issue create --body-file $OWNPR"             "$TMPBASE" 0
+run "-R sibling from an opted-in cwd" "gh -R go-to-k/cdkd issue create --body-file $OWNPR" "$OPTIN" 2
+
+echo "== relative paths and the cd chain ========================================"
+run "relative body-file via payload cwd" "gh issue create --body-file own-pr.md"                "$OPTIN" 2
+run "relative body-file via leading cd"  "cd $OPTIN && gh issue create --body-file own-pr.md"   "/"      2
+# `gate_target_dir` reads the last `cd` BEFORE the matched segment, so the
+# search-then-cd-then-file chain `/work-issues` section 5 prescribes resolves.
+run "search, cd, then file (PR-shaped)"  "gh issue list --state open --search x && cd $OPTIN && gh issue create --body-file own-pr.md" "$TMPBASE" 2
+run "search, cd, then file (legitimate)" "gh issue list --state open --search x && cd $OPTIN && gh issue create --body-file fixture.md" "$TMPBASE" 0
+# `gh -C <dir>` in the matched segment wins over the payload cwd.
+run "gh -C <dir> resolves the opt-in tree" "gh -C $OPTIN issue create --body-file own-pr.md" "$TMPBASE" 2
+
+echo "== more body-file spellings ==============================================="
+run "--body-file=<p> form"      "gh issue create --body-file=$OWNPR"       "$OPTIN" 2
+run "--body-file=<p> legitimate" "gh issue create --body-file=$FIXTURE"    "$OPTIN" 0
+run "quoted --body-file path"   "gh issue create --body-file \"$OWNPR\""   "$OPTIN" 2
+run "-F body=@ form"            "gh issue create -F body=@$OWNPR"          "$OPTIN" 2
+run "bare -F <file> form"       "gh issue create -F $OWNPR"                "$OPTIN" 2
+run "--raw-field body=@ form"   "gh issue create --raw-field body=@$OWNPR" "$OPTIN" 2
+
+echo "== the unreadable-path window ============================================="
+# Unlike issue-dup-check-gate.sh, an unreadable body file must NOT block: that
+# gate demands a line be PRESENT, so "cannot read" is evidence of a miss, while
+# this one objects to content it FINDS and a refusal would be unclearable.
+run "unreadable body-file, nothing offending" "gh issue create --body-file $OPTIN/nope.md" "$OPTIN" 0
+run "unexpanded \$VAR path, nothing offending" "gh issue create --body-file \"\$BODY\""    "$OPTIN" 0
+run "unexpanded \$VAR path, PR-shaped inline"  "gh issue create --body-file \"\$BODY\" --title 'x' # Session-fit: next -- own PR" "$OPTIN" 2
+
+echo "== heredoc -> file -> --body-file in ONE command ==========================="
+# The file does not exist at PreToolUse time. This is the repo's mandated
+# publishing shape, so a PR-shaped body written that way must still be caught,
+# and a legitimate one must still pass.
+HD_BAD="cat > $OPTIN/hd.md <<'EOF'
+The ALB router drops a nested condition.
+
+Session-fit: next (not this session) -- this needs its own PR
+EOF
+gh issue create --body-file $OPTIN/hd.md"
+HD_OK="cat > $OPTIN/hd2.md <<'EOF'
+The ALB router drops a nested condition.
+
+Session-fit: next (not this session) -- a NEW integ fixture must be written
+EOF
+gh issue create --body-file $OPTIN/hd2.md"
+run "heredoc body is PR-shaped"  "$HD_BAD" "$OPTIN" 2
+run "heredoc body is legitimate" "$HD_OK"  "$OPTIN" 0
+
+echo "== the heredoc window when the path ALREADY EXISTS ========================="
+# The go-to-k/cdk-local#637 shape with a file already on disk: reading the file
+# alone judges a body nobody is submitting, in BOTH directions -- it can miss,
+# and it can BLOCK a clean submission quoting a line that will not exist.
+STALE_OK="$OPTIN/stale-ok.md"
+mkbody "$STALE_OK" 'Session-fit: next (not this session) -- a NEW integ fixture must be written'
+STALE_BAD="$OPTIN/stale-bad.md"
+mkbody "$STALE_BAD" 'Session-fit: next (not this session) -- this needs its own PR'
+run "existing CLEAN file, heredoc rewrites it PR-shaped" \
+  "cat > $STALE_OK <<'EOF'
+Session-fit: next (not this session) -- this needs its own PR
+EOF
+gh issue create --body-file $STALE_OK" "$OPTIN" 2
+run "existing PR-shaped file, heredoc rewrites it CLEAN" \
+  "cat > $STALE_BAD <<'EOF'
+Session-fit: next (not this session) -- a NEW integ fixture must be written
+EOF
+gh issue create --body-file $STALE_BAD" "$OPTIN" 0
+# An APPEND does not supersede: the file is the FIRST HALF of the submitted
+# body, so its PR-shaped line is still being published. Collapsing `rewrites`
+# and `appends` into one predicate is the regression this pins.
+run "APPEND leaves the existing PR-shaped half scanned" \
+  "cat >> $STALE_BAD <<'EOF'
+Estimate: ~30 min -- the unit fixture already exists
+EOF
+gh issue create --body-file $STALE_BAD" "$OPTIN" 2
+# The RELATIVE spelling. The write-detection matches against raw command TEXT,
+# so handing it only the resolved absolute path leaves this shape unscanned.
+STALE_REL_OK="$OPTIN/stale-rel.md"
+mkbody "$STALE_REL_OK" 'Session-fit: next (not this session) -- a NEW integ fixture must be written'
+run "relative spelling, existing file, heredoc PR-shaped" \
+  "cd $OPTIN && cat > stale-rel.md <<'EOF'
+Session-fit: next (not this session) -- this needs its own PR
+EOF
+gh issue create --body-file stale-rel.md" "/" 2
+
+echo "== a body ARGUING about the rule: fenced blocks are not scanned ============"
+run "fenced backtick-text exhibit, own fit is now" "gh issue create --body-file $FENCED"       "$OPTIN" 0
+run "fenced ~~~ exhibit, own fit is now"           "gh issue create --body-file $FENCED_TILDE" "$OPTIN" 0
+run "the same quote UNFENCED still blocks"         "gh issue create --body-file $UNFENCED"     "$OPTIN" 2
+run "an UNCLOSED fence does not swallow the body"  "gh issue create --body-file $UNCLOSED_FENCE" "$OPTIN" 2
+run "a mismatched inner marker does not close a ~~~ block" "gh issue create --body-file $MIXED_FENCE" "$OPTIN" 2
+
+echo "== a BOLDED key is still a key ============================================"
+run "bold **Session-fit:** PR-shaped"  "gh issue create --body-file $BOLDFIT"  "$OPTIN" 2
+run "bold **Session-fit**: PR-shaped"  "gh issue create --body-file $BOLDFIT2" "$OPTIN" 2
+run "bold key, legitimate reason"      "gh issue create --body-file $BOLDOK"   "$OPTIN" 0
+
+echo "== a LIST ITEM ends the reason, like a blank line or a heading ============="
+run "legitimate reason then a bullet"        "gh issue create --body-file $BULLET"    "$OPTIN" 0
+run "legitimate reason then a numbered item" "gh issue create --body-file $NUMLIST"   "$OPTIN" 0
+run "PR-shaped ON the fit line, then a bullet" "gh issue create --body-file $BULLETBAD" "$OPTIN" 2
+
+echo "== quoted mentions of the trigger ========================================="
+run "quoted mention in commit message" "git commit -m 'docs: explain gh issue create --body-file flow'" "$OPTIN" 0
+run "quoted mention in echo"           "echo 'run: gh issue create --body-file own-pr.md'"             "$OPTIN" 0
+
+echo "== the escape hatch, both channels ========================================"
+run_env "bypass via the process env" "CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1" \
+  "gh issue create --body-file $OWNPR" "$OPTIN" 0
+# The TEXT channel is the only one an agent's Bash call can actually deliver (a
+# PreToolUse hook is spawned with the session env), and it is the spelling the
+# refusal advertises -- go-to-k/cdkd#2368, where the advertised remediation
+# silently did nothing and the suite certified the failure.
+run "bypass via a leading assignment at the START of the command" \
+  "CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1 gh issue create --body-file $OWNPR" "$OPTIN" 0
+# The DELIBERATE narrowing: not at offset 0, not a bypass. This repo's matcher
+# has no `strip_noncommand_spans`, so a mid-command scan could not tell an
+# assignment from the same text quoted inside a body -- and the refusal prints
+# the assignment-first spelling for exactly this reason.
+run "assignment after a cd is NOT a bypass" \
+  "cd $OPTIN && CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1 gh issue create --body-file own-pr.md" "$OPTIN" 2
+# A QUOTED mention of the bypass is not a bypass.
+run "quoted mention of the bypass does not bypass" \
+  "gh issue create --title 'CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1 is the hatch' --body-file $OWNPR" "$OPTIN" 2
+
+echo "== the refusal names the offending line and the local rules ================"
+run_msg "refusal quotes the offending reason" "gh issue create --body-file $OWNPR" "$OPTIN" 2 \
+  "this needs its own PR"
+# The quoted line is RENDERED as a body would spell it -- `Session-fit:` then a
+# space -- rather than stitched back on without one.
+run_msg "refusal renders the key with its space" "gh issue create --body-file $OWNPR" "$OPTIN" 2 \
+  "Session-fit: next (not this session) -- this needs its own PR"
+run_msg "refusal names THIS repo's rule files" "gh issue create --body-file $OWNPR" "$OPTIN" 2 \
+  ".claude/skills/work-issues/references/implement.md"
+run_msg "refusal names the session-report field reference" "gh issue create --body-file $OWNPR" "$OPTIN" 2 \
+  ".claude/rules/session-report.md"
+run_msg "refusal names the sanctioned sweep carve-out" "gh issue create --body-file $OWNPR" "$OPTIN" 2 \
+  "RESIDUE carries its own verification"
+run_msg "refusal names the bypass, with the CDKL_ prefix" "gh issue create --body-file $OWNPR" "$OPTIN" 2 \
+  "CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1"
+
+echo "== the library guard must FAIL CLOSED ====================================="
+lib_fail_closed() {
+  local tmp out rc
+  tmp=$(mktemp -d)
+  cp "$HOOK" "$tmp/gate.sh"          # no _command-match.sh beside it
+  chmod +x "$tmp/gate.sh"
+  out=$(jq -n --arg d "$OPTIN" '{tool_name:"Bash", tool_input:{command:"gh issue create --body-file /nope.md"}, cwd:$d}' \
+        | invoke_hook "$tmp/gate.sh" 2>&1) && rc=0 || rc=$?
+  rm -rf "$tmp"
+  if [ "$rc" -eq 2 ] && printf '%s' "$out" | grep -qF "command-match.sh"; then
+    printf 'OK   %-62s (exit %s)\n' "unloadable library fails CLOSED" "$rc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL unloadable library should exit 2 naming the library (got %s)\n' "$rc"
+    fail=$((fail + 1))
+  fi
+}
+lib_fail_closed
+
+echo "== the hook is actually REGISTERED ========================================"
+# The suite invokes the hook directly, so it would not otherwise notice the hook
+# being dropped from .claude/settings.json. The TS-side twin
+# (tests/unit/hooks/gate-if-matchers.test.ts) checks the `if:` patterns; this
+# one is here so a shell-only run still sees a de-registration.
+registration_check() {
+  local settings
+  settings="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/.claude/settings.json"
+  if [ -f "$settings" ] && grep -q 'issue-deferral-criteria-gate.sh' "$settings"; then
+    printf 'OK   %-62s\n' "registered in .claude/settings.json"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL not registered in .claude/settings.json\n'
+    fail=$((fail + 1))
+  fi
+}
+registration_check
+
+echo "== payload edge cases ====================================================="
+run "empty command passes" "" "$OPTIN" 0
+nonbash_check() {
+  local out rc
+  out=$(jq -n '{tool_name:"Edit", tool_input:{file_path:"/tmp/x"}}' | invoke_hook "$HOOK" 2>&1) && rc=0 || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    printf 'OK   %-62s (exit %s)\n' "non-Bash tool passes" "$rc"
+    pass=$((pass + 1))
+  else
+    printf 'FAIL non-Bash tool should pass (got %s)\n' "$rc"
+    fail=$((fail + 1))
+  fi
+}
+nonbash_check
+
+# --- the shared GATE_PERL_WORD value class, and its guard --------------------
+# Ported with the class from go-to-k/cdkd#2639. Three spellings were LIVE
+# fail-opens here before the port, each measured rc=0 where the plain path gave
+# 2: a quoted path containing a SPACE, a BACKSLASH-escaped one, and the GLUED
+# `-F<path>` gh accepts. They are cases rather than a note because a value class
+# that enumerates quote POSITIONS grows a new hole every time gh accepts another
+# spelling.
+GWDIR="$OPTIN/gw dir"
+mkdir -p "$GWDIR"
+printf 'Session-fit: next (not this session) -- it needs its own PR\n' > "$GWDIR/defer.md"
+printf 'Session-fit: next (not this session) -- a new fixture must be written\n' > "$GWDIR/ok.md"
+run "spaced --body-file path, double-quoted, blocks" \
+  "gh issue create -t x --body-file \"$GWDIR/defer.md\"" "$OPTIN" 2
+run "spaced --body-file path, backslash-escaped, blocks" \
+  "gh issue create -t x --body-file ${GWDIR// /\\ }/defer.md" "$OPTIN" 2
+run "glued -F<spaced path> blocks" \
+  "gh issue create -t x -F\"$GWDIR/defer.md\"" "$OPTIN" 2
+run "spaced --body-file path, compliant reason, passes" \
+  "gh issue create -t x --body-file \"$GWDIR/ok.md\"" "$OPTIN" 0
+
+# The guard. `[ -n "$GATE_PERL_WORD" ]` cannot see a prelude that is present but
+# does not COMPILE, and every extraction runs perl with stderr discarded -- so
+# the gate would extract nothing and PASS. The payload is one this gate NORMALLY
+# PASSES, so exit 2 can only come from the guard. The second case is the
+# ENVIRONMENT half: the memo is an ordinary shell variable, so without a reset
+# at library load `__GATE_PW_OK=1` made the probe report a prelude it never ran.
+GWBROKEN="$OPTIN/brokenlib"
+mkdir -p "$GWBROKEN"
+cp "$HOOK" "$GWBROKEN/"
+sed "s|^  my \$GW = qr/.*|  my \$GW = qr/(((unclosed/;|" \
+  "$(dirname "$HOOK")/_command-match.sh" > "$GWBROKEN/_command-match.sh"
+if grep -q 'unclosed' "$GWBROKEN/_command-match.sh" \
+   && ! grep -q 'my \$GW = qr/(?:' "$GWBROKEN/_command-match.sh"; then
+  for gw_env in "" "__GATE_PW_OK=1"; do
+    gw_rc=0
+    jq -n --arg c "gh issue create -t x --body-file \"$GWDIR/ok.md\"" --arg d "$OPTIN" \
+      '{tool_name:"Bash", tool_input:{command:$c}, cwd:$d}' \
+      | env $gw_env "$GWBROKEN/$(basename "$HOOK")" >/dev/null 2>&1 || gw_rc=$?
+    if [ "$gw_rc" = "2" ]; then
+      pass=$((pass + 1))
+      echo "PASS: a non-compiling GATE_PERL_WORD fails CLOSED (env='$gw_env')"
+    else
+      fail=$((fail + 1))
+      echo "FAIL: a non-compiling GATE_PERL_WORD returned $gw_rc with env='$gw_env', expected 2"
+    fi
+  done
+else
+  # A probe that silently does not run is the failure mode this file is about.
+  fail=$((fail + 1))
+  echo "FAIL: could not stage a broken GATE_PERL_WORD (sed anchor drifted)"
+fi
+
+# --- a substitution INSIDE the body must not split the reason ---------------
+# `gate_segments` used to push a `$( )` or backtick span onto its stack and emit
+# a newline, which SPLIT the enclosing text: `Session-fit:` landed in one
+# segment and the PR-shaped clause in another, so the gate saw neither together
+# and returned 0. Measured against cdkd and cdk-real-drift, which both returned
+# 2 on the identical body -- a three-way divergence, and backticks are ordinary
+# in the bodies this flow writes.
+#
+# The compliant twins are the polarity control: collapsing the span must not
+# make every body block.
+run "a backtick span inside the body does not split the reason" \
+  "gh issue create --body \"Session-fit: next (not this session) -- the \`nested cond\` fix needs its own PR\"" "$OPTIN" 2
+run "a \$( ) span inside the body does not split the reason" \
+  "gh issue create --body \"Session-fit: next (not this session) -- the \$(nested cond) fix needs its own PR\"" "$OPTIN" 2
+run "a backtick span in a COMPLIANT body still passes" \
+  "gh issue create --body \"Session-fit: next (not this session) -- a \`new\` fixture must be written\"" "$OPTIN" 0
+run "a \$( ) span in a COMPLIANT body still passes" \
+  "gh issue create --body \"Session-fit: next (not this session) -- a \$(new) fixture must be written\"" "$OPTIN" 0
+
+printf '\npass: %s  fail: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/.claude/hooks/issue-deferral-criteria-gate.test.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.test.sh
@@ -46,8 +46,10 @@
 #   - PASS for a legitimate reason followed by a list item (this repo's own
 #     report template nests the four fields as bullets)
 #
-# MUTATION-PROBED rather than asserted, re-measured 2026-09-05 over the 87
-# cases below, under bash 3.2 (the harness default). A tally says how many
+# MUTATION-PROBED rather than asserted. The round-4 rows were taken on the 119
+# cases below, under bash 3.2 (the harness default); the rows above them were
+# taken on the 87-case baseline and are NOT re-taken here -- see the note after
+# the table, and re-take them wholesale before quoting any of them again. A tally says how many
 # cases ran, not what any of them fences, so each fence was broken in the real
 # hook and the survivors counted:
 #
@@ -88,6 +90,35 @@
 #                                                        FENCED into the list
 #                                                        rather than merely
 #                                                        commented into it
+#
+# ROUND 4, taken on the 119-case suite:
+#
+#   always-`exit 0` stub                     fails 67
+#   always-`exit 2` stub                     fails 58
+#   `restore_inline_newlines` call removed   fails  4
+#   restore slice -> the whole raw command   fails  1   -- a sibling
+#                                                        `gh issue comment` body
+#                                                        deciding this verdict
+#   restore `-b[=\s]*` -> `[=\s]+`          fails  1   -- the GLUED `-b<body>`
+#   fallback -> the segment only             fails  2
+#   `input_body_text` call removed           fails  4
+#   `--input` heredoc STATUS -> emptiness    fails  1
+#   `--input` `$VAR` heredoc arm removed     fails  1
+#   `--input` relative join dropped          fails  1
+#   `-b` extractor arm removed               fails  1
+#   `[*_]*next` -> `next`                    fails  1
+#   `:([^/]|/[^/]|$)` -> `:([^/]|$)`         fails  1   -- the `Key:/value`
+#                                                        continuation
+#   `:([^/]|$)` -> `:`                       fails  1   -- the URL scheme
+#
+# THE ROWS ABOVE THIS BLOCK WERE NOT RE-TAKEN. They predate every case added
+# since, so their numbers moved by an unknown amount -- three numbers carried
+# forward one round were contradicted the next, which is why none is carried
+# forward silently here.
+#
+# TWO PROBES NEED BOTH SITES BROKEN AT ONCE: the fallback lives at two arms
+# (unresolvable-path and unreadable-file) and each case reaches only one, so a
+# one-arm mutation kills nothing and reads as unfenced.
 #
 # Keep these numbers current when cases are added — a stale count in a comment
 # that exists to prove non-vacuity is itself the thing it warns about.
@@ -772,12 +803,52 @@ run "gh api --input: a relative payload path resolves against the cwd" \
   "gh api repos/o/r/issues -f title=t --input rel-input.json" "$OPTIN" 2
 # RELATIVE and heredoc-written at once: the heredoc lookup is handed BOTH the
 # raw spelling and the resolved path, and only the raw one matches a command
-# that writes `hd-input.json`. Dropping either spelling makes this case red.
+# that writes `hd-input.json`. The RAW spelling is the load-bearing one --
+# dropping it makes this case red; passing the resolved path twice does not.
 run "gh api --input: a relative payload written by a heredoc in the same call" \
   "cat > hd-input.json <<'JSON'
 {\"title\":\"t\",\"body\":\"Session-fit: next (not this session) -- it needs its own PR\"}
 JSON
 gh api repos/o/r/issues -f title=t --input hd-input.json" "$OPTIN" 2
+
+# Round-3 review shapes, each measured before the fix and each killed by
+# mutating its own line.
+run "a GLUED -b multi-line body is restored too" \
+  "gh issue create --title t -b'Session-fit: next (not this session) -- blocked on an AWS quota increase
+Effort: large (L) -- a behavior change needing its own PR plus review'" "$OPTIN" 0
+# The fallback must be the SEGMENT plus the WRITER segments, never the whole
+# command: with a writer AND a quoting sibling in one chain, a `$cmd` fallback
+# refuses a clean body.
+run "a writer and a quoting sibling in one chain do not collide" \
+  "git commit -m 'quote: Session-fit: next (not this session) -- it needs its own PR' && printf 'ok\\n' > $OPTIN/nodir/b.md && gh issue create --title t --body-file $OPTIN/nodir/b.md" \
+  "$OPTIN" 0
+run "an unresolvable body-file whose writer is in the command is judged" \
+  "printf 'Session-fit: next (not this session) -- it needs its own PR\\n' > \"\$BODY\" && gh issue create --title t --body-file \"\$BODY\"" \
+  "$OPTIN" 2
+# The restore lookup is scoped to this segment's raw slice: another segment's
+# body must not decide this one's verdict.
+run "a sibling comment body does not decide the create verdict" \
+  "gh issue comment 1 --body 'Session-fit: now -- fine.
+Session-fit: next (not this session) -- it needs its own PR' && gh issue create --title t --body 'Session-fit: now -- fine. Session-fit: next (not this session) -- it needs its own PR'" \
+  "$OPTIN" 0
+# An EMPTY heredoc body is legal, so the STATUS reports whether a heredoc was
+# found -- reading emptiness as "none" falls through to the stale file on disk.
+printf '{"title":"t","body":"Session-fit: next (not this session) -- it needs its own PR"}\n' > "$OPTIN/stale-input.json"
+run "gh api --input: an empty heredoc rewrite supersedes the stale payload" \
+  "cat > $OPTIN/stale-input.json <<'JSON'
+JSON
+gh api repos/o/r/issues -f title=t --input $OPTIN/stale-input.json" "$OPTIN" 0
+run "gh api --input: a \$VAR payload written by a heredoc is still read" \
+  "cat > \"\$P\" <<'JSON'
+{\"title\":\"t\",\"body\":\"Session-fit: next (not this session) -- it needs its own PR\"}
+JSON
+gh api repos/o/r/issues -f title=t --input \"\$P\"" "$OPTIN" 2
+# The URL carve-out excepts a SCHEME, not any `Key:/value` -- a bare `:([^/]|$)`
+# folded a `Repro:/tmp/x` continuation into the reason and refused a legitimate
+# `next`.
+run "a Key:/value continuation still ends the reason" \
+  "gh issue create --title t --body 'Session-fit: next (not this session) -- blocked on an AWS quota increase
+Repro:/tmp/x it needs its own PR'" "$OPTIN" 0
 
 # --- the shared GATE_PERL_WORD value class, and its guard --------------------
 # Ported with the class from go-to-k/cdkd#2639. Three spellings were LIVE

--- a/.claude/hooks/issue-deferral-criteria-gate.test.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.test.sh
@@ -46,7 +46,7 @@
 #   - PASS for a legitimate reason followed by a list item (this repo's own
 #     report template nests the four fields as bullets)
 #
-# MUTATION-PROBED rather than asserted. The round-4 rows were taken on the 119
+# MUTATION-PROBED rather than asserted. The round-4 rows were taken on the 123
 # cases below, under bash 3.2 (the harness default); the rows above them were
 # taken on the 87-case baseline and are NOT re-taken here -- see the note after
 # the table, and re-take them wholesale before quoting any of them again. A tally says how many
@@ -91,10 +91,10 @@
 #                                                        rather than merely
 #                                                        commented into it
 #
-# ROUND 4, taken on the 119-case suite:
+# ROUND 4, taken on the 123-case suite:
 #
-#   always-`exit 0` stub                     fails 67
-#   always-`exit 2` stub                     fails 58
+#   always-`exit 0` stub                     fails 70
+#   always-`exit 2` stub                     fails 59
 #   `restore_inline_newlines` call removed   fails  4
 #   restore slice -> the whole raw command   fails  1   -- a sibling
 #                                                        `gh issue comment` body
@@ -116,6 +116,17 @@
 # forward one round were contradicted the next, which is why none is carried
 # forward silently here.
 #
+#   segment ORDINAL -> plain `index`         fails  1   -- two segments that
+#                                                      collapse to identical text
+#                                                      sharing one raw slice
+#   `pull[[:space:]-]+requests?` dropped     fails  2   -- `own pull request`
+#                                                      and `own-PR`
+#
+# THE WRITER PRE-FILTER IS NOT FENCED BY A CASE, deliberately. It is a COST fix
+# -- without it 40 chained `--body-file missing$i.md` crossed the PreToolUse
+# timeout, which is a SILENT PASS -- and a wall-clock assertion in a unit suite
+# is a flake generator. Deleting it leaves the suite green; the measurement
+# lives in the comment beside it.
 # TWO PROBES NEED BOTH SITES BROKEN AT ONCE: the fallback lives at two arms
 # (unresolvable-path and unreadable-file) and each case reaches only one, so a
 # one-arm mutation kills nothing and reads as unfenced.
@@ -849,6 +860,26 @@ gh api repos/o/r/issues -f title=t --input \"\$P\"" "$OPTIN" 2
 run "a Key:/value continuation still ends the reason" \
   "gh issue create --title t --body 'Session-fit: next (not this session) -- blocked on an AWS quota increase
 Repro:/tmp/x it needs its own PR'" "$OPTIN" 0
+
+# Round-4 blockers, each measured before the fix.
+# `index` alone hands the SECOND of two segments that collapse to identical
+# text the FIRST one's raw slice, so a flat PR-shaped filing passed on its
+# twin's newline placement. The ordinal selects the right occurrence.
+run "twin segments do not share one raw slice" \
+  "gh issue create --title t --body 'Session-fit: next (not this session)
+Severity: high it needs its own PR' && gh issue create --title t --body 'Session-fit: next (not this session) Severity: high it needs its own PR'" \
+  "$OPTIN" 2
+# `PR` / `pull request` / `own-PR` are SPELLINGS of one noun. A passing mention
+# of somebody else's pull request is not a PR-shaped REASON and must still pass.
+run "own pull request, spelled out" \
+  "gh issue create --title t --body 'Session-fit: next (not this session) -- it needs its own pull request'" \
+  "$OPTIN" 2
+run "own-PR, hyphenated" \
+  "gh issue create --title t --body 'Session-fit: next (not this session) -- it needs its own-PR'" \
+  "$OPTIN" 2
+run "a passing mention of an upstream pull request still passes" \
+  "gh issue create --title t --body 'Session-fit: next (not this session) -- blocked on upstream pull request aws/aws-cdk#123 landing'" \
+  "$OPTIN" 0
 
 # --- the shared GATE_PERL_WORD value class, and its guard --------------------
 # Ported with the class from go-to-k/cdkd#2639. Three spellings were LIVE

--- a/.claude/hooks/issue-deferral-criteria-gate.test.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.test.sh
@@ -689,6 +689,55 @@ nonbash_check() {
 }
 nonbash_check
 
+# --- the inline-body channel vs `--body-file` --------------------------------
+# An inline `--body` and the SAME body through `--body-file` must reach the
+# SAME verdict. They did not before `restore_inline_newlines`: `gate_segments`
+# emits one line per segment, so a multi-line inline body arrived flattened,
+# every reason terminator (`Key:` field, list item, heading, blank line) became
+# unreachable, and the whole body read as ONE reason -- folding a LATER field`s
+# text in. The MEASURED defect is a FALSE BLOCK: a legitimate `next` whose
+# `Effort:` line quotes this repo`s own "needing its own PR plus review"
+# wording. That is the first case, and it is the one the mutation probe kills.
+#
+# The last case is the OTHER direction -- a PR-shaped reason on a later line
+# must still be caught. It passed before this change too (flattening moved the
+# text, it did not hide it), so it fences the FIX against over-correcting
+# rather than fencing the defect.
+INLINE_LIMIT="gh issue create --title t --body 'Session-fit: next (not this session) -- blocked on an AWS quota increase
+Effort: large (L) -- a behavior change needing its own PR plus review'"
+run "an inline multi-line --body ends the reason at the next field" \
+  "$INLINE_LIMIT" "$OPTIN" 0
+printf 'Session-fit: next (not this session) -- blocked on an AWS quota increase\nEffort: large (L) -- a behavior change needing its own PR plus review\n' > "$OPTIN/inline-limit.md"
+run "...and the SAME body via --body-file reaches the same verdict" \
+  "gh issue create --title t --body-file $OPTIN/inline-limit.md" "$OPTIN" 0
+run "an inline multi-line --body still catches a PR-shaped reason on a later line" \
+  "gh issue create --title t --body 'Dup-check: searched, none
+Session-fit: next (not this session) -- it needs its own PR
+Severity: low -- x'" "$OPTIN" 2
+
+# The UNRESOLVABLE-BODY fallback is SEGMENT-scoped, like every other scan here.
+# It used to fall back to the whole command, so a `git commit -m` message that
+# QUOTES a PR-shaped line -- what the commit introducing this gate does -- was
+# read as the issue body and refused.
+run "an unresolvable body-file does not read the sibling commit message" \
+  "git commit -m 'gate: refuse a body reading
+Session-fit: next (not this session) -- it needs its own PR' && gh issue create --title t --body-file \"\$BODY\"" \
+  "$OPTIN" 0
+
+# `gh api ... --input <file>` is a body CHANNEL of its own: the REST mint the
+# gate already arms on carries the whole payload as JSON on disk, so no
+# `--body-file` / `-F` / `-f body=` arm reads it. It filed a PR-shaped `next`
+# at rc=0 before `input_body_text`. Both directions, plus the "cannot read is
+# not evidence" rule that governs every other file arm here.
+printf '{"title":"t","body":"Session-fit: next (not this session) -- it needs its own PR"}\n' > "$OPTIN/input-bad.json"
+printf '{"title":"t","body":"Session-fit: next (not this session) -- blocked on an AWS quota increase"}\n' > "$OPTIN/input-ok.json"
+run "gh api --input: PR-shaped body in the JSON payload" \
+  "gh api repos/o/r/issues -f title=t --input $OPTIN/input-bad.json" "$OPTIN" 2
+run "gh api --input: legitimate body in the JSON payload" \
+  "gh api repos/o/r/issues -f title=t --input $OPTIN/input-ok.json" "$OPTIN" 0
+run "gh api --input: an unreadable payload is not evidence" \
+  "gh api repos/o/r/issues -f title=t --input $OPTIN/input-missing.json" "$OPTIN" 0
+
 # --- the shared GATE_PERL_WORD value class, and its guard --------------------
 # Ported with the class from go-to-k/cdkd#2639. Three spellings were LIVE
 # fail-opens here before the port, each measured rc=0 where the plain path gave

--- a/.claude/hooks/issue-deferral-criteria-gate.test.sh
+++ b/.claude/hooks/issue-deferral-criteria-gate.test.sh
@@ -738,6 +738,47 @@ run "gh api --input: legitimate body in the JSON payload" \
 run "gh api --input: an unreadable payload is not evidence" \
   "gh api repos/o/r/issues -f title=t --input $OPTIN/input-missing.json" "$OPTIN" 0
 
+# Cases for the fixes an earlier round shipped UNFENCED -- each verified to go
+# red when its own line is reverted, and green otherwise.
+run "-b (gh short --body) carries a PR-shaped reason" \
+  "gh issue create --title t -b 'Session-fit: next (not this session) -- it needs its own PR'" \
+  "$OPTIN" 2
+run "-b (gh short --body) carries a legitimate reason" \
+  "gh issue create --title t -b 'Session-fit: next (not this session) -- blocked on an AWS quota increase'" \
+  "$OPTIN" 0
+run "a BOLDED next value is read like a bolded key" \
+  "gh issue create --title t --body '**Session-fit:** **next** -- it needs its own PR'" \
+  "$OPTIN" 2
+# The reason boundary is any `Key:` line EXCEPT a URL scheme -- both halves,
+# because narrowing to the named fields fixed the URL at the cost of refusing
+# every OTHER field line, and `Note:` is one character from the `Notes:` that
+# passes.
+run "a wrapped reason is not ended by a URL scheme" \
+  "gh issue create --title t --body 'Session-fit: next (not this session) -- see
+https://example.com/x it needs its own PR'" "$OPTIN" 2
+run "a sibling Note: line still ends the reason" \
+  "gh issue create --title t --body 'Session-fit: next (not this session) -- blocked on an AWS quota increase
+Note: the cleanup will get its own PR'" "$OPTIN" 0
+# The unresolvable / unreadable body fallback reads the WRITER, which lives in
+# another segment, but not an unrelated sibling command`s message.
+run "an unreadable body-file whose writer is in the command is still judged" \
+  "printf 'Session-fit: next (not this session) -- it needs its own PR\\n' > $OPTIN/nodir/b.md && gh issue create --title t --body-file $OPTIN/nodir/b.md" \
+  "$OPTIN" 2
+# `--input` goes through the same path resolution as `--body-file`: a relative
+# path is joined to the resolved cwd, and a payload written by a heredoc in the
+# SAME command is read out of it.
+printf '{"title":"t","body":"Session-fit: next (not this session) -- it needs its own PR"}\n' > "$OPTIN/rel-input.json"
+run "gh api --input: a relative payload path resolves against the cwd" \
+  "gh api repos/o/r/issues -f title=t --input rel-input.json" "$OPTIN" 2
+# RELATIVE and heredoc-written at once: the heredoc lookup is handed BOTH the
+# raw spelling and the resolved path, and only the raw one matches a command
+# that writes `hd-input.json`. Dropping either spelling makes this case red.
+run "gh api --input: a relative payload written by a heredoc in the same call" \
+  "cat > hd-input.json <<'JSON'
+{\"title\":\"t\",\"body\":\"Session-fit: next (not this session) -- it needs its own PR\"}
+JSON
+gh api repos/o/r/issues -f title=t --input hd-input.json" "$OPTIN" 2
+
 # --- the shared GATE_PERL_WORD value class, and its guard --------------------
 # Ported with the class from go-to-k/cdkd#2639. Three spellings were LIVE
 # fail-opens here before the port, each measured rc=0 where the plain path gave

--- a/.claude/hooks/issue-dup-check-gate.sh
+++ b/.claude/hooks/issue-dup-check-gate.sh
@@ -255,7 +255,7 @@ seg_is_api_mint() {
 # satisfied the gate with a marker-free body (verified rc=0). A title is not a
 # record of having searched anything.
 seg_inline_bodies() {
-  printf '%s' "$1" | perl -0777 -ne '
+  printf '%s' "$1" | perl -0777 -ne "$GATE_PERL_WORD"'
       my $Q = "\x27";
       # --body <v> / --body=<v>, quoted either way or bare. `--body-file` does
       # NOT match: `[=\s]` after `--body` cannot consume the `-` of `-file`.
@@ -270,9 +270,24 @@ seg_inline_bodies() {
       # value, and a bare-token-only pattern truncated it at the first space and
       # lost the marker. `body=@file` is excluded: that is a body FILE, and the
       # file scan below owns it.
-      while (/(?:--field|--raw-field|-f|-F)[=\s]+${Q}body=([^${Q}]*)${Q}/g) { print "$1\n"; }
-      while (/(?:--field|--raw-field|-f|-F)[=\s]+"body=([^"]*)"/g)    { print "$1\n"; }
-      while (/(?:--field|--raw-field|-f|-F)[=\s]+body=([^"${Q}\s@][^"${Q}\s]*)/g) { print "$1\n"; }
+      # `$GW` + `gate_unq`, one arm instead of three enumerating quote
+      # POSITIONS. The three-arm shape could not see a quote INSIDE the value --
+      # `-f body=<single-quoted text>`, which is gh`s own documented spelling --
+      # so a COMPLIANT body carrying `Dup-check:` was extracted as nothing and
+      # the gate, which fails CLOSED on an empty extraction, REFUSED it.
+      # Measured in cdk-local before the change: quote-outside rc=0,
+      # quote-inside rc=2.
+      #
+      # `body=` is stripped AFTER unquoting for that reason: in the quote-inside
+      # spelling the prefix sits outside the quotes, so a strip-then-unquote
+      # order never finds it. `body=@file` is excluded -- that is a body FILE,
+      # and the file scan below owns it.
+      while (/(?:--field|--raw-field|-f|-F)[=\s]*($GW)/g) {
+        my $v = gate_unq($1);
+        next unless $v =~ s/^body=//;
+        next if $v =~ /^\@/;
+        print "$v\n";
+      }
     ' 2>/dev/null
 }
 
@@ -355,10 +370,29 @@ seg_has_marker() {
   # warning; a missed read here costs the gate.
   # Stated rather than left to be discovered: if you fix a path-extraction bug
   # in either, check the other.
-  done < <(printf '%s' "$seg" | perl -0777 -ne '
-      while (/--body-file[=\s]+(["\x27]?)([^"\x27\s]+)\1/g) { print "$2\n"; }
-      while (/(?:--field|--raw-field|-F)[=\s]+(["\x27]?)body=\@([^"\x27\s]+)\1/g) { print "$2\n"; }
-      while (/(?:^|\s)-F[=\s]+(["\x27]?)([^"\x27\s=]+)\1(?=\s|$)/g) { print "$2\n"; }
+  done < <(printf '%s' "$seg" | perl -0777 -ne "$GATE_PERL_WORD"'
+      # The value class is `$GW` from the SHARED `GATE_PERL_WORD` prelude in
+      # _command-match.sh, not a local `(["\x27]?)([^"\x27\s]+)\1`. That local
+      # shape ENUMERATES where a quote may sit instead of taking one shell WORD,
+      # and it could not span a QUOTED PATH CONTAINING A SPACE, a
+      # BACKSLASH-ESCAPED one, or the GLUED `-F<path>` gh accepts -- each
+      # measured here as a FAIL-OPEN before this change (rc=0 where the plain
+      # spelling gave 2). Ported from go-to-k/cdkd#2639; the full per-shape
+      # table lives in the header of that constant, in _command-match.sh.
+      # (No apostrophe anywhere in this comment: the whole perl program is a
+      # SHELL single-quoted string, so one would end it and hand the rest to
+      # bash as code.)
+      while (/--body-file[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+      while (/(?:--field|--raw-field|-F)[=\s]*($GW)/g) {
+        my $v = gate_unq($1);
+        next unless $v =~ s/^body=\@//;
+        print "$v\n";
+      }
+      while (/(?:^|\s)-F[=\s]*($GW)(?=[\s;&|)]|$)/g) {
+        my $v = gate_unq($1);
+        next if $v =~ /^\w+=/;
+        print "$v\n";
+      }
     ' 2>/dev/null)
   return 1
 }
@@ -366,6 +400,18 @@ seg_has_marker() {
 found_body_file=0
 unresolvable_path=""
 offending=""
+# `GATE_PERL_WORD` is one shared literal that several BLOCKING gates
+# interpolate, and every extraction runs `perl ... 2>/dev/null`. A prelude
+# that is present but does NOT COMPILE therefore produces no output, no
+# stderr and no exit-code change -- the gate extracts nothing and PASSES
+# what it exists to refuse. Measured in cdkd: one broken literal disarmed
+# four gates at once, with zero stderr. A non-empty test cannot see that,
+# so probe it FUNCTIONALLY, once, after arming, and at TOP LEVEL -- the
+# extraction helpers run inside `$( )`, where `exit 2` ends only the
+# substitution subshell (measured: an in-function guard PRINTED its
+# refusal and the hook still returned 0).
+gate_perl_word_or_die issue-dup-check-gate || exit 2
+
 while IFS= read -r seg; do
   if [[ "$seg" =~ $GATE_RE_GH_ISSUE_CREATE ]]; then
     :

--- a/.claude/hooks/issue-dup-check-gate.sh
+++ b/.claude/hooks/issue-dup-check-gate.sh
@@ -256,15 +256,23 @@ seg_is_api_mint() {
 # record of having searched anything.
 seg_inline_bodies() {
   printf '%s' "$1" | perl -0777 -ne "$GATE_PERL_WORD"'
-      my $Q = "\x27";
-      # --body <v> / --body=<v>, quoted either way or bare. `--body-file` does
-      # NOT match: `[=\s]` after `--body` cannot consume the `-` of `-file`.
-      while (/--body[=\s]+("([^"]*)"|${Q}([^${Q}]*)${Q}|([^\s]+))/g) {
-        print((defined($2) ? $2 : defined($3) ? $3 : $4), "\n");
-      }
-      while (/(?:^|\s)-b[=\s]+("([^"]*)"|${Q}([^${Q}]*)${Q}|([^\s]+))/g) {
-        print((defined($2) ? $2 : defined($3) ? $3 : $4), "\n");
-      }
+      # --body <v> / --body=<v>, and gh`s short `-b`, through the SAME `$GW`
+      # value class as the `-f body=` arm below. They were left on a three-arm
+      # enumeration of quote POSITIONS when the rest of this function moved,
+      # which is a half-applied refactor rather than a decision.
+      #
+      # NO measured behaviour delta here, and no test claims one: this gate
+      # fails CLOSED on an empty extraction, and every shape probed (ANSI-C
+      # `--body` / `-b`, a backslash-escaped space) reached rc=0 with the old
+      # arms too, because a later arm or the marker scan found the marker
+      # anyway. The reason to convert is the class itself -- it cannot span a
+      # quote INSIDE the value, and leaving one copy behind is how the next
+      # edit inherits it.
+      #
+      # `--body-file` still does not match: `[=\s]` after `--body` cannot
+      # consume the `-` of `-file`.
+      while (/(?:^|\s)--body[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+      while (/(?:^|\s)-b[=\s]*($GW)/g) { print gate_unq($1), "\n"; }
       # `-f body=<v>` / `--field body=<v>` and friends. The QUOTED forms come
       # first and may contain spaces -- a single-quoted `body=x Dup-check: none` is one
       # value, and a bare-token-only pattern truncated it at the first space and

--- a/.claude/hooks/issue-dup-check-gate.test.sh
+++ b/.claude/hooks/issue-dup-check-gate.test.sh
@@ -378,6 +378,49 @@ run_no_tool_name "absent tool_name is treated as Bash (blocks)" "gh issue create
 run_no_tool_name "absent tool_name is treated as Bash (passes)" "gh issue create --body-file $WITH"    "$TMPROOT" 0
 run_nonbash "non-Bash tool passes" 0
 
+# --- the shared GATE_PERL_WORD value class, and its guard --------------------
+# Ported with the class from go-to-k/cdkd#2639. Three spellings were LIVE
+# fail-opens here before the port, each measured rc=0 where the plain path gave
+# 2: a quoted path containing a SPACE, a BACKSLASH-escaped one, and the GLUED
+# `-F<path>` gh accepts. They are cases rather than a note because a value class
+# that enumerates quote POSITIONS grows a new hole every time gh accepts another
+# spelling.
+GWDIR="$TMPROOT/gw dir"
+mkdir -p "$GWDIR"
+printf 'A body with no marker at all.\n' > "$GWDIR/nomark.md"
+printf 'Dup-check: searched open+closed, no match\nBody.\n' > "$GWDIR/ok.md"
+run "spaced --body-file path, no Dup-check, blocks" \
+  "gh issue create -t x --body-file \"$GWDIR/nomark.md\"" "$TMPROOT" 2
+# The FALSE BLOCK this gate carried: it fails CLOSED on an unreadable path, so a
+# compliant body at a spaced path was refused for a marker it DID have.
+run "spaced --body-file path, WITH Dup-check, passes" \
+  "gh issue create -t x --body-file \"$GWDIR/ok.md\"" "$TMPROOT" 0
+run "backslash-escaped path, WITH Dup-check, passes" \
+  "gh issue create -t x --body-file ${GWDIR// /\\ }/ok.md" "$TMPROOT" 0
+
+# --- the GATE_PERL_WORD guard is wired here, and CANNOT be fenced by a case ---
+#
+# The other two gates assert it: with a non-compiling prelude they exit 2 on a
+# payload they normally pass, and deleting `gate_perl_word_or_die` reddens those
+# cases. This gate cannot have that case, and the reason is worth stating rather
+# than leaving as an absence.
+#
+# It fails CLOSED on an unreadable body by design (see the header): with no path
+# extracted, `seg_has_marker` returns 1 and the gate BLOCKS. A broken prelude
+# extracts nothing, so it lands on that same refusal -- exit 2 with the guard
+# and exit 2 without it. Measured: removing `gate_perl_word_or_die` leaves this
+# suite fully green, both before and after the payload was corrected.
+#
+# The first version of these cases passed the body-file path UNQUOTED through a
+# directory whose name has a space, which made them doubly vacuous -- they were
+# testing the unreadable-path refusal, not the guard. Quoting fixed that half
+# and revealed the structural half underneath.
+#
+# The guard stays wired anyway. Relying on a coincidence of polarity is exactly
+# what made this file's original miss invisible, and a later edit to
+# `seg_has_marker` could reverse it without anyone noticing this gate had been
+# leaning on it.
+
 echo ""
 echo "Pass: $PASS  Fail: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.claude/hooks/pr-body-item-number-gate.sh
+++ b/.claude/hooks/pr-body-item-number-gate.sh
@@ -55,7 +55,8 @@ if [ ! -r "$_gate_lib" ]; then
 fi
 # shellcheck source=/dev/null
 . "$_gate_lib"
-if ! declare -F gate_matches >/dev/null 2>&1; then
+if ! declare -F gate_matches >/dev/null 2>&1 \
+  || ! declare -F gate_perl_word_or_die >/dev/null 2>&1; then
   echo "Blocked: .claude/hooks/_command-match.sh loaded but gate_matches is undefined (truncated file?)." >&2
   exit 2
 fi
@@ -98,9 +99,25 @@ extract_files() {
   # Use perl to handle quoted args robustly. Output is one path per
   # line. perl's regex is more permissive than bash's, and we
   # collapse single/double quotes around the value.
-  printf '%s' "$cmd" | perl -ne '
-    while (/--body-file[=[:space:]]+(["\x27]?)([^"\x27[:space:]]+)\1/g) { print "$2\n"; }
-    while (/(?:--field|-F)[[:space:]]+(["\x27]?)body=@([^"\x27[:space:]]+)\1/g) { print "$2\n"; }
+  # `$GW` from the SHARED `GATE_PERL_WORD` prelude, not a local
+  # `(["\x27]?)([^"\x27[:space:]]+)\1`. That local shape names WHERE a quote may
+  # sit instead of taking one shell WORD, so it lost a quoted path containing a
+  # SPACE, a backslash-escaped one, and the GLUED `-F<path>` gh accepts -- the
+  # same three spellings measured as live misses on the three issue gates in
+  # this repo. This gate was the last sibling still carrying it; leaving it
+  # would have kept a known-defective class in the tree with a note beside it
+  # saying the class was retired.
+  #
+  # `[[:space:]]` -> `\s` with it: the retired class used the POSIX name, and
+  # `$GW` is defined with `\s`, so keeping both spellings in one regex would be
+  # the kind of near-duplicate that drifts.
+  printf '%s' "$cmd" | perl -ne "$GATE_PERL_WORD"'
+    while (/--body-file[=\s]+($GW)/g) { print gate_unq($1), "\n"; }
+    while (/(?:--field|--raw-field|-F)[=\s]*($GW)/g) {
+      my $v = gate_unq($1);
+      next unless $v =~ s/^body=\@//;
+      print "$v\n";
+    }
   '
 }
 
@@ -317,6 +334,14 @@ scan_text() {
 # other than a heredoc redirect (`printf > f`, `python3 -c ... > f`) cannot be
 # extracted, so it falls back to whatever is on disk -- and to nothing at all
 # when the path does not exist yet. Both halves are pinned by cases.
+# The extraction below runs the shared prelude, and a prelude that is present
+# but does NOT COMPILE is silent (`perl` here has no stderr redirect, but the
+# gate reads its OUTPUT, and a failed program prints none) -- the gate would
+# scan no body and pass. Probe it functionally, once, after arming, and at TOP
+# LEVEL: `extract_files` is called inside `$( )`, where `exit 2` would end only
+# the substitution subshell.
+gate_perl_word_or_die pr-body-item-number-gate || exit 2
+
 while IFS= read -r f; do
   [[ -z "$f" ]] && continue
 

--- a/.claude/hooks/pr-body-item-number-gate.test.sh
+++ b/.claude/hooks/pr-body-item-number-gate.test.sh
@@ -366,6 +366,53 @@ registration_check() {
 }
 registration_check
 
+# --- the spellings the shared value class buys ------------------------------
+# Each was a live miss with the retired `(["\x27]?)([^"\x27[:space:]]+)\1`,
+# which names WHERE a quote may sit instead of taking one shell WORD. This gate
+# was the last sibling in the repo still carrying that class. The ok-body twin
+# is the polarity control: without it a gate that refuses everything satisfies
+# the blocking half for the wrong reason.
+PBDIR="$TMPROOT/pb dir"
+mkdir -p "$PBDIR"
+printf 'Review fixes:\n\n- item #4 was addressed\n' > "$PBDIR/bad.md"
+printf 'Review fixes:\n\n- the mapper was corrected\n' > "$PBDIR/ok.md"
+printf 'Review fixes:\n\n- item #4 was addressed\n' > "$TMPROOT/pb-plain.md"
+run "spaced --body-file path blocks" \
+  "gh pr create --title t --body-file \"$PBDIR/bad.md\"" 2
+run "spaced --body-file path, clean body, passes" \
+  "gh pr create --title t --body-file \"$PBDIR/ok.md\"" 0
+run "backslash-escaped --body-file path blocks" \
+  "gh pr create --title t --body-file ${PBDIR// /\\ }/bad.md" 2
+run "glued -Fbody=@<quoted spaced path> blocks" \
+  "gh pr create --title t -Fbody=@\"$PBDIR/bad.md\"" 2
+run "glued -Fbody=@<plain path> blocks" \
+  "gh pr create --title t -Fbody=@$TMPROOT/pb-plain.md" 2
+
+# The guard: a prelude that is present but does not COMPILE extracts nothing, so
+# the gate would scan no body and pass. The payload is one it NORMALLY PASSES.
+PBBROKEN="$TMPROOT/brokenlib"
+mkdir -p "$PBBROKEN"
+cp "$HOOK" "$PBBROKEN/"
+sed "s|^  my \$GW = qr/.*|  my \$GW = qr/(((unclosed/;|" \
+  "$(dirname "$HOOK")/_command-match.sh" > "$PBBROKEN/_command-match.sh"
+if grep -q 'unclosed' "$PBBROKEN/_command-match.sh" \
+   && ! grep -q 'my \$GW = qr/(?:' "$PBBROKEN/_command-match.sh"; then
+  pb_rc=0
+  jq -n --arg c "gh pr create --title t --body-file \"$PBDIR/ok.md\"" \
+    '{tool_name:"Bash", tool_input:{command:$c}}' \
+    | "$PBBROKEN/$(basename "$HOOK")" >/dev/null 2>&1 || pb_rc=$?
+  if [ "$pb_rc" = "2" ]; then
+    echo "PASS: a non-compiling GATE_PERL_WORD fails CLOSED (exit 2)"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: a non-compiling GATE_PERL_WORD returned $pb_rc, expected 2"
+    FAIL=$((FAIL + 1))
+  fi
+else
+  echo "FAIL: could not stage a broken GATE_PERL_WORD (sed anchor drifted)"
+  FAIL=$((FAIL + 1))
+fi
+
 echo ""
 echo "Pass: $PASS  Fail: $FAIL"
 [ "$FAIL" -eq 0 ]

--- a/.claude/hooks/testdata/probe-rejects.py
+++ b/.claude/hooks/testdata/probe-rejects.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Assert `gate_perl_word_ok` rejects a prelude with any ONE dimension removed.
+
+Driven from `_command-match.test.sh`. The guard's whole job is catching a library
+that is PRESENT but does not work, and the case it is most likely to meet is a
+sibling repo one revision behind -- this prelude is copied between cdkd,
+cdk-local and cdk-real-drift on purpose, and a review measured a four-dimension
+probe certifying exactly that stale copy: every assertion was pure ASCII at word
+position 0, so neither the mid-word ANSI-C arm nor the byte-fidelity contract
+was exercised.
+
+Each mutation below deletes ONE dimension from the REAL prelude. A dimension
+whose deletion still PASSES is one the probe does not actually certify, and the
+case says so by name rather than as a count.
+
+It lives in `testdata/` so neither `run-tests.sh` (which globs `*.test.sh`)
+nor the hook class fence picks it up as a suite of its own.
+"""
+
+import io
+import os
+import subprocess
+import sys
+import tempfile
+
+# (name, old, new) -- each `old` must appear EXACTLY once, so a prelude edit that
+# moves the anchor fails loudly here instead of silently mutating nothing.
+MUTATIONS = [
+    (
+        "quoted span dropped from $GW",
+        r'"(?:[^"\\]|\\.)*"|',
+        "",
+    ),
+    (
+        "backslash arm dropped from $GW",
+        r"|\\.|[^\s",
+        r"|[^\s",
+    ),
+    (
+        "ANSI-C arm dropped from $GW",
+        r"(?:\$\x27(?:[^\x27\\]|\\.)*\x27|",
+        "(?:",
+    ),
+    (
+        "metachar stop widened",
+        r'[^\s"\x27;|&()<>\x60]',
+        r'[^\s"\x27]',
+    ),
+    (
+        "bare-run arm eats the $ sigil (mid-word ANSI-C)",
+        r'((?:[^"\x27\\\$]|\$(?!\x27))+)',
+        r'([^"\x27\\]+)',
+    ),
+    (
+        "single-quote span dropped from $GW",
+        r"|\x27[^\x27]*\x27|",
+        "|",
+    ),
+    (
+        "gate_unq decodes instead of returning bytes",
+        "{ $o .= gate_ansi_c($1);",
+        "{ $o .= gate_utf8_lenient(gate_ansi_c($1));",
+    ),
+]
+
+
+def probe(lib_text: str) -> bool:
+    """True when `gate_perl_word_ok` accepts this library text."""
+    with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False, encoding="utf-8") as fh:
+        fh.write(lib_text)
+        path = fh.name
+    try:
+        r = subprocess.run(
+            ["bash", "-c", '. "$1"; gate_perl_word_ok', "_", path],
+            capture_output=True,
+        )
+        return r.returncode == 0
+    finally:
+        os.unlink(path)
+
+
+def main() -> int:
+    lib = sys.argv[1]
+    text = io.open(lib, encoding="utf-8").read()
+
+    # The control comes first and is not optional: if the real prelude were
+    # rejected, every mutation below would "pass" for the wrong reason and the
+    # whole block would read as six clean assertions.
+    if not probe(text):
+        print("FAIL probe-rejects: the UNMUTATED prelude is rejected (control)")
+        return 1
+
+    bad = 0
+    for name, old, new in MUTATIONS:
+        n = text.count(old)
+        if n != 1:
+            print(f"FAIL probe-rejects: {name} (anchor appears {n} times, expected 1)")
+            bad += 1
+            continue
+        if probe(text.replace(old, new, 1)):
+            print(f"FAIL probe-rejects: {name} (the probe ACCEPTED it)")
+            bad += 1
+        else:
+            print(f"OK   probe-rejects: {name}")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/rules/hooks.md
+++ b/.claude/rules/hooks.md
@@ -2,10 +2,10 @@
 
 Reference for the `.claude/hooks/*.sh` safety + enforcement hooks
 shipped in cdk-local — PreToolUse gates, plus the one `Stop` hook in
-section 4. Auto-loaded when working on `.claude/hooks/**` or
-`.markgate.yml`.
+section 4 and the one non-blocking PreToolUse advisory in section 5.
+Auto-loaded when working on `.claude/hooks/**` or `.markgate.yml`.
 
-The hooks split into four classes:
+The hooks split into five classes:
 
 1. **Universal-shape one-shot safety hooks** — block known foot-guns
    at the source. Each produces an actionable error with the exact
@@ -20,6 +20,10 @@ The hooks split into four classes:
 4. **Stop hooks** — fire when a turn is about to end rather than on a
    tool call, and choose an OUTPUT CHANNEL that decides whether the turn
    continues. Section 4 covers the channel table and the nudge cadence.
+5. **Non-blocking PreToolUse advisories** — fire on a tool call like a
+   gate, but exit 0 unconditionally and write only to stderr. They guard
+   a SPEND rather than a merge, where a wrong refusal would cost more
+   than the waste it prevents.
 
 ## 1. Universal-shape safety hooks
 
@@ -420,6 +424,96 @@ The hooks split into four classes:
   always-`exit 2` stub 39 of 40, relaxing the space rule exactly 1,
   reverting the body-file precedence exactly 2, dropping the bare
   `-F <path>` arm exactly 1.
+
+- **`issue-deferral-criteria-gate.sh`** blocks `gh issue create` (and the
+  `gh api repos/<o>/<r>/issues` mint) when the body's `Session-fit: next`
+  line defers the work for a PR-SHAPED reason — `own PR`, `separate PR`,
+  `shar(e|ing) a PR`, `independent`/`separate review surface`, `own
+  review`, `unreviewable`, case-insensitively. **An ESCALATION, not a new rule**:
+  `/work-issues` §5 already says "'It needs its own PR' is NOT a `next`
+  reason — it is a `now` item that gets its own PR; the bar is the
+  SESSION, not the diff", and records its own violation (2026-09-01, a
+  missing sibling hook filed `next` on exactly that wording). The
+  sibling repo repeated the class three times in one session
+  (go-to-k/cdkd#2587 / go-to-k/cdkd#2588 / go-to-k/cdkd#2590, all
+  re-classified `now` and finished the same day). §10-b: a rule written
+  down and violated anyway escalates to a MECHANISM.
+  **`unreviewable` was dropped by the first cut of this port and RESTORED
+  on 2026-09-05**, matching go-to-k/cdkd#2619 rather than diverging from
+  it. The port left the word out because two passages here blessed a
+  review-SIZE deferral — §5's "a sweep that would make the PR
+  unreviewable is a genuine `next`" and
+  [session-report.md](session-report.md)'s Calibration paragraph naming
+  "review of a larger diff" among the things to defer on — and a gate
+  must not contradict its host repo's rules. cdkd hit the same tension
+  and resolved it the other way: review size is the SIGNAL you notice,
+  not the criterion; underneath it is verification the residue needs and
+  this lane is not already paying. Both passages were reworded in the
+  same commit (the umbrella, the named sites and the ROOT-CAUSE boundary
+  kept verbatim; Calibration now files review cost under `Effort` as a
+  reason to SPLIT the PR), so the rules and the gate agree — and three
+  repos running one skill answer this question the same way. Two suite
+  cases fence the word IN: dropping it from `PR_SHAPE_RE` reddens exactly
+  them, and a third case passes the same sweep re-stated in the
+  criteria's terms, so the block is a rewording tax rather than a filing
+  threshold.
+  **Measured 2026-09-05** over `gh issue list --state all --limit 300` — 206
+  bodies, 74 carrying a `Session-fit: next` FIELD LINE (the anchored predicate
+  the gate reads; a bare `grep -i` agrees at 74 here). Without `unreviewable`
+  the vocabulary fires on **10 of the 74** (14%), all genuine PR-SPLIT
+  deferrals; **with it, on 16 of the 74** (22%). The 6 added are sweeps —
+  go-to-k/cdk-local#569 (~54 fixtures), go-to-k/cdk-local#585 (a repo-wide
+  segmentation change), go-to-k/cdk-local#591 (30 fixtures),
+  go-to-k/cdk-local#654 (20 fixtures), go-to-k/cdk-local#655 and
+  go-to-k/cdk-local#665 — and refusing them is the INTENT: each named review
+  size where it owed the verification claim underneath, and several already
+  named the next session's command, so a re-filing states the real criterion
+  and passes. It does NOT catch reasoning that never names a PR or a review,
+  and the needle was deliberately not widened to chase those.
+  **Not a ritual** — a gate asking the body to carry a "criteria audit"
+  line is satisfiable by boilerplate; this refuses the specific defect and
+  leaves every legitimate `next` untouched. **Only `next` is gated**: a
+  `now` line is never refused whatever its reason says, and a body with no
+  `Session-fit` line passes — filing hygiene belongs to the two sibling
+  issue gates. `gh issue edit` / `comment` are NOT gated: re-classification
+  is the outcome this gate steers toward. The reason is read across
+  WRAPPED lines (a 76-column body puts "needs its own PR" on the next
+  line), bounded by a blank line, the next `Key:` field, a LIST ITEM (this
+  repo's report template nests the four fields as bullets) or a heading. A
+  FENCED CODE BLOCK is stripped first (``` and `~~~`, opening only when
+  the same marker recurs later), so a body quoting the refused line to
+  argue ABOUT the rule is not blocked by its own quotation. A bolded
+  `**Session-fit:**` key is read like the bare one. Repo opt-in
+  (`.markgate.yml`), shared command-position matcher via
+  `gate_target_dir`, fails CLOSED when the library is unloadable.
+  **It reads the body the command is about to WRITE**, reusing
+  `pr-body-item-number-gate.sh`'s go-to-k/cdk-local#637 heredoc
+  extraction: precedence is the heredoc body this command writes, then the
+  file on disk (unless a REWRITE superseded it — an APPEND still reads
+  it), then the whole command, then an inline `--body`. Without that the
+  one-call `heredoc -> file -> --body-file` shape is a FAIL-OPEN whenever
+  the target path already exists: the gate judges the PREVIOUS body and
+  passes. Unlike `issue-dup-check-gate.sh`, an UNREADABLE `--body-file`
+  still does not block: this gate objects to content it FINDS, so a
+  refusal would be unclearable. Bypass
+  `CDKL_SKIP_DEFERRAL_CRITERIA_GATE=1` for an INLINE quote of PR-shaped
+  reasoning, honored from the env and from a leading assignment AT THE
+  START of the command (go-to-k/cdkd#2368 — a PreToolUse hook is spawned
+  with the session env, so the text channel is the only one an agent's
+  Bash call can deliver). Offset 0 rather than any command position is
+  deliberate: this repo's matcher has no `strip_noncommand_spans`, so a
+  mid-command scan could not tell an assignment from the same text quoted
+  inside a body, and a bypass a body can spell is not a bypass — pinned by
+  a case where the assignment after a `cd` still BLOCKS. Smoke test:
+  `.claude/hooks/issue-deferral-criteria-gate.test.sh` (87 cases, bash 3.2
+  by default via `HOOK_BASH`). Mutation-probed 2026-09-05 and re-measured
+  after the `unreviewable` restoration, every mutation checked to have
+  applied: `exit 0` 50, `exit 2` 43, `next` polarity
+  exactly the two `now` cases, continuation boundary 4, segment scoping 4,
+  fence strip 2, bolded key 2, list item 2, heredoc arm 3, the
+  rewrite/append split exactly the APPEND case, the raw path spelling
+  exactly the relative case, and DROPPING `unreviewable` exactly the two
+  sweep cases.
 
 - **`docs-inline-json-flag-gate.sh`** blocks `gh pr create` /
   `gh pr edit` / `gh pr merge` (and their `gh -C <path>` / `cd <path>
@@ -1981,3 +2075,69 @@ cost a case a wrong-reason pass:
   field and sets the env var — and each asserts that the SECOND turn
   downgrades, since the defect there is that the nudge never stops
   firing, not that the first one is missing.
+
+## 5. Non-blocking PreToolUse advisories
+
+**`.claude/hooks/integ-stale-base-detector.sh`** — PreToolUse (`Bash`),
+**never blocks**. Warns, before a Docker integ fixture is spent, that the
+branch is behind `origin/main`, because a rebase after the run moves the merge
+base and can stale the very `integ` marker the run was spent to earn.
+
+**It warns on the OVERLAP, not on being behind.** The `integ` gate is this
+repo's only `hash: diff` gate, so its digest is this branch's delta against
+`merge-base(origin/main, HEAD)` inside `src/**` + `tests/integration/**` — and
+that delta is recomputed by a rebase for exactly one population: an in-scope
+file BOTH `main` and this branch changed (the freshness table under
+`### integ-gate` states the same rule from the marker's side). So the hook
+intersects main's in-scope advance with this branch's own in-scope delta, and
+the two arms give opposite advice: `N in-scope file(s) arriving with them are
+files THIS BRANCH also changed … Rebase FIRST` versus `None of them overlap …
+the marker will probably survive a rebase`. It counts FILES and says files.
+Both sides use a THREE-dot diff and each dot count is pinned by its own
+fixture: 2-dot on main's side sweeps in the lane's own commits, 2-dot on the
+branch's side reports main's files as part of the branch's delta, and each
+manufactures a false alarm. It does NOT `git fetch` — a PreToolUse hook must
+stay fast and side-effect-free — so it under-reports on a stale local ref,
+which is the safe direction for a nudge.
+
+**Placement is the design**: beside `markgate set integ` the fixture run is
+already spent, so this fires on the INVOCATION — the last moment a rebase is
+free. `/run-integ` §5's run is a Docker fixture whose first-ever base-image
+pull is ~600 MB and whose measured worst case (go-to-k/cdk-local#650) stalled
+for hours, so "one more run" is not a rounding error.
+**Non-blocking on purpose**, unlike `integ-gate.sh`: a deliberate run on an old
+base (a bisect, a repro) is legitimate, and it guards a SPEND, not a merge.
+
+Unlike its go-to-k/cdkd sibling this is not an escalation of a written rule —
+`references/verify.md` §8 says to run the integ LAST and `gates-and-pr.md` §7
+says to rebase when `main` advances, but neither states that a rebase ALONE can
+stale a marker already earned. The message names both files. Its scope ERE is
+DERIVED from `.markgate.yml`'s `integ` include and fenced against it: the suite
+re-reads that include block and fails on set inequality, so a hand copy cannot
+drift from the gate it describes. One invocation shape arms it —
+`bash tests/integration/<name>/verify.sh`, redirected to a log — because every
+fixture in this repo ships a `verify.sh` (re-derive with
+`for d in tests/integration/*/; do [ -f "$d/verify.sh" ] || echo "$d"; done`);
+`tests/integration/_lib/aws-orphan-sweep.sh` deliberately does not.
+Recognition goes through the SHARED matcher, which every hook on the `Bash`
+matcher must source (`_command-match.test.sh` enforces both directions of
+that) and which is also strictly better here than the grep pair cdkd's copy
+carries: `gate_matches` anchors the regex at the start of each SEGMENT, so
+`cat` / `git diff` / `cd x && grep -n foo` over a fixture path cannot match at
+all — no read-verb exclusion list is needed — and a fixture path quoted inside
+an arbitrary string, which that copy documents as a known false positive, is
+silent here. Unlike every GATE, an unloadable matcher exits 0 rather than 2:
+this hook refuses nothing, so failing "closed" would mean blocking an integ run
+the operator deliberately started. Repo opt-in (`.markgate.yml`); its `if:`
+selector is `Bash(*verify*)` and NOT `Bash(*verify.sh*)`, because a `.sh` token
+inside an `if` pattern is counted as a hook script by
+`_command-match.test.sh`'s raw cross-scan of the hooks block.
+
+Smoke test: `.claude/hooks/integ-stale-base-detector.test.sh` (24 cases, real
+git fixtures, bash 3.2 by default via `HOOK_BASH`). Every assertion is about
+the MESSAGE, because the exit code carries no signal and a silent stub would
+pass an exit-code-only suite. Mutation-probed 2026-09-05: silent stub 14,
+alarming-arm-always 4, soft-arm-always 5, each 3-dot-to-2-dot exactly 2, the
+scope regex widened to `.` exactly 1, the `overlap` initialiser forced to the
+behind-count exactly 3, and dropping the segment anchor from the run regex
+exactly the quoted-mention case.

--- a/.claude/rules/session-report.md
+++ b/.claude/rules/session-report.md
@@ -100,9 +100,30 @@ over the 268 rows of cdkd's `docs/_generated/integ-last-run.tsv` on 2026-08-20:
 median run 85 s, mean 4.6 min, p90 8.8 min. A passing run costs a few hundred
 tokens. If the session is running one for its current lane anyway, a fix riding
 the same fixture costs zero — the same run refreshes the same gate. What is
-genuinely expensive is WRITING a new fixture, an integ that FAILS, and above
-all review of a larger diff, which grows superlinearly because a reviewer reads
-the whole thing and cross-file interactions multiply. Defer on those.
+genuinely expensive is WRITING a new fixture, and an integ that FAILS
+(unbounded, and paid again next session). Defer on those.
+
+Review of a larger diff also grows superlinearly, and that cost is real — but
+it is a reason to SPLIT the PR, not to end the session, and it belongs under
+`Effort`. This paragraph listed it as a third thing to "defer on" until
+2026-09-05 — the criterion the NEXT paragraph refuses, arriving through the
+back door one paragraph early; a body wording it as `unreviewable` is now
+refused by `.claude/hooks/issue-deferral-criteria-gate.sh`, so the two halves
+of this file would have contradicted each other AND the gate.
+
+**PR SHAPE is not one of those reasons, and a gate now says so.**
+`/work-issues` §5 ("'It needs its own PR' is NOT a `next` reason — it is a
+`now` item that gets its own PR; the bar is the SESSION, not the diff") is
+enforced at the filing site by
+`.claude/hooks/issue-deferral-criteria-gate.sh`, which refuses a
+`gh issue create` whose `Session-fit: next` reason reads `own PR` /
+`separate PR` / `share a PR` / `independent` or `separate review surface` /
+`own review` / `unreviewable`. The N-sites SWEEP §5 sanctions is still a
+genuine `next`, but state it in the criteria's terms — "a sweep whose residue
+carries its own verification … file an umbrella naming every site" — because
+review size is the signal, not the criterion. `.claude/rules/hooks.md` carries
+the measurement, and the 2026-09-05 reversal that put `unreviewable` back in
+the vocabulary alongside the sibling repos.
 
 **A newly DISCOVERED bug is not a residual.** A residual (deferred polish, a
 nit, a parity gap) is fully describable, so writing it down loses nothing. A

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -149,6 +149,20 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-deferral-criteria-gate.sh",
+            "if": "Bash(*gh*issue*create*)",
+            "timeout": 15,
+            "statusMessage": "Checking the Session-fit deferral reason..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/issue-deferral-criteria-gate.sh",
+            "if": "Bash(*gh*api*)",
+            "timeout": 15,
+            "statusMessage": "Checking the Session-fit deferral reason..."
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/pr-body-item-number-gate.sh",
             "if": "Bash(*gh*pr*create*)",
             "timeout": 30,
@@ -230,6 +244,13 @@
             "if": "Bash(*git*merge*)",
             "timeout": 15,
             "statusMessage": "Verifying integ markgate marker..."
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR:-.}/.claude/hooks/integ-stale-base-detector.sh",
+            "if": "Bash(*verify*)",
+            "timeout": 10,
+            "statusMessage": "Checking the integ base against origin/main..."
           },
           {
             "type": "command",

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -2,18 +2,17 @@
 
 ## 5. One tree per lane, then implement
 
-This stage (and stages 6–8) normally runs INSIDE a lane subagent the
-orchestrator dispatched — one general-purpose agent per claimed issue, so the
-lane's diffs, test output and review round-trips never land in the parent
-context. Every rule below applies unchanged inside the lane: hooks fire on the
-lane's tool calls, and markgate markers land in the lane's own worktree.
-Two actions are reserved to the parent's serialization turn and are NOT the
-lane's to start: a Docker-side integ run (`/run-integ` — and the
-`/create-integ` run a new-factory PR needs before `gh pr create`: ask the
-parent for that turn mid-lane) and the merge (`/merge-pr`) — the
-orchestrator's serialization invariant; §9. A lane stops at merge-ready and
-reports. The placement is live-proven: go-to-k/cdk-local#621 was built
-end-to-end by a lane subagent with every hook and gate firing inside the lane
+This stage (and §6–§8) normally runs INSIDE a lane subagent the orchestrator
+dispatched — one general-purpose agent per claimed issue, so the lane's diffs,
+test output and review round-trips never land in the parent context. Every
+rule below applies unchanged there: hooks fire on the lane's tool calls, and
+markgate markers land in the lane's own worktree. Two actions belong to the
+parent's serialization turn and are NOT the lane's to start: a Docker-side
+integ run (`/run-integ` — and the `/create-integ` run a new-factory PR needs
+before `gh pr create`: ask the parent for that turn mid-lane) and the merge
+(`/merge-pr`) — the orchestrator's serialization invariant; §9. A lane stops
+at merge-ready and reports. Live-proven: go-to-k/cdk-local#621 was built
+end-to-end by a lane subagent with every hook and gate firing inside it
 (sibling go-to-k/cdk-real-drift#1831 shipped the same way the same day).
 
 ### 5-a. Sweep the class, not the instance
@@ -47,10 +46,17 @@ CLASS: once the root cause is named, grep for the same shape across `src/`.
   and `Effort` / `Estimate` are what a future session budgets from.
 - **N sites of one root cause is ONE issue and ONE PR, never N issues** —
   split into N, each site pays the full fixed cost for the same edit. Two
-  boundaries: a sweep that would make the PR unreviewable is a genuine `next`
-  (file an umbrella naming every site, say which sites this lane DID close);
-  and sweep the same ROOT CAUSE, not the same AREA — the test is whether a
-  single sentence describes the fix at every site.
+  boundaries: a sweep whose RESIDUE carries its own verification is a genuine
+  `next` (file an umbrella naming every site, say which sites this lane DID
+  close); and sweep the same ROOT CAUSE, not the same AREA — the test is
+  whether a single sentence describes the fix at every site.
+  **Say WHY in the criteria's terms, not the PR's.** The first boundary read
+  "a sweep that would make the PR unreviewable" until 2026-09-05 — a spelling
+  `.claude/hooks/issue-deferral-criteria-gate.sh` refuses, so this file blessed
+  what the gate blocks (the same fix as go-to-k/cdkd#2619; three repos run this
+  skill and must answer it alike). Review size is the SIGNAL; under it is
+  verification the residue needs and this lane is not already paying. Else the
+  residue is `now`.
 - **A mechanical sweep is not verified by a PARSE — RUN every site you
   converted.** `bash -n` and the typechecker see neither of the two ways a
   sweep dies at every site at once (both hit in the go-to-k/cdk-local#603
@@ -233,11 +239,11 @@ naming the command is hard, that difficulty IS the finding, usually one of:
 
 Measured 2026-08-26: go-to-k/cdk-local#560 was filed `next` on "a fixture /
 base-image change, on a different axis" — a CATEGORY statement. The defect is
-a Go RIE fault under `linux/amd64` emulation, the filing machine was arm64,
-and a fixture with no `Architectures` resolves to `x86_64` (defaults in
+a Go RIE fault under `linux/amd64` emulation; the filing host was arm64, and a
+fixture with no `Architectures` resolves to `x86_64` (defaults in
 `src/cli/commands/local-start-api.ts` / `src/local/container-pool.ts`), so an
-amd64 host runs it natively, never reaching the emulated path. Review caught
-the misclassification; nothing in this flow did.
+amd64 host runs it natively and never reaches the emulated path. Review caught
+this; nothing in the flow did.
 
 - **Then ask what the next session will have to RE-DERIVE.** If you can point
   at something that exists only in THIS session — a table you measured, a
@@ -248,10 +254,12 @@ the misclassification; nothing in this flow did.
   gets its own PR; the bar is the SESSION, not the diff. Writing "independent
   review surface" on a `Session-fit` line is the classify-by-MEANS error
   arriving through the PR boundary (2026-09-01: a hook missing from one
-  sibling was filed `next` on exactly that wording minutes after its
+  sibling was filed `next` on exactly that wording, minutes after its
   two-directional defect had been measured and fixed in the other two repos;
-  re-classified `now` on the maintainer's challenge and shipped — the port
-  then found four more defects a fresh session would not have looked for).
+  re-classified `now` on the maintainer's challenge and shipped — the port then
+  found four more defects a fresh session would not have looked for). Enforced
+  at the filing site by `.claude/hooks/issue-deferral-criteria-gate.sh`,
+  `unreviewable` included.
 - **A reason about THIS SESSION's own state is legal and EXPIRES** — "held by
   another open PR's diff", "no integ run budgeted here", "no overlap with this
   session's lanes". Unlike the bullet above it is a real reason, but it goes

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ cdk.context.json
 
 # Node diagnostic reports (issue #402, --report-on-fatalerror)
 report.*.json
+
+# Python bytecode from the hook testdata probes.
+__pycache__/

--- a/.markgate.yml
+++ b/.markgate.yml
@@ -126,9 +126,14 @@ gates:
       # follows `readFileSync` but cannot follow an argument into a
       # subprocess; the `execFileSync` budget there is what keeps this honest.
       - ".gitignore"
-      # The shell half (issue #630). Eight `.claude/hooks/*.test.sh` suites
+      # The shell half (issue #630). The `.claude/hooks/*.test.sh` suites
       # read `.claude/hooks/*.sh`, each resolving its subject self-relatively,
-      # and two more live under `tests/integration/_lib/`. Adding the path here
+      # and more live under `tests/integration/_lib/`. (Both sets are GLOBBED by
+      # `vp run test:hooks`, so a count here is a number nothing keeps current:
+      # it read "Eight" while nine were on disk, and this comment's own PR added
+      # two more. Same reason `markgate-include-globs.test.ts` fences the
+      # check-gate scope sentence by set equality rather than by a tally.)
+      # Adding the path here
       # is only HALF the fix and would be misleading on its own: `vp run test`
       # does not execute them (`test:hooks` is a separate task in
       # `vite.config.ts`), so a stale marker cleared by a `/check` that never

--- a/tests/unit/hooks/gate-if-matchers.test.ts
+++ b/tests/unit/hooks/gate-if-matchers.test.ts
@@ -54,6 +54,12 @@ const REQUIRED: Record<string, string[]> = {
   'closes-paren-form-gate.sh': ['Bash(*gh*pr*merge*)'],
   'issue-dup-check-gate.sh': ['Bash(*gh*issue*create*)', 'Bash(*gh*api*)'],
   'issue-classification-label-gate.sh': ['Bash(*gh*issue*create*)', 'Bash(*gh*issue*edit*)'],
+  // Same two selectors as the dup-check gate, and for the same reason: the
+  // REST mint (`gh api repos/<o>/<r>/issues`) is `gh issue create` through
+  // another verb, so gating only the porcelain spelling under-approximates the
+  // TRIGGER. `gh issue edit` is deliberately absent — re-classifying a filed
+  // issue is the outcome that gate steers toward.
+  'issue-deferral-criteria-gate.sh': ['Bash(*gh*issue*create*)', 'Bash(*gh*api*)'],
   'pr-body-item-number-gate.sh': [
     'Bash(*gh*pr*create*)',
     'Bash(*gh*pr*edit*)',
@@ -68,10 +74,24 @@ const REQUIRED: Record<string, string[]> = {
   'cdkd-parity-gate.sh': ['Bash(*gh*pr*create*)'],
   'create-integ-gate.sh': ['Bash(*gh*pr*create*)'],
   'gh-pr-merge-worktree-gate.sh': ['Bash(*gh*pr*merge*)'],
-  // The only gate selected on a non-`git`/`gh` command word
+  // The only BLOCKING gate selected on a non-`git`/`gh` command word
   // (go-to-k/cdk-local#571): a piped `markgate verify` reports the PIPE's
   // exit code, so a STALE gate reads as a pass.
   'markgate-pipe-gate.sh': ['Bash(*markgate*)'],
+  // Selected on a non-`git`/`gh` word too, but it is NOT a gate: a
+  // non-blocking warn on the integ fixture INVOCATION, which is the last
+  // moment a rebase is still free. `/run-integ` section 5's one invocation
+  // shape is `bash tests/integration/<name>/verify.sh`, redirected to a log,
+  // so the selector is part of the script name rather than a command verb.
+  // `*verify*` and NOT `*verify.sh*`: `_command-match.test.sh` cross-checks the
+  // parsed hook-script list against a raw `[A-Za-z0-9_-]*\.sh` scan of this
+  // block, so a `.sh` inside an `if` PATTERN is counted as a 24th hook script
+  // and the two methods disagree (measured — that is exactly how the first
+  // spelling of this entry reddened that suite). The wider glob also selects
+  // `vp run verify` and the like; the hook exits 0 after one segment match, so
+  // an over-selection costs a process spawn and an under-selection costs the
+  // nudge this hook exists to give.
+  'integ-stale-base-detector.sh': ['Bash(*verify*)'],
 };
 
 interface GateHook {

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -187,8 +187,8 @@ const MEASURED: Record<
   // wrong file.
   'work-issues': {
     orchestratorBytes: 11_885,
-    corpusBytes: 148_579,
-    largest: { file: 'implement.md', bytes: 29_545 },
+    corpusBytes: 149_125,
+    largest: { file: 'implement.md', bytes: 30_091 },
     runnerUp: { file: 'verify.md', bytes: 22_452 },
   },
 };


### PR DESCRIPTION
## Summary

Ports two PreToolUse hooks from cdkd, adapted to this repo rather than copied.

**`issue-deferral-criteria-gate`** blocks `gh issue create` (and the
`gh api .../issues` mint) when an issue body's `Session-fit: next` line defers
the work for a PR-SHAPED reason. `Session-fit` answers "do I finish this in THIS
session", and none of its criteria is about the pull request — splitting across
several PRs costs no session. This repo already says so in `implement.md` §5,
and it was violated anyway in cdkd on 2026-09-04, three times in one session, so
it escalates from prose to a mechanism (go-to-k/cdkd#2597).

**`integ-stale-base-detector`** warns — never blocks — before an integ fixture
runs that the branch is behind `origin/main`, because a rebase afterwards moves
the merge base and can stale the marker the run was spent to earn.

## Adapted, not copied

- This repo's gate is `integ` (singular, `hash: diff`, `base: origin/main`), not
  cdkd's `integ-destroy` / `integ-broad`. The detector's scope regex is derived
  from that gate's `include` block, and a test re-reads the block and compares
  the sets so a hand-copy cannot drift.
- **The detector's logic differs from cdkd's**, because the gate does. Under
  `hash: diff` only files BOTH main and this branch touched can change the
  digest, so it intersects main's advance with the branch's own delta and warns
  in two arms (overlap -> rebase first; none -> the marker will likely survive).
  Both sides use a 3-dot diff, each pinned by its own fixture.
- Sources `_command-match.sh`, which this repo enforces for every Bash-matcher
  hook. That also removes two things cdkd carries as known limits: a quoted path
  is no longer a false positive, and no read-verb exclusion list is needed.
- `if:` is one pattern per entry (cdkd has none). `Bash(*verify.sh*)` is not
  usable: `_command-match.test.sh` raw-scans the hooks block for `*.sh` and
  would count the `if:` string as a 24th hook script.
- Bypass is `CDKL_`-prefixed and honoured only at command offset 0, since this
  repo's matcher has no `strip_noncommand_spans` to tell a real assignment from
  one quoted inside a body.

## `unreviewable`: dropped, then restored on the maintainer's call

The first commit left `unreviewable` OUT of the vocabulary, because
`implement.md` §5 blessed "a sweep that would make the PR unreviewable is a
genuine `next`" and including it would have refused 6 real deferrals.

The maintainer resolved this the other way, matching cdkd's go-to-k/cdkd#2619:
the gate keeps the word and the DOC is reworded. Review size is the SIGNAL you
noticed; the deferrable thing underneath is verification the residue needs and
this lane is not already paying. Three repos run this skill and must not answer
it differently.

So the second commit restores the word and reworks both rules that contradicted
it — `implement.md` §5's sweep bullet and `session-report.md`'s Calibration
paragraph, which listed "review of a larger diff" as a third thing to defer on
(the same back-door criterion cdkd removed). The substance is kept verbatim in
both: file an umbrella naming every site, say which sites this lane closed, and
sweep the same ROOT CAUSE rather than the same AREA.

## Measured

Corpus, driving the real hook over every issue body (anchored `Session-fit:`
field-line predicate, value starting `next`):

```
bodies fetched                      206
carrying a Session-fit: next FIELD   74
fires WITHOUT `unreviewable`         10
fires WITH    `unreviewable`         16   <- shipped
newly refused by the restoration      6   (#569 #585 #591 #654 #655 #665, all sweeps)
```

Those 6 are the intended effect: each must now state the verification its
residue needs instead of citing review size.

- `issue-deferral-criteria-gate.test.sh` — **87 cases**, green under bash 5.3.9
  and `/bin/bash` 3.2.57. 12 mutation probes, each verified to have applied:
  always-`exit 0` 50, always-`exit 2` 43, `next` polarity exactly the two `now`
  cases, continuation boundary 4, segment scoping 4, fence strip 2, bolded key 2,
  list item 2, heredoc arm 3, rewrite-vs-append 1, raw path 1, and
  `unreviewable` DROPPED 2 (polarity flipped by the restoration).
- `integ-stale-base-detector.test.sh` — 24 cases, green.
- `vp run verify` — **real rc=0** (252 files / 4,636 tests; all hook suites).

No byte cap or corpus floor was raised. `implement.md` grew +519 B, paid down by
compressing three verbose passages in the same file; `MEASURED` is updated to
the new values.

## Known limits, stated rather than implied

- **End-to-end firing is unverifiable from the session that wrote this**: it
  runs with cdkd as its project, so this repo's `settings.json` is never loaded
  by the harness. Registration was reproduced by applying the `if:` globs and
  invoking the selected hooks with real payloads (PR-shaped body -> rc=2 with
  the refusal text; the same body reworded in criteria terms -> rc=0; the REST
  mint -> rc=2). That is a reproduction of registration, not a proof of it.
- Commit `35408ea`'s message says the detector has 22 cases; it has 24. Already
  pushed, so not amendable. `.claude/rules/hooks.md` states 24 correctly.


## Added after review: the value class the three issue gates shared

Porting these hooks to cdkd and back surfaced a defect in gates this PR was not
originally about. `issue-deferral-criteria`, `issue-classification-label` and
`issue-dup-check` each spelled the flag-value class
`(["\x27]?)([^"\x27\s]+)\1` — which names WHERE a quote may sit instead of taking
one shell WORD and unquoting it, so it loses a whole family of spellings at
once. Three were LIVE here, each measured in this worktree against the pre-change
hooks:

```
--body-file "<dir with space>/x.md"     rc=0   plain path rc=2
--body-file <dir\ with\ space>/x.md     rc=0
-F<path>   (glued, as gh accepts)       rc=0   -F <path>  rc=2
```

On the deferral and classification gates that is a FAIL-OPEN: a PR-shaped
deferral, and an unlabelled `Severity: high`, both reached GitHub. On
`issue-dup-check` the same miss is a FALSE BLOCK — it fails closed on an
unreadable path, so a compliant body at a spaced path was refused for a
`Dup-check:` line it DID carry.

The class now comes from a shared `GATE_PERL_WORD` prelude in
`_command-match.sh`, kept **textually identical** to go-to-k/cdkd#2639 apart from
path references, so a `diff` across the repos is the review. That is not
tidiness: the vocabulary DIVERGING between repos is itself one of the defects
this work keeps finding — this repo already refused `separate review surface`
while cdkd passed it, and neither side knew.

### A non-empty test is not a guard

Every extraction runs `perl … 2>/dev/null`, so a prelude that is PRESENT and
does not COMPILE produces no output, no stderr and no exit-code change: the gate
extracts nothing and PASSES what it exists to refuse. Measured in cdkd, one
broken literal disarmed four gates at once.

`gate_perl_word_or_die` runs the prelude on known inputs and requires the known
answers — once, after arming, and at TOP LEVEL, because the extraction helpers
run inside `$( )` where `exit 2` ends only the substitution subshell. Verified
here: with a deliberately broken prelude all three gates exit 2 on a payload
they normally pass, both with a clean environment and with `__GATE_PW_OK=1`.

Also restored during the port: the bare `-F <path>` arm in `issue-dup-check-gate`
that the first pass of the conversion dropped. `-F` IS gh's short `--body-file`
for `gh issue create`, and this gate BLOCKS on a missing marker, so losing that
arm would have been a false block.

### Measured

Suites: deferral 87 → 93, classification 39 → 44, dup-check 82 → 88; every other
hook suite unchanged and green (0 failing across the directory). `vp test run`
252 files / 4636 passed; `vp check` / build clean. Rebased onto `origin/main`
(the `skill-file-payload` byte baselines were re-measured on the resolved tree
rather than taking either side).

## Added after review: the inline body was judged differently from a body file

Two review rounds on this branch found four more defects in the gate it ports,
two of them FALSE BLOCKS on legitimate filings. All measured, with the same body
sent through each channel as the control.

| shape | was | now |
|---|---|---|
| multi-line inline `--body` carrying a LEGITIMATE `next` | 2 | 0 |
| `git commit -m <PR-shaped>` beside an unresolvable `--body-file` | 2 | 0 |
| `gh api ... --input p.json` with a PR-shaped body | 0 | 2 |
| `-b` (gh documented short `--body`) with a PR-shaped body | 0 | 2 |

`gate_segments` emits one line per segment, so a newline inside a quoted value
arrives as a space. `scan_text` is line-structured, so a flattened body has one
line, every reason terminator is unreachable, and the whole body reads as ONE
reason -- refusing a `next` whose `Effort:` line quotes this repo own
"needing its own PR plus review" wording. `restore_inline_newlines` is a
LOOKUP, not a re-extraction: a raw value is used only when collapsing its
newlines to spaces reproduces the extracted line byte for byte.

The lookup is scoped to the segment's own BYTES, and the slice is exact rather
than approximate: the segmenter rewrites a newline to a SPACE and leaves every
other byte alone, so collapsing the whole command the same way gives a
same-length string in which the segment appears verbatim, and its offset there
is its offset in the raw command. An earlier round built the table from the
whole command and called that a bounded fail-open; review showed it was
neither -- a sibling `gh issue comment --body` handed the create its own
newline placement, and added line structure can also expose a LATER
`Session-fit:` the flat line hid. Restoration is ACCURACY, not a safety
direction: it makes the gate judge the body gh will actually send.

**The fallback is the segment plus the WRITER segments**, never the whole
command. Three shapes force exactly that rule: the segment alone loses a
`printf ... > b.md` writer living elsewhere; the whole command refuses a filing
whose sibling `git commit -m` message merely QUOTES a PR-shaped line; and
"whole command when a writer exists" still refuses it the moment BOTH appear in
one chain. "Is there a writer" was the wrong question -- "WHICH segment is the
writer" is the right one, and the segmenter answers it. A probe must break BOTH
arms at once: each case reaches only one, so a one-arm mutation fails 0 and
reads as unfenced.

**Two unread body channels.** `input_body_text` reads `.body` out of a
`gh api ... --input` payload through the SAME path resolution as the
`--body-file` arms (relative join, literal `~/`, and a payload written by a
heredoc in the same call), with the same "cannot read is not evidence" rule.
`-b` gets an arm on the inline scan, and the restore mirrors the extractor arm
for arm so the GLUED `-b<multi-line body>` is restored too. `--input` reads the
heredoc STATUS rather than output emptiness: an EMPTY heredoc rewrite is legal,
and reading it as "no heredoc" fell through to the STALE payload on disk.

**The vocabulary now covers spellings of one noun**, not a third evasion: `its
own pull request` and `its own-PR` both filed at rc=0 while `its own PR` gave
2. That is the same term hyphenated or spelled out -- distinct from the
reasoning that never names a PR at all, which this gate still deliberately does
not chase.

**The reason boundary excepts a URL SCHEME, not any `Key:/value` line.** A bare
`:([^/]|$)` also excepted every `Key:/value`, so a continuation reading
`Repro:/tmp/x it needs its own PR` folded into the reason and refused a
legitimate `next`.

**Three claimed fixes had no killing case** in the first fix round, which the
commit message asserted they did. Each now has one, verified red when its own
source line is reverted.

## Still open, filed rather than fixed

A body delivered through a process substitution
(`--body-file <(printf ...)`) passes at rc=0. Two independent reasons, and the
second is a segmenter decision rather than an arm: `$GW` stops at `(`, and
`gate_segments` treats `<( )` as a boundary, so the reason text is not in the
`gh issue create` segment at all. Deciding where the segment should end for a
substitution that is an ARGUMENT VALUE belongs with the segmenter cases.
