### PR TITLE
fix(deps): bump commander to ^14.0.0, which now rejects extra command arguments instead of discarding them

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -49,6 +49,35 @@ Shared across every `cdkl` subcommand (declared in
 The `--from-cfn-stack` / `--stack-region` family is described in the
 per-command sections below.
 
+## Extra arguments are rejected, not discarded
+
+A command that takes ONE target — `invoke`, `invoke-agentcore`,
+`run-task`, `start-agentcore`, `start-cloudfront` — or none at all —
+`list`, `studio` — exits `1` with
+`error: too many arguments. Expected N arguments but got M.` when handed
+more:
+
+```console
+$ cdkl invoke MyStack:FnA MyStack:FnB
+error: too many arguments. Expected 1 argument but got 2.
+```
+
+Up to cdk-local 0.148.x the extra arguments were **silently discarded**:
+that command ran `FnA` alone and exited `0`, so it looked like both had
+run. Naming several targets was never supported by these commands; the
+second one was simply dropped. Pass one target per invocation.
+
+`start-api`, `start-alb` and `start-service` declare a variadic
+`[targets...]` and are unaffected — they accept several targets by
+design.
+
+Relatedly, a negative-number-shaped argument such as `-1` is now read as
+a VALUE rather than rejected as an unknown option, so a mistyped
+`-3000` is taken as a target name and fails later as "not found" instead
+of immediately.
+
+Both follow from the `commander` 14 upgrade.
+
 ## Interactive target selection
 
 The five run commands — `invoke`, `invoke-agentcore`, `run-task`,

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -45,16 +45,37 @@ when they pass conflicting flags.
 ## Your `commander` major must match cdk-local's
 
 `addCommand` splices a cdk-local-built `Command` into **your** Commander
-tree, so both must resolve the same `commander` copy. If your project and
-cdk-local end up on different majors, your tree dispatches a subcommand
-built by the other major and calls internals it does not have — the
-failure is a `TypeError` deep inside `commander/lib/command.js`, not a
-version warning, and it appears at parse time rather than at install
-time.
+tree. If your project and cdk-local resolve different commander MAJORS,
+your tree dispatches a subcommand built by the other major and calls
+internals it does not have — the failure is a `TypeError` deep inside
+`commander/lib/command.js`, not a version warning, and it arrives at
+parse time rather than at install time. Measured with a host on
+commander 15 and cdk-local on 12:
+
+```
+TypeError: subCommand._prepareForParse is not a function
+  at Command._dispatchSubcommand (commander/lib/command.js:1368)
+```
+
+Two *copies* of the SAME major are fine — commander uses `instanceof`
+only for the `.option(Option)` overload and detects argParser failures by
+`err.code`, so nothing depends on object identity across the boundary.
+What must match is the major.
+
+The type layer does not save you either way, and it does not fully warn
+you: cdk-local's published typings import `Command` and `Option` from
+`commander`, so the package enters your type graph. Commander's typings
+declare no `private` / `protected` members, so the two `Command` types
+are compared structurally — a NEWER `Command` is assignable where an
+older one is expected (it is a superset), while the reverse is not.
+Measured on that same 15-vs-12 pair: 8 errors, all of the shape
+`Type 'Command' is missing the following properties from type 'Command':
+saveStateBeforeParse, restoreStateBeforeParse, helpGroup, commandsGroup`.
+So a mismatch may typecheck in one direction and fail in the other.
 
 Check the version cdk-local depends on (`commander` in its
 `package.json`) and depend on the same major. `npm ls commander` /
-`pnpm why commander` should show one version.
+`pnpm why commander` should show one major.
 
 ## Rebranding the embedded commands
 

--- a/docs/library-mode.md
+++ b/docs/library-mode.md
@@ -42,6 +42,20 @@ The dispatcher enforces mutual exclusion across `--from-cfn-stack` and
 every registered extra flag, so users get one consistent error message
 when they pass conflicting flags.
 
+## Your `commander` major must match cdk-local's
+
+`addCommand` splices a cdk-local-built `Command` into **your** Commander
+tree, so both must resolve the same `commander` copy. If your project and
+cdk-local end up on different majors, your tree dispatches a subcommand
+built by the other major and calls internals it does not have — the
+failure is a `TypeError` deep inside `commander/lib/command.js`, not a
+version warning, and it appears at parse time rather than at install
+time.
+
+Check the version cdk-local depends on (`commander` in its
+`package.json`) and depend on the same major. `npm ls commander` /
+`pnpm why commander` should show one version.
+
 ## Rebranding the embedded commands
 
 By default the factories render cdk-local's own branding into

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@smithy/types": "^4.14.2",
     "agent-base": "^9.0.0",
     "chokidar": "^5.0.0",
-    "commander": "^12.0.0",
+    "commander": "^14.0.0",
     "fflate": "^0.8.3",
     "graphlib": "^2.1.8",
     "http-proxy-agent": "^9.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
         specifier: ^5.0.0
         version: 5.0.0
       commander:
-        specifier: ^12.0.0
-        version: 12.1.0
+        specifier: ^14.0.0
+        version: 14.0.3
       constructs:
         specifier: ^10.0.0
         version: 10.6.0
@@ -1965,9 +1965,9 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   compress-commons@6.0.2:
     resolution: {integrity: sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==}
@@ -4848,7 +4848,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  commander@12.1.0: {}
+  commander@14.0.3: {}
 
   compress-commons@6.0.2:
     dependencies:

--- a/tests/unit/cli/ecs-service-emulator-shadow-ready-timeout.test.ts
+++ b/tests/unit/cli/ecs-service-emulator-shadow-ready-timeout.test.ts
@@ -162,7 +162,13 @@ describe('shadow-ready-timeout resolution (issue #265)', () => {
       );
       const cmd = addCommonEcsServiceOptions(new Command('start-service')).action(() => {});
       cmd.exitOverride();
-      cmd.parse(['node', 'cdkl', '--shadow-ready-timeout', '45000'], { from: 'user' });
+      // `from: 'user'` means the array is USER arguments — it carries no
+      // argv[0]/argv[1] prefix. Passing one made `node` and `cdkl` excess
+      // positional arguments on a command declaring no `.argument()`.
+      // Measured: commander 12 accepted them silently (they landed in
+      // `cmd.args`), commander 14 rejects with "too many arguments. Expected
+      // 0 arguments but got 2" — with or without an action handler.
+      cmd.parse(['--shadow-ready-timeout', '45000'], { from: 'user' });
       expect(cmd.opts().shadowReadyTimeout).toBe(45000);
     });
 

