### PR TITLE
chore: port four sibling retro runs' lessons, and bound the aws-proxy cold import

### DIFF
--- a/.claude/rules/session-report.md
+++ b/.claude/rules/session-report.md
@@ -113,6 +113,33 @@ which it is: if the evidence is session-only, finish it now unless a genuine
 defer criterion fires, and if you must defer it anyway, put the EVIDENCE in the
 issue body, not just the diagnosis.
 
+**A reason about the FILING SESSION's own STATE expires when that session
+does.** It is a different failure from the one `/work-issues`
+`references/implement.md` §5-c refuses outright — that one is a claim about
+the PULL REQUEST ("it needs its own review surface"), which is never a
+deferral reason at all. This one is a claim about the SESSION that filed it:
+"the file is held by another open PR's diff", "the session that found it
+budgeted no integ run", "that lane's scope was frozen at its final review
+round". A PR can be named on either side, so the mention is not the tell —
+ask which of the two the sentence is ABOUT. Session-state clauses are legal
+and merely go STALE, and deciding-once does not protect them, because it
+freezes the DECISION and not the PREMISE.
+
+So prefer a reason the WORK owns. When a session-state clause is written
+anyway, name the event that ENDS it on the same line — "unblocked the moment
+that PR merges" is the model, because it is what lets a later reader see,
+without asking anyone, that the reason has expired. The "no file overlap with
+this session's lanes" reason needs it too: that is a claim about a MOVING
+target, since the lane keeps editing after the reason is written
+(go-to-k/cdkd#2440 was deferred on exactly it, and the same lane's merged PR
+then changed that very file `+9/-2`). `/work-issues` `references/retro.md`
+§10-0 re-checks every `next` at the end of a run, and this shape has been
+caught in consecutive sibling runs — go-to-k/cdkd#2544 by that end-of-run
+check, go-to-k/cdkd#2595 by the session that later claimed it.
+Nothing mechanical closes it — the wording of an expired reason is
+unremarkable, and only the question "what ends this?" separates it from a
+live one.
+
 **Before writing `next`, NAME the command the next session will run to
 verify the fix.** Every deferral is a PREDICTION that a later session can
 finish the work, and an unstated prediction is never checked: the reason

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -37,6 +37,60 @@ The skill itself never spawns reviewers. It reads PR stats, applies the heuristi
 
    Note: `fc` is NOT adjusted — a 12-file diff is still cross-cutting even when 2 of the files are lockfiles.
 
+   **Then gather each touched `src/` file's recent HISTORY in the same pass.**
+   The recent-defect up-bias in step 3 is the one trigger that cannot be read
+   off `paths`, so a step that does not FETCH it leaves the trigger to be
+   remembered rather than evaluated — which is how it goes unused.
+
+   ```bash
+   # `paths` came from step 1's own `gh pr view`; reuse it rather than asking
+   # again. Only `baseRefOid` is a second call.
+   BASE=$(gh pr view <N> --json baseRefOid -q .baseRefOid)   # NOT a plain HEAD:
+   # run on the PR branch, an unanchored log counts the PR's OWN fix-back
+   # commits and a 2-fix-back PR self-trips the bias it already has.
+   git fetch -q origin
+   # The `if` is the point, not the `echo`. baseRefOid can be missing locally
+   # (a shallow clone; a base that exists only on the remote), and then
+   # `git log` dies, `|| true` swallows it, and every file prints 0 -- a VOID
+   # probe whose output is character-identical to a clean one. A warning BESIDE
+   # the loop does not fix that; the loop must not run at all. It is necessary
+   # but not sufficient: a GRAFTED shallow clone whose base object IS present
+   # passes this check while `git log -3` still under-counts, so read a 0 on a
+   # file you know has been fixed as a clone problem, not an answer.
+   if git rev-parse --verify -q "$BASE^{commit}" >/dev/null; then
+     for f in <the paths from step 1>; do
+       case "$f" in
+         src/*)
+           # `|| true` because `grep -c` exits 1 when the count is zero.
+           n=$(git log --oneline -3 "$BASE" -- "$f" | grep -cE '^[a-f0-9]+ fix(\(|:)' || true)
+           printf 'COUNT\t%s\t%s\n' "$f" "$n" ;;   # n >= 2 of 3 = evaluate the step-3 bias
+         .claude/*)
+           # No prefix count works here (see below) -- emit SUBJECTS to read.
+           git log --oneline -5 "$BASE" -- "$f" | sed "s|^|SUBJECT\t$f\t|" ;;
+       esac
+     done
+   else
+     echo "base $BASE is not local -- history probe VOID, not zero"
+   fi
+   ```
+
+   **The `.claude/**` arm emits subjects rather than a count because no prefix
+   count works there at all — and that is where the stakes are highest**, since
+   a wrong rule propagates into every future session. Measured 2026-09-05 over
+   the last 20 commits on `origin/main` touching `.claude/`
+   (`git log --oneline -20 origin/main -- .claude/` — anchor it, or this PR's own
+   commits shift the window):
+   16 carry a `chore` prefix (15 scoped, one bare), which is what an
+   agent-instruction change takes here, so those score ZERO however many times
+   the file has been corrected. The other four — `c3a18a2 feat:`,
+   `79438d3 fix(utils)`, `dce9064 fix(local)`, `971a5f9 fix(integ)` — each also
+   change `src/**` (14, 1, 6 and 1 source files in that order), so they are
+   source changes that edited a rule beside the code, and a NONZERO score on a
+   `.claude/**` path is about the source file rather than the instruction file.
+   Both directions are useless, which is why the arm prints commit subjects:
+   treat consecutive retro / correction commits on the same file as the
+   recency signal.
+
 2. **Determine the base tier** from `(loc, fc)` per the heuristic:
 
    | Condition | Base tier |
