### PR TITLE
chore(skills): make work-issues batch by default rather than merely permit it

### DIFF
--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: work-issues
-description: Work through already-filed GitHub issues (typically the bug-hunt's output) end to end — triage safely, pick a few FILE-DISJOINT issues to fix in parallel, claim each on the issue before starting (collision-safe with other agents), verify, then carry each through merge (via /merge-pr) → pull → worktree cleanup. Use when asked to "handle/address filed issues", not to hunt for new bugs (that is /hunt-bugs).
+description: Work through already-filed GitHub issues (typically the bug-hunt's output) end to end — triage safely, pick as many FILE-DISJOINT issues as the run can carry, claim each on the issue before starting (collision-safe with other agents), verify, then carry each through merge (via /merge-pr) → pull → worktree cleanup. Use when asked to "handle/address filed issues", not to hunt for new bugs (that is /hunt-bugs).
 argument-hint: "[optional focus, e.g. 'start-alb issues' | '#231 #234' | 'cloudfront FPs']"
 ---
 

--- a/.claude/skills/work-issues/SKILL.md
+++ b/.claude/skills/work-issues/SKILL.md
@@ -116,7 +116,7 @@ wants to watch); the stage files apply unchanged either way.
 | 0. Safety screen | `references/triage.md` | Untrusted issues/comments: `author_association` via REST, never download/run third-party content, defer engage/minimize/block to the maintainer |
 | 1. List backlog | `references/triage.md` | REST listing (PR filter, `per_page=100`, `created_at`), volume assessment |
 | 2. Collision landscape | `references/triage.md` | Worktree/branch/PR/ref-recency probes (absolute, via `<MAIN_CHECKOUT>`), their pre-first-write blind spot, the shared cross-cutting runtime modules at most one lane may own |
-| 3. Pick file-disjoint issues | `references/triage.md` | Lane count from the launch mode, ownership probes before adopting a tree, disjointness gate, ranking rules, premise checks against `origin/main`, and §3-a: a FRESH issue belongs to the lane that FILED it (60-minute window) |
+| 3. Pick file-disjoint issues | `references/triage.md` | Lane count from the launch mode, batching as the DEFAULT (largest safe set), ownership probes before adopting a tree, disjointness gate, ranking rules, premise checks against `origin/main`, and §3-a: a FRESH issue belongs to the lane that FILED it (60-minute window) |
 | 4. Claim | `references/claim.md` | Claim comment BEFORE first edit (English only, like every issue this run files), claim what you FILE too, re-check for a competing claim right before you start |
 | 5. Implement | `references/implement.md` | One tree per lane, build before first test, sibling-site sweeps, unit + integ in the SAME PR |
 | 6. Gates + PR | `references/gates-and-pr.md` | Gate liveness probe before the first commit, `vp run verify`, `/check` + `/check-docs` markers, PR create with `Closes #<n>` |

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -275,19 +275,20 @@ symbol; read the issue's "Fix direction") before choosing.
   Docker/fixture repro) for a clean lane; hold complex redesigns (novel
   mechanism, needs a live design pass) for a focused solo lane.
 