--- a/tests/unit/cli/local-start-alb-watch.test.ts
+++ b/tests/unit/cli/local-start-alb-watch.test.ts
@@ -72,7 +72,7 @@ describe('start-alb --watch (Phase 3 of #214)', () => {
     // throws into the test rather than calling process.exit(1).
     cmd.exitOverride();
     cmd.configureOutput({ writeOut: () => {}, writeErr: () => {} });
-    cmd.parse(['node', 'cdkl', 'start-alb', 'MyStack:WebLB', '--watch'], { from: 'user' });
+    cmd.parse(['MyStack:WebLB', '--watch'], { from: 'user' });
     expect(cmd.opts().watch).toBe(true);
 
     // Default value: a parse WITHOUT `--watch` must leave `opts().watch`
@@ -81,7 +81,7 @@ describe('start-alb --watch (Phase 3 of #214)', () => {
     const cmd2 = withoutAction(createLocalStartAlbCommand());
     cmd2.exitOverride();
     cmd2.configureOutput({ writeOut: () => {}, writeErr: () => {} });
-    cmd2.parse(['node', 'cdkl', 'start-alb', 'MyStack:WebLB'], { from: 'user' });
+    cmd2.parse(['MyStack:WebLB'], { from: 'user' });
     expect(cmd2.opts().watch).toBe(false);
   });
 });

--- a/tests/unit/cli/local-start-cloudfront.test.ts
+++ b/tests/unit/cli/local-start-cloudfront.test.ts
@@ -201,7 +201,13 @@ describe('createLocalStartCloudFrontCommand — option surface', () => {
     // Options only: `parse()` would otherwise run the real start-cloudfront
     // action (issue #402).
     const fresh = withoutAction(createLocalStartCloudFrontCommand());
-    const parsed = fresh.parse(['node', 'cdkl', 'My/Dist', '--no-pull'], { from: 'user' });
+    // `from: 'user'` carries no argv[0]/argv[1] prefix, so `node` and `cdkl`
+    // were excess operands against the one declared `.argument()`. commander
+    // 12 accepted them; commander 14 calls `error()`, which only stayed
+    // invisible because `tests/setup.ts` no-ops `process.exit` — the command
+    // printed "too many arguments. Expected 1 argument but got 3." and this
+    // case passed anyway, since option parsing precedes the operand check.
+    const parsed = fresh.parse(['My/Dist', '--no-pull'], { from: 'user' });
     expect(parsed.opts().pull).toBe(false);
   });
 });