@@ -92,6 +146,19 @@ The skill itself never spawns reviewers. It reads PR stats, applies the heuristi
 
      This list exists in FOUR places — `UP_PATHS` in `.claude/hooks/pr-review-gate.sh`, here, `.claude/rules/hooks.md`, and `.claude/agents/pr-code-reviewer.md` — and issue go-to-k/cdk-local#506 found it drifted in both directions at once. `.claude/hooks/pr-review-gate.test.sh` (run by `vp run test:hooks`, in CI) asserts the four agree and that every entry resolves to a real file. Keep adding to it freely — a module listed here costs one extra reviewer, a module missing from it costs a security review that never happened. Do not re-quote an individual path anywhere in this bullet: the test reads the surface out of the list above, and a stray mention would refill an entry a copy had dropped.
    - Branch has > 1 fix-back commit (heuristic for "multiple sub-agents wrote the diff" — count commits whose message starts with `fix:` / `fix(` via `git log main..<branch> --oneline | grep -cE '^[a-f0-9]+ fix(\(|:)'`)
+   - **The code this PR edits shipped a defect in a RECENT PR.** A judgement
+     trigger, not a path list: `pr-review-gate.sh` reads the PR's stats, its
+     `files`, and the BRANCH's own commit subjects, and has no view of an
+     edited file's HISTORY — so it cannot see this and may not require the
+     marker at all. Raise the tier anyway and say why. Read the tell off the
+     history step 1 gathered — 2 or more `fix:` commits among a touched file's
+     last 3 — rather than off what you remember about the area. Measured in
+     the sibling go-to-k/cdkd#2593: the size heuristic said `inline`, while
+     the log on the one file it edited showed the two preceding merges were
+     both fixes to the same guard and the nearer one had fixed a fail-open
+     reading in the very function this PR edited again; the raised tier's
+     reviewers converged on two untested response shapes. Recency is evidence
+     about the code, the same way a security path is.
 
    **Down-bias triggers** (move tier DOWN by one step, never below inline) — only fires when ALL paths fall in the listed buckets:
 
@@ -121,7 +188,15 @@ The skill itself never spawns reviewers. It reads PR stats, applies the heuristi
    - If **any blocker** surfaces (correctness bugs, security issues,
      test gaps that justify rejecting the PR), the marker is NOT set
      — the orchestrator addresses the blockers (or asks the
-     implementing agent to fix them) and re-runs `/review-pr <N>`.
+     implementing agent to fix them) and re-runs `/review-pr <N>`
+     **from step 1, on the PR's CURRENT stats**. A fix round adds LOC and
+     files AND a `fix:` commit, so neither the tier nor whether
+     `pr-review-gate.sh` demands the marker at all is fixed for the life of a
+     PR: go-to-k/cdkd#2593 opened at 306 LOC / 4 files (`inline`, no marker
+     required) and its review-fix commit took it to 406 LOC / 6 files —
+     `1-reviewer` by size, and `3-axis` once the second-`fix:`-commit up-bias
+     fired on the same push. Only recomputing before the merge catches it, and
+     it moves in both directions.
    - If every finding is **minor / nit / clean**, the orchestrator
      sets the marker bound to the PR's current HEAD sha:
 