-**Batch: take the LARGEST safe set, not the smallest.** A run pays for its
-context load, its build, the `/check` cycle, the review dispatch and the
-Docker-side integ ONCE and amortizes them across every issue it carries;
-closing one issue and stopping makes the NEXT session re-pay all of it from
-zero. So batching is the DEFAULT, IN-PLACE included — there the batch runs in
-SEQUENCE through the one tree, which is why the four-issue run cited above is
-the shape to aim at rather than an allowance. Scale the count to the backlog
-and to how many shared modules are free: 2–3 clean lanes is a typical
-OBSERVATION, not a ceiling. What bounds the batch is what the run can still do
-WELL — never force a lane into a contested file to raise the count, and never
-shorten a verification to fit one more issue: the amortization argument buys
-issue COUNT, never rigor (CLAUDE.md → "Cost is not a tiebreaker"). Report or
-stand down the ones you do not reach.
+**Batch: take the LARGEST safe set, not the smallest.** What a run amortizes
+is CONTEXT — the launch-mode probe, §2's collision map, the backlog read and
+§10's retro — NOT the per-lane build / `/check` / review / Docker-side integ,
+which §9 even serializes. Context is still the largest single cost and the
+next session re-pays it from zero, so the second issue is far cheaper than the
+first and batching is the DEFAULT, IN-PLACE included — which is why the
+four-issue run cited above is the shape to aim at rather than an allowance.
+Scale the count to the backlog and to how many shared modules are free; 2–3
+clean lanes is a typical OBSERVATION, not a ceiling. What bounds the batch is
+what the run can still do WELL: never force a lane into a contested file to
+raise the count, and never shorten a verification to fit one more issue — the
+argument buys issue COUNT, never rigor (CLAUDE.md → "Cost is not a
+tiebreaker"). Report the candidates you did not take, and stand down the
+claimed ones you did not reach.
 
 ### 3-a. A FRESH issue belongs to the lane that FILED it
 

--- a/.claude/skills/work-issues/references/triage.md
+++ b/.claude/skills/work-issues/references/triage.md
@@ -165,9 +165,9 @@ CONCURRENCY, not a count of issues — a second SIMULTANEOUS lane needs a
 worktree nested inside this one, which dies with the outer workspace and takes
 its uncommitted work (go-to-k/cdk-local#635), and two lanes sharing the ONE
 tree is worse still (either lane's `git switch` moves the branch under the
-other). Rank as usual; taking SEVERAL issues is fine when they share this one
-tree in SEQUENCE: claim them all up front (§4) with every lane after the first
-marked `QUEUED`, finish them one at a time, and stand down any unreached one
+other). Rank as usual; taking SEVERAL issues is the DEFAULT (see the
+batching paragraph below) when they share this one tree in SEQUENCE: claim
+them all up front (§4) with every lane after the first marked `QUEUED`, finish them one at a time, and stand down any unreached one
 with a comment carrying the four classification fields (measured shapes:
 go-to-k/cdkd#2417 — three claimed, one merged, two left resumable; one
 IN-PLACE run here carried FOUR issues in sequence, go-to-k/cdk-local#647 /
@@ -275,9 +275,19 @@ symbol; read the issue's "Fix direction") before choosing.
   Docker/fixture repro) for a clean lane; hold complex redesigns (novel
   mechanism, needs a live design pass) for a focused solo lane.
 
-Scale the count to the backlog and to how many shared modules are free — 2–3
-clean lanes is typical; never force a lane into a contested file to raise the
-count; report the deferred ones instead.
+**Batch: take the LARGEST safe set, not the smallest.** A run pays for its
+context load, its build, the `/check` cycle, the review dispatch and the
+Docker-side integ ONCE and amortizes them across every issue it carries;
+closing one issue and stopping makes the NEXT session re-pay all of it from
+zero. So batching is the DEFAULT, IN-PLACE included — there the batch runs in
+SEQUENCE through the one tree, which is why the four-issue run cited above is
+the shape to aim at rather than an allowance. Scale the count to the backlog
+and to how many shared modules are free: 2–3 clean lanes is a typical
+OBSERVATION, not a ceiling. What bounds the batch is what the run can still do
+WELL — never force a lane into a contested file to raise the count, and never
+shorten a verification to fit one more issue: the amortization argument buys
+issue COUNT, never rigor (CLAUDE.md → "Cost is not a tiebreaker"). Report or
+stand down the ones you do not reach.
 
 ### 3-a. A FRESH issue belongs to the lane that FILED it
 

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -115,9 +115,17 @@ const MIN_REFERENCE_FILES = 6;
 // the flip because ITS top two are ~2 KB apart.
 // The 2026-09-05 batching pass added one paragraph to triage.md (batching as
 // the DEFAULT rather than a permission, with the amortization reason stated)
-// and one clause to the orchestrator's stage-3 row: corpus 144,680 -> 145,479,
-// so the margin over `corpus - largest` went 3,117 -> 2,318 B. The floor is
+// and one clause to the orchestrator's stage-3 row: corpus 144,680 -> 145,551,
+// so the margin over `corpus - largest` went 3,117 -> 2,246 B. The floor is
 // unchanged; the next addition of that size should be paid for by compression.
+// The paragraph's FIRST draft claimed a run amortizes its build, `/check`,
+// review dispatch and integ. A review of the sibling cdkd's identical text
+// found all four are PER-LANE here (references/gates-and-pr.md is titled
+// "per lane"; section 9 serializes the integs), so the corrected text claims
+// only the context -- the probe, the collision map, the backlog read and the
+// retro. Worth recording because the wrong version READ fine: an amortization
+// argument is checkable against the flow it describes, and nothing in this
+// file would have caught it.
 const MIN_REFERENCE_CORPUS_BYTES = 119_500;
 
 /**
@@ -149,8 +157,8 @@ const MEASURED: Record<
   // against work-issues' numbers -- permanently red, with a message naming the
   // wrong file.
   'work-issues': {
-    orchestratorBytes: 11_881,
-    corpusBytes: 145_479,
+    orchestratorBytes: 11_885,
+    corpusBytes: 145_551,
     largest: { file: 'implement.md', bytes: 28_297 },
     runnerUp: { file: 'verify.md', bytes: 21_533 },
   },

--- a/tests/unit/skills/skill-file-payload.test.ts
+++ b/tests/unit/skills/skill-file-payload.test.ts
@@ -113,6 +113,11 @@ const MIN_REFERENCE_FILES = 6;
 // are ~7.0 KB apart, so a flip is not near -- that gap has narrowed from
 // ~10.0 KB, so re-check it rather than assuming; the sibling cdkd sizes against
 // the flip because ITS top two are ~2 KB apart.
+// The 2026-09-05 batching pass added one paragraph to triage.md (batching as
+// the DEFAULT rather than a permission, with the amortization reason stated)
+// and one clause to the orchestrator's stage-3 row: corpus 144,680 -> 145,479,
+// so the margin over `corpus - largest` went 3,117 -> 2,318 B. The floor is
+// unchanged; the next addition of that size should be paid for by compression.
 const MIN_REFERENCE_CORPUS_BYTES = 119_500;
 
 /**
@@ -144,8 +149,8 @@ const MEASURED: Record<
   // against work-issues' numbers -- permanently red, with a message naming the
   // wrong file.
   'work-issues': {
-    orchestratorBytes: 11_837,
-    corpusBytes: 144_680,
+    orchestratorBytes: 11_881,
+    corpusBytes: 145_479,
     largest: { file: 'implement.md', bytes: 28_297 },
     runnerUp: { file: 'verify.md', bytes: 21_533 },
   },


### PR DESCRIPTION
## Summary

Makes `/work-issues` batch by DEFAULT instead of merely permitting it.

Every launch mode already said several issues in one run "is fine", and nothing said to prefer it — so a run that closed one issue and stopped read as fully compliant. This adds the preference and, more importantly, the reason it exists.

- `references/triage.md` §3 — new paragraph **"Batch: take the LARGEST safe set, not the smallest."** What a run amortizes is **CONTEXT**: the launch-mode probe, §2's collision map, the backlog read, and §10's retro — paid once here and re-paid from zero by the next session. The four-issue IN-PLACE run already cited above it becomes the shape to aim at rather than an allowance.
- Bounded in the same breath: never force a lane into a contested file to raise the count, and never shorten a verification to fit one more issue — **the argument buys issue COUNT, never rigor** (CLAUDE.md "Cost is not a tiebreaker").
- The superseded "Scale the count ... 2-3 clean lanes is typical" sentence folds in as an OBSERVATION rather than a ceiling; §3's IN-PLACE paragraph changes "taking SEVERAL issues is still fine" to "is the DEFAULT".
- `SKILL.md`'s stage-3 row and description name batching, so the parent — which decides the lane count — sees it without opening the stage file.

Ported from the sibling cdkd in the same session (go-to-k/cdkd#2632; cdk-real-drift is go-to-k/cdk-real-drift#1884). The AREA-priority half of that change — rank `local` last — is cdkd-only by design, with no analogue here.

## The first draft's amortization claim was false (commit 2)

It said a run pays for "its context load, its build, the `/check` cycle, the review dispatch and the Docker-side integ ONCE". A review of cdkd's identical text found four of the five are PER-LANE here too: `references/gates-and-pr.md` is literally titled "6. Gates + PR (per lane)", each lane subagent runs its own build, `/check` + `/check-docs` and review dispatch, and §9 SERIALIZES the Docker-side integs and the merges — so a larger batch costs strictly *more* for the serialized ones. The conclusion survives, but only on the context costs, which really are once-per-run.

The draft had also dropped the removed sentence's duty to REPORT candidates you looked at and did not take; that and standing down claimed-but-unreached ones are different acts and both are back. And `SKILL.md`'s description still said "pick a few FILE-DISJOINT issues" while the stage file said "take the LARGEST safe set" — the frontmatter is what a reader sees first, so it decided against the rule.

Worth stating because the wrong version read fine: an amortization argument is checkable against the flow it describes, and nothing in the fences would have caught it.

## Byte budget

`tests/unit/skills/skill-file-payload.test.ts` asserts the corpus figures its own comments reason from. Corpus 144,680 -> 145,551 B; the floor's margin over `corpus - largest` goes 3,117 -> 2,246 B. `MEASURED` and the comment beside the floor are updated; the floor itself is NOT raised (`references/retro.md` §10-c forbids buying room that way), so the next addition of this size is paid for by compression.

## Test plan

- `vp run check` / `vp check` — 0 errors.
- `vp run build` — clean.
- `vp run test` — 252 files / 4634 tests passed, including the payload and refs fences over this skill.
- `vp run test:hooks` — 70 pass / 0 fail.
- No `src/**` or `tests/integration/**` change, so the `cdkd-parity` and `integ` gates are not activated by this diff.
- No runtime behavior changes: the diff is agent-instruction prose plus the assertions that fence it.