--- a/tests/unit/cli/local-start-no-logs.test.ts
+++ b/tests/unit/cli/local-start-no-logs.test.ts
@@ -68,9 +68,6 @@ describe('--no-logs CLI binding (Issue #227 review fix — Test G1)', () => {
     // `true` shape under today's Commander behavior; the predicate
     // mirror below locks the gate's `!== false` contract regardless.
     const opts = parseWith(createLocalStartServiceCommand, [
-      'node',
-      'cdkl',
-      'start-service',
       'MyStack:Svc',
     ]);
     expect(opts.logs).toBe(true);
@@ -81,9 +78,6 @@ describe('--no-logs CLI binding (Issue #227 review fix — Test G1)', () => {
 
   it('start-service: parse with `--no-logs` populates opts().logs=false → emulator flips streamLogs OFF', () => {
     const opts = parseWith(createLocalStartServiceCommand, [
-      'node',
-      'cdkl',
-      'start-service',
       'MyStack:Svc',
       '--no-logs',
     ]);
@@ -93,9 +87,6 @@ describe('--no-logs CLI binding (Issue #227 review fix — Test G1)', () => {
 
   it('start-alb: parse without `--no-logs` populates opts().logs=true → emulator treats this as default-on', () => {
     const opts = parseWith(createLocalStartAlbCommand, [
-      'node',
-      'cdkl',
-      'start-alb',
       'MyStack:WebLB',
     ]);
     expect(opts.logs).toBe(true);
@@ -104,9 +95,6 @@ describe('--no-logs CLI binding (Issue #227 review fix — Test G1)', () => {
 
   it('start-alb: parse with `--no-logs` populates opts().logs=false → emulator flips streamLogs OFF', () => {
     const opts = parseWith(createLocalStartAlbCommand, [
-      'node',
-      'cdkl',
-      'start-alb',
       'MyStack:WebLB',
       '--no-logs',
     ]);


### PR DESCRIPTION
Unblocks go-to-k/cdkd#2533, which cannot be fixed in cdkd alone.

## Why this is a cross-repo change

The host CLI cdkd splices this package's command factories into its **own** commander tree, so the two must resolve the SAME commander copy. When they do not, the outer tree dispatches an inner `Command` built by a different major and calls internals it does not have.

Measured on dependabot go-to-k/cdkd#2533 (cdkd moved to commander 15, this package still on 12):

```
TypeError: subCommand._prepareForParse is not a function
  at Command._dispatchSubcommand (commander@15.0.0/lib/command.js:1368)
```

29 of cdkd's cases, plus 8 type errors where the two `Command` types meet at the boundary (`Type 'Command' is missing the following properties ...: saveStateBeforeParse, restoreStateBeforeParse, helpGroup, commandsGroup`).

## Why 14 and not 15

`commander@15.0.0` declares `engines.node: ">=22.12.0"`. This package and cdkd both declare `">=20.0.0"`, and cdkd's `vp pack` targets Node 20 — so taking 15 would raise the published Node floor as a side effect of a dependency bump, with no line in the diff saying so.

`commander@14.0.3` declares `">=20"` and **already carries** `helpGroup`, `commandsGroup` and `saveStateBeforeParse` — the members whose absence produced those type errors — so nothing is given up by stopping at 14.

Cutting Node 20 (EOL 2026-04-30) is a real decision with its own blast radius — `engines` in both repos, both pack targets, both CI matrices, README and docs. Tracked separately at #722 and go-to-k/cdkd#3037, to be resolved together or not at all.

## API surface

Every commander API this package uses was checked against the **installed** 14 build rather than the release notes:

`addOption` (166 call sites) · `default` (43) · `parse` (40) · `description` (11) · `addCommand` (10) · `action` (10) · `argParser` (9) · `argument` (8) · `choices` (3) · `version` · `parseAsync` · `name` · `alias` — all present.

## The one behaviour change, and the two tests it caught

A command declaring no `.argument()` used to accept excess operands; 14 rejects them. Measured both ways — commander 12 accepted them and they landed in `cmd.args`, 14 throws `too many arguments` — and measured **with and without** an action handler, so the action handler is not the discriminator.

Both affected tests passed an argv-shaped array together with `{ from: 'user' }`, which carries no `argv[0]`/`argv[1]` prefix, making `node` and `cdkl` excess operands:

| File | commander 12 | commander 14 |
| --- | --- | --- |
| `ecs-service-emulator-shadow-ready-timeout.test.ts:165` | pass | **fail** |
| `local-start-cloudfront.test.ts:204` | pass, silent | pass, **printing** `too many arguments. Expected 1 argument but got 3.` |

The second is the interesting one: it kept passing because `tests/setup.ts` no-ops `process.exit` and option parsing precedes the operand check, so its assertion was still meaningful — but the command had errored. Both now pass the user arguments alone.

## The docs commit

`docs/library-mode.md` teaches `program.addCommand(createLocalInvokeCommand(...))` — the exact pattern that breaks on a major mismatch — and said nothing about the requirement. It now does, since the failure surfaces at parse time as a `TypeError` inside commander's own source with nothing at install time to hint at the cause.

## Verification

- `vp run verify` (check + test + test:hooks + build): **254 files / 4669 tests**, every hook suite, build — all green, and the spurious `too many arguments` line is gone from the run output.
- `vp run runtime:smoke` plus the built artifact by hand: `node dist/cli.js --version`, and the `--help` tree for `invoke`, `start-api`, `start-alb`, `list|ls` (alias intact), `studio`, plus negated `--no-pull` / `--no-build` — all render correctly.
- **Host interop proven before proposing this**, in a cdkd worktree with `overrides: { commander: ^14.0.0 }` forcing cdk-local onto the same copy: cdkd's `vp run check` is clean and all 29 previously-failing `local-*` cases pass. That run also surfaced the same excess-operand shape in cdkd's own tests — 3 hard failures and 19 silent ones — which cdkd's side of the change fixes.

## Merge order

This must merge and be RELEASED before cdkd's side can land — cdkd needs a published `cdk-local` whose commander major matches its own. cdkd pins `cdk-local` per-minor, so nothing reaches cdkd users until that bump is made explicitly.