--- a/.claude/skills/verify-pr/SKILL.md
+++ b/.claude/skills/verify-pr/SKILL.md
@@ -44,7 +44,47 @@ Run each check and report pass/fail:
    - If no PR exists for current branch, use the `AskUserQuestion` tool to ask for the PR number
    - **First: check merge state** — `gh pr view <PR> --json mergeStateStatus,mergeable -q '"mergeable=\(.mergeable) state=\(.mergeStateStatus)"'`. When this returns `mergeable=CONFLICTING state=DIRTY`, the CI workflow will NOT fire on the PR no matter how long you wait. Resolution: `git fetch origin main && git rebase origin/main`, resolve conflicts, `git push --force-with-lease` — CI fires within ~30s of the push.
    - Only after `mergeStateStatus` is `CLEAN` / `UNSTABLE` / `BLOCKED` / `BEHIND`: `gh pr checks <PR-number>` — all checks pass.
-   - If checks are pending, wait and recheck.
+   - If checks are pending, wait and recheck — but **`--watch` waits for
+     PENDING rows to settle, not for rows to APPEAR.** With none reported it
+     has nothing to wait on and returns AT ONCE: measured 2026-09-05 on
+     go-to-k/cdk-local#1, whose branch has no checks, `gh pr checks 1 --watch`
+     came back in about a second with rc=1 and
+     `no checks reported on the '<branch>' branch`. (Do not read a fast return
+     as proof of the empty case — the same flag also returns in about a second
+     once every row has SETTLED, rc=0. It blocks only while something is
+     pending.) So an `until` loop wrapping `--watch` to wait for CI to start
+     hot-spins through a whole tool timeout. Poll for existence first, then
+     watch:
+
+     ```bash
+     gh pr checks <PR-number> --json name,state   # rc=1 + "no checks reported" = none yet
+     gh pr checks <PR-number> --watch             # only once a row exists
+     ```
+
+     **And the row set is not fixed — never compare it against a remembered
+     number, and never read a rollup as a verdict on the whole set.** The
+     mechanisms below all vary it, each measured on go-to-k/cdk-local#702, and
+     the list is not claimed to be exhaustive:
+
+     - **Rows arrive in WAVES.** `check`, `check-build-test` and `inherit`
+       existed 3 s after `gh pr create`; the `runtime-compat` matrix rows were
+       created only when `check-build-test` completed, 3 min 22 s later, because
+       `ci.yml` declares `runtime-compat: needs: check-build-test`. A gated row
+       does not exist to be watched until the job it depends on is done.
+     - **The set differs by EVENT.** `pr-inherit-issue-labels.yml` triggers on
+       `pull_request_target: [opened, edited, reopened]` with no `synchronize`,
+       so the `inherit` row appears when the PR is opened or its title or body
+       is edited, and not on a plain push; `ci.yml` takes the default
+       `pull_request` types, so a body edit produces the opposite set.
+     - **A CONFLICTING PR gets no `pull_request` rows at all** — the bullet
+       above already says CI will not fire in that state, and the rollup then
+       shows only the `pull_request_target` rows, which looks like a short green
+       rather than a blocked PR.
+
+     So derive what you EXPECT from `.github/workflows/` for the event(s) this
+     head actually saw, and reconcile the rollup against it. With runner backlog
+     the first row can be minutes out too. Read "no checks yet" as "not queued
+     yet", never as "nothing to wait for", and never as a green.
 
 4. **Working tree**
    - `git status` — clean (no uncommitted changes)

--- a/.claude/skills/work-issues/references/implement.md
+++ b/.claude/skills/work-issues/references/implement.md
@@ -75,6 +75,14 @@ CLASS: once the root cause is named, grep for the same shape across `src/`.
   yourself before it goes anywhere durable (cdkd, 2026-08-26: FOUR relayed
   counts published in one run, all wrong — "all nine sibling sites" was 78
   across 14 files by grep).
+- **A measurement written into a SOURCE COMMENT is a published claim too** —
+  give it one of three dispositions: delete it, fence it with a test that
+  reads the code, or attribute it as a DATED measurement. Nothing downstream
+  re-checks such a line and no suite can see it — go-to-k/cdkd#2612's wrong
+  probe result sat in a branch comment beside a destructive confirm prompt,
+  and only the review round stopped it becoming a fence a later editor would
+  trust. What such a comment should state is the INVARIANT the code jointly
+  enforces, which is re-derivable and cannot go stale.
 - **Re-derive at the FINAL sha, not at the round that produced the number** —
   the PR body is written once, the branch keeps moving (measured here
   2026-08-27: FOUR published counts each accurate for its round and wrong
@@ -148,7 +156,7 @@ cat > /tmp/wi-issue-body-<issue-slug>.md <<'BODY'
 <one paragraph: the root cause, and where the evidence for it is>
 
 Dup-check: searched open issues for <terms> -- none covers this root cause
-Session-fit: next (not this session) -- <reason>
+Session-fit: next (not this session) -- <reason the WORK owns, not this session's circumstances -- .claude/rules/session-report.md>
 Severity: high -- <what stays broken while it is undone>
 Effort: large (L) -- <which verification cycle it drags>
 Estimate: ~3 h+ -- <what eats the time>
@@ -244,6 +252,14 @@ the misclassification; nothing in this flow did.
   two-directional defect had been measured and fixed in the other two repos;
   re-classified `now` on the maintainer's challenge and shipped — the port
   then found four more defects a fresh session would not have looked for).
+- **A reason about THIS SESSION's own state is legal and EXPIRES** — "held by
+  another open PR's diff", "no integ run budgeted here", "no overlap with this
+  session's lanes". Unlike the bullet above it is a real reason, but it goes
+  false silently while the decision it justified still stands, and §10-0's
+  promotion check is what finds it afterwards. Prefer a reason the WORK owns;
+  write one of these anyway and it must name the event that ENDS it on the
+  same line. Full shape, and the boundary against the bullet above, in
+  `.claude/rules/session-report.md`.
 - **When the issue body offers more than one fix, say which one the four
   fields cost** — cost the CHEAPEST one you would actually accept (2026-09-02:
   a `next` reason read "a behaviour change across three repos", costing only

--- a/.claude/skills/work-issues/references/launch-mode.md
+++ b/.claude/skills/work-issues/references/launch-mode.md
@@ -119,6 +119,18 @@ does not fail, it re-targets. A placeholder that was never substituted is
 visible in the command you are about to run; an empty variable is not visible
 anywhere.
 
+**The recorded values govern READS, not just re-derivations — and the fault
+arrives through commands that never MENTION them**: a `sed -n` / `grep` /
+`cat` on a RELATIVE path, or a bare `git branch --show-current` /
+`git diff`, all answer about whichever tree the shell is standing in. Read
+every file this run owns under the recorded absolute `<LANE_TREE>`, and treat
+an answer CONTRADICTING the recorded values as a cwd fault rather than a
+finding: in a sibling run (go-to-k/cdkd#2514) a `main` from
+`git branch --show-current` plus an EMPTY `git diff --stat origin/main..HEAD`
+were read as "the branch was switched, the PR maybe merged", and two "unfixed
+prose" defects were then reported that were the MAIN checkout's copies of text
+the lane had already fixed.
+
 **This repo keeps no worktree-owner sentinel** — cdkd's `session-owner` file
 has no counterpart here, and cdk-real-drift has none either — so the recorded
 `LANE_TREE`, the ownership probes in §5 and the §4 claim comments are the WHOLE

--- a/.claude/skills/work-issues/references/retro.md
+++ b/.claude/skills/work-issues/references/retro.md
@@ -79,11 +79,12 @@ findings.
   a hit as a DIRECTORY question ("which of the sites this issue lists did the
   run open?"), never as a file one. Do the item now while the context is
   loaded, or re-classify it in the issue body with the reason.
-- **Re-read the REASON, not just the files** — a deferral reason phrased in
-  the run's transient state ("the PR is still open") is FALSE once that state
-  resolves; re-reading an expired premise is not re-litigation — keeping a
-  `next` alive on it is (go-to-k/cdkd#2259 deferred behind go-to-k/cdkd#2247;
-  the reason outlived the merge).
+- **Re-read the REASON, not just the files — when a hit CONTRADICTS it, the
+  BODY is the stale side.** A reason anchored to the filing session's own
+  state goes false while the decision it justified still stands. Re-reading an
+  expired premise is not re-litigation — keeping a `next` alive on one is.
+  `.claude/rules/session-report.md` holds the shape, the boundary against the
+  reason §5-c refuses outright, and the incidents. Correct the body.
 
 Report one line — `closed N / filed M (new K / folded J)` — and **when M > N,
 give the reason in one more line**. `J = 0` over several findings in one area

--- a/.claude/skills/work-issues/references/verify.md
+++ b/.claude/skills/work-issues/references/verify.md
@@ -282,6 +282,15 @@ clean afterwards (measured 2026-09-02: a lane's harness restored a snapshot
 taken before the round's new tests existed and took 133 lines of them with
 it). Surviving the restore is what the pre-probe commit actually buys.
 
+**ONE mutation per probe, and restore the tree byte-exact between them.** A
+probe that changed two things at once attests to NEITHER — and unlike a
+suspicious green, its RED reads as evidence and is filed as one. Measured in
+the sibling go-to-k/cdkd#2612: a comment claimed reordering either consumer
+"reds four cases", but that probe had also edited the rendered line's TEXT, so
+the reds belonged to the text edit. Re-measured one mutation at a time, each
+alone was green and the two TOGETHER reddened one case — the mechanisms are
+mutually redundant, the opposite of what the comment recorded.
+
 **A probe that reports NO discrimination is a claim about the FENCE, and four
 other things produce the identical output.** Ask in order before touching the
 fence (each hit in one cdkd session, go-to-k/cdkd#2197 / go-to-k/cdkd#2200 /
@@ -320,7 +329,11 @@ go-to-k/cdkd#2198; the fifth measured here 2026-09-03):
    and concludes the fence is DEAD, one keyed on rc alone concludes it is
    ALIVE, and both are false — nothing ran. Believe a verdict only when the
    `Tests` line carries DIGITS, its total matches a known BASELINE, and no
-   `Test Files … failed` sits beside zero case failures.
+   `Test Files … failed` sits beside zero case failures. And read the RIGHT
+   line: `vite.config.ts` enables `typecheck`, so a clean run prints
+   `Type Errors  no errors` — which is not the separate `Errors  N errors`
+   line a dying worker or a load failure puts above it. §8-e's "an exit code
+   lies both ways" is the other half: neither summary line is the verdict.
 
 Only after all five does "the fence is weak" remain. Deleting an assertion on
 the strength of an unexamined green is how a working guard gets removed.

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -126,6 +126,23 @@ const MIN_REFERENCE_FILES = 6;
 // retro. Worth recording because the wrong version READ fine: an amortization
 // argument is checkable against the flow it describes, and nothing in this
 // file would have caught it.
+//
+// The 2026-09-05 port of four sibling retro runs' lessons is the worked example
+// of what this bound does and does not charge, and it is stated as an INVARIANT
+// rather than as figures because every figure here has now gone stale twice in
+// one day. Additions to the LARGEST stage file move `corpus - largest` by
+// exactly zero; additions to any other file, INCLUDING ones arriving from main,
+// are charged in full. So a margin that moved less than the corpus is evidence
+// about WHICH file grew, never about room the additions created -- and a file
+// that escapes this bound by being the largest pays instead out of its own
+// MAX_REFERENCE_FILE_BYTES headroom. Read the live numbers off MEASURED's
+// failure message, which is the only place they are asserted; do not re-quote
+// them here, per the convention the three constants above already state.
+//
+// That port paid section 10-c's "pay for what you add" by a CUT, not a move:
+// references/retro.md's stale-reason bullet carried one incident that the new
+// rule in .claude/rules/session-report.md subsumes, so it was deleted and
+// replaced by a pointer. Nothing left this corpus for another file.
 const MIN_REFERENCE_CORPUS_BYTES = 119_500;
 
 /**
@@ -158,9 +175,9 @@ const MEASURED: Record<
   // wrong file.
   'work-issues': {
     orchestratorBytes: 11_885,
-    corpusBytes: 145_551,
-    largest: { file: 'implement.md', bytes: 28_297 },
-    runnerUp: { file: 'verify.md', bytes: 21_533 },
+    corpusBytes: 148_597,
+    largest: { file: 'implement.md', bytes: 29_545 },
+    runnerUp: { file: 'verify.md', bytes: 22_452 },
   },
 };
 

--- a/tests/unit/utils/aws-proxy.test.ts
+++ b/tests/unit/utils/aws-proxy.test.ts
@@ -931,6 +931,28 @@ describe('aws-proxy (issue #634)', () => {
 
     });
 
+    // The `30_000` bound at the end of this case is load-bearing, and it is
+    // here rather than on any sibling because this is the ONLY case in the file
+    // whose body awaits an import: `src/internal.ts` pulls the whole
+    // local-execution graph, and it is paid COLD, inside the case budget. Under
+    // full-suite contention it exceeded the 5000 ms default in 3 of 4
+    // `vp run verify` runs on one host on 2026-09-05 -- always this case,
+    // always `Test timed out in 5000ms` -- while the file ALONE and CI both
+    // stayed green (go-to-k/cdk-local#703).
+    //
+    // Why a bound and not a hoist. Hoisting the import beside the two at the
+    // top of this file would pay the cost at module init, outside every case
+    // budget, and would need no number at all -- but it would EVALUATE that
+    // graph before the `beforeEach` that scrubs `PROXY_ENV_KEYS`, in a file
+    // whose whole subject is proxy env-var behaviour. That is the trade, and it
+    // is why the cheaper-looking fix is not taken here.
+    //
+    // The bound is a bound, not a removal, and it fails in the two directions
+    // that matter: an import that never RESOLVES rejects and takes the case
+    // with it long before the clock (measured: ~3 s), and one that resolves to
+    // the wrong namespace reds the guard-the-guard assertion below. Setting the
+    // bound to `1` reds the case with `Test timed out in 1ms`, which is what
+    // says the argument is honoured at all rather than decorative.
     it('resetProxySchemeWarnings is not on the host-facing surface', async () => {
       // BEHAVIOURAL, not a substring scan of source text. The first version
       // asserted `internal.ts` does not CONTAIN the name, which a
@@ -941,6 +963,6 @@ describe('aws-proxy (issue #634)', () => {
       expect(Object.keys(internal)).not.toContain('resetProxySchemeWarnings');
       // Guard-the-guard: the import really resolved the module under test.
       expect(Object.keys(internal)).toContain('buildProxyClientConfig');
-    });
+    }, 30_000);
   });
 });


### PR DESCRIPTION
## Summary

Ports the substantive lessons of four sibling `/work-issues` retro runs into this
repo's own flow text. Not a copy: each lesson was first checked against a
mechanism this repo actually has, one was dropped, and two were folded into text
that already bites rather than given a second spelling.

- **A deferral reason about the FILING SESSION's own state expires when that
  session does.** New rule in `.claude/rules/session-report.md`: prefer a reason
  the WORK owns, and when a session-state clause is written anyway, name the
  event that ENDS it on the same line. It lands at three depths — the rule
  itself, a pointer bullet at the filing point (`references/implement.md`
  section 5-c, beside the "it needs its own PR" reason that is refused
  outright), and section 5-b's issue-body TEMPLATE line, which is the one text
  read at the moment the reason is written — and `references/retro.md` section
  10-0's stale-reason bullet now points at the rule instead of restating its
  incident.
- **One mutation per probe.** New paragraph in `references/verify.md` section
  8-z: a probe that changed two things at once attests to neither, and unlike a
  suspicious green its RED reads as evidence.
- **A probe result written into a SOURCE COMMENT is a published claim.** New
  bullet in `references/implement.md` section 5-a beside the existing
  unearned-count rule: delete it, fence it, or attribute it as a dated
  measurement.
- **The recent-defect review up-bias, made a query rather than a memory.**
  `/review-pr` step 1 gathers each touched file's recent history in the same
  pass that reads `paths` — with a `baseRefOid` existence guard, because a
  shallow clone otherwise yields a VOID probe whose output is identical to a
  clean one — step 3 carries the trigger, and step 6 re-runs from step 1 on the
  PR's CURRENT stats. The loop has two arms: a `fix:` count for `src/**`, and
  commit SUBJECTS for `.claude/**`, where no prefix count works in either
  direction.
- **The recorded launch-mode values govern READS, not just re-derivations.**
  `references/launch-mode.md`: a relative `sed`/`grep`, or a bare
  `git branch --show-current`, answers about whichever tree the shell stands in,
  and an answer contradicting the recorded values is a cwd fault, not a finding.
- **`gh pr checks --watch` waits for PENDING rows to settle, not for rows to
  APPEAR.** `/verify-pr` step 3 previously said only "if checks are pending, wait
  and recheck".

Two smaller ones were folded into existing text rather than added beside it: the
`Errors` / `Type Errors` distinction now sits inside `references/verify.md`
section 8-z item 5, which was already teaching how to read a vitest summary, and
points at section 8-e's "an exit code lies both ways" for the other half.

## What was NOT ported

- **Rewriting a marker's sentinel AFTER setting the marker stales it** — already
  stated, in `/review-pr` step 6: "the next /review-pr run rewrites the sentinel
  and markgate's digest reports stale". This repo has exactly one sentinel-bound
  gate and the skill already prescribes write-then-set order.
- The sibling's `filing.md` stage file has no counterpart here, so its lessons
  were routed to the places this repo keeps the same content:
  `.claude/rules/session-report.md`, `references/implement.md` section 5-c, and
  that file's issue-body template line in section 5-b — the one text read at the
  moment a deferral reason is written.
- The sibling's `commit-prefix-scope-gate` does not exist here, so the
  `.claude/**` caveat in `/review-pr` step 1 is calibrated on this repo's own
  measured commit history instead of on that gate.
- Two lessons in the source commits were left out deliberately and are recorded
  here rather than silently dropped: cdkd's "a hand-typed `markgate` is not the
  one the hooks run" (this repo's `hooks.md` already spells hand checks
  `mise exec -- markgate`, so only the *why* is missing) and cdkd's
  sweep-widening tripwires (peer PR 701 is removing `unreviewable` from this
  repo's deferral vocabulary, so porting them would fight it).

## One forced widening, stated

Verifying this PR reddened `vp run verify` three times out of four, always on
`tests/unit/utils/aws-proxy.test.ts > ... > resetProxySchemeWarnings is not on
the host-facing surface`, always `Test timed out in 5000ms`, while the file alone
stayed green and CI stayed green. That case is the only one in the file paying a
COLD dynamic import of the whole `src/internal.ts` graph inside a 5 s case
budget, and a peer session was running its own full suite on the same host at the
time. It is filed as go-to-k/cdk-local#703 and fixed HERE rather than deferred,
because this lane cannot produce the green run its own `check` gate requires
without it — one widening, named before it was taken.

Closes #703

The bound is 30 s, not a removal, and the comment beside it states the hoist
trade-off it was chosen over. Four probes, ONE MUTATION AT A TIME with the tree
restored byte-exact between them (`cksum` verified):

1. re-export `resetProxySchemeWarnings` from `src/internal.ts` -> the negative
   assertion reds;
2. drop `buildProxyClientConfig` from that export list -> the guard-the-guard
   assertion reds;
3. point the dynamic import at a non-existent module -> rejects in 3 s with
   `Cannot find module`, so the raised bound cannot turn a broken import into a
   hang;
4. set the bound to `1` -> `Test timed out in 1ms`. Added after a reviewer
   observed that probes 1-3 behave identically whether or not the bound is
   honoured at all.

## Byte budget

No cap or floor was raised — `references/retro.md` section 10-c forbids that
direction, and every cap/floor constant in the file is byte-identical to
`origin/main`. `MEASURED` is re-derived at the FINAL, rebased tree, and the
floor still sits strictly above `corpus - largest`.

The comment beside `MIN_REFERENCE_CORPUS_BYTES` deliberately states an
INVARIANT and no figures: additions to the LARGEST stage file move
`corpus - largest` by exactly zero, additions to any other file — including
ones arriving from `main` — are charged in full, and a file that escapes the
bound by being largest pays out of its own `MAX_REFERENCE_FILE_BYTES` headroom
instead. Earlier revisions of this PR hand-quoted five derived figures there;
four of them went stale twice in one day (once from this PR's own fix rounds,
once when go-to-k/cdk-local#704 merged), and none of the five was asserted
anywhere. `MEASURED` is the only place those numbers are asserted and its
failure message prints them, which is also what the three constants above
already tell the reader.

Section 10-c's "pay for what you add" was paid by a CUT: `retro.md`'s
stale-reason bullet carried one incident the new `session-report.md` rule
subsumes, so it was deleted and replaced by a pointer. Nothing left the corpus
for another file.

## Review

The tier was raised to 3-axis by judgement, using the very trigger this PR
adds: the `.claude/**` files it edits carry consecutive retro / correction
commits, and a wrong rule there propagates into every future session. Size
alone puts the PR at `inline`, so `pr-review-gate.sh` demands no marker; one is
set and HEAD-bound anyway, because the review did happen.

A hazard the flatten exposed, filed as go-to-k/cdk-local#706: the branch was
four commits, three of them `fix:`-prefixed, which put the hook's own
computation at `1-reviewer`. Flattening for the rebase left one `chore:` commit
and dropped it back to `inline` — the up-bias is defined over commit subjects,
so a history rewrite erases the evidence it reads, and the hook cannot tell that
from an ordinary rebase-flatten. The paragraph this PR adds to `/review-pr`
step 6 predicts the tier moving in both directions but does not warn about this
case.

Three reviewers ran on the first head and returned one blocker plus a
convergent finding; three further independent rounds each audited the previous
round's fix. That was worth it — every round found something the previous fix
had introduced, all in this PR's own subject class:

- round 1's fix invented a "displacement" that never happened (the incident was
  deleted, not moved) and left a stale `73 B` where the delta had become 111;
- round 2's fix asserted "six is the full set" of CI rows, true only on the
  PR-open event, because `pr-inherit-issue-labels.yml` has no `synchronize`
  trigger;
- round 3's fix replaced that count with "two independent ways", which is a
  count one scope down — and a third way was already documented three bullets
  above it in the same step.

Four rounds of the same shape is the signal to change the METHOD rather than
add a round, so the last fix stops enumerating: the byte comment now states an
invariant and quotes nothing, and the CI-rows paragraph names the mechanisms
without claiming the list is exhaustive. Round 4 also caught the reason CI had
stopped firing — `origin/main` had moved under the branch and left it
`CONFLICTING`, which suppresses every `pull_request` row. The branch is now
flattened to one commit and rebased onto `de17d5a`, with `MEASURED` re-derived
after the rebase rather than before it.

## Merge-order note

Peer PR 701 touches three of the same files (`.claude/rules/session-report.md`,
`references/implement.md`, `tests/unit/skills/skill-file-payload.test.ts`).
There is no semantic contradiction — 701's new gate refuses PR-SHAPED deferral
vocabulary only, so this PR's "nothing mechanical closes it" about SESSION-STATE
reasons stays true. But whichever merges second must rebase and re-derive the
whole `MIN_REFERENCE_CORPUS_BYTES` comment, not just the `MEASURED` record: 701
adds bytes to `implement.md` — which is the LARGEST stage file, so by the
invariant above those bytes move `corpus - largest` by exactly zero and only the
`MEASURED` record needs re-deriving. That is the easy case; go-to-k/cdk-local#704,
which won the race and merged first, was the hard one, because it grew
`triage.md` and every byte of that is charged against the floor. Worth re-deriving 702's
"nothing mechanical closes it" by running 701's gate against a session-state
body once 701 has landed.

## Test plan

- `vp run verify` green on the rebased tree (252 files / 4634 tests,
  `Type Errors  no errors`, build ok) and `vp run test:hooks` green across all
  13 shell suites — 10 under `.claude/hooks/` plus 3 under
  `tests/integration/_lib/`, all 13 printing a `pass: N fail: 0` tally (five of
  them capitalized, which is what a case-sensitive grep drops).
- Prose is the artifact here, so every command the new text sends the next agent
  to run was RUN: both arms of the `/review-pr` history loop (against this PR
  and against a merged src-touching one), its VOID branch with an unresolvable
  base, the `grep -c` zero case, `gh pr checks --watch` on a PR with no checks
  (rc=1, ~1 s) and on a settled one (rc=0, ~1 s), and the CI row timings above.
- The commit-prefix measurement quoted in `/review-pr` step 1 was derived, not
  remembered, and is anchored to `origin/main` because the unanchored window
  absorbs this PR's own commits: of the last 20 commits on `origin/main`
  touching `.claude/`, 16 carry a `chore` prefix (15 scoped, one bare) and the
  other four — `c3a18a2`, `79438d3`, `dce9064`, `971a5f9` — change 14, 1, 6 and
  1 `src/` files respectively.